### PR TITLE
fix: skip serializing functions returned by exported functions during pause

### DIFF
--- a/packages/qwik/src/core/container/pause.ts
+++ b/packages/qwik/src/core/container/pause.ts
@@ -25,7 +25,12 @@ import {
   QError_missingObjectId,
   QError_verifySerializable,
 } from '../error/error';
-import { isArray, isObject, isSerializableObject } from '../util/types';
+import {
+  isArray,
+  isFunction,
+  isObject,
+  isSerializableObject
+} from '../util/types';
 import { directGetAttribute, directSetAttribute } from '../render/fast-calls';
 import { isNotNullable, isPromise } from '../util/promises';
 import { collectDeps, serializeValue, UNDEFINED_PREFIX } from './serializers';
@@ -891,6 +896,10 @@ export const collectValue = (obj: any, collector: Collector, leaks: boolean | Qw
               collectValue(value, collector, leaks);
             })
           );
+          return;
+        } else if (isFunction(obj)) {
+          collector.$objSet$.add(undefined);
+          collector.$noSerialize$.push(obj);
           return;
         }
 


### PR DESCRIPTION
Overview:

Prevents serializing functions that return other functions which otherwise yields in error `Only primitive and object literals can be serialized`:

Fixes https://github.com/BuilderIO/qwik/issues/4371

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
