### PR TITLE
feat(vite-plugin): set assets path in build to /assets

### DIFF
--- a/.changeset/sour-papayas-travel.md
+++ b/.changeset/sour-papayas-travel.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': minor
+---
+
+The default asset filenames in the build have changed. Now they are under `assets/hash-name.ext`, so they are clearly separated from code.

--- a/packages/qwik/src/optimizer/src/plugins/rollup.ts
+++ b/packages/qwik/src/optimizer/src/plugins/rollup.ts
@@ -182,35 +182,23 @@ export function normalizeRollupOutputOptionsObject(
 ): Rollup.OutputOptions {
   const outputOpts: Rollup.OutputOptions = { ...rollupOutputOptsObj };
 
-  if (!outputOpts.assetFileNames) {
-    outputOpts.assetFileNames = 'build/q-[hash].[ext]';
-  }
   if (opts.target === 'client') {
     // client output
-    outputOpts.assetFileNames = useAssetsDir
-      ? `${opts.assetsDir}/${outputOpts.assetFileNames}`
-      : outputOpts.assetFileNames;
-
-    if (opts.buildMode === 'production') {
-      // client production output
-      if (!outputOpts.entryFileNames) {
-        const fileName = 'build/q-[hash].js';
-        outputOpts.entryFileNames = useAssetsDir ? `${opts.assetsDir}/${fileName}` : fileName;
-      }
-      if (!outputOpts.chunkFileNames) {
-        const fileName = 'build/q-[hash].js';
-        outputOpts.chunkFileNames = useAssetsDir ? `${opts.assetsDir}/${fileName}` : fileName;
-      }
-    } else {
-      // client development output
-      if (!outputOpts.entryFileNames) {
-        const fileName = 'build/[name].js';
-        outputOpts.entryFileNames = useAssetsDir ? `${opts.assetsDir}/${fileName}` : fileName;
-      }
-      if (!outputOpts.chunkFileNames) {
-        const fileName = 'build/[name].js';
-        outputOpts.chunkFileNames = useAssetsDir ? `${opts.assetsDir}/${fileName}` : fileName;
-      }
+    if (!outputOpts.assetFileNames) {
+      // SEO likes readable asset names
+      const assetFileNames = 'assets/[hash]-[name].[ext]';
+      outputOpts.assetFileNames = useAssetsDir
+        ? `${opts.assetsDir}/${assetFileNames}`
+        : assetFileNames;
+    }
+    // Friendly name in dev
+    const fileName = opts.buildMode == 'production' ? 'build/q-[hash].js' : 'build/[name].js';
+    // client production output
+    if (!outputOpts.entryFileNames) {
+      outputOpts.entryFileNames = useAssetsDir ? `${opts.assetsDir}/${fileName}` : fileName;
+    }
+    if (!outputOpts.chunkFileNames) {
+      outputOpts.chunkFileNames = useAssetsDir ? `${opts.assetsDir}/${fileName}` : fileName;
     }
   } else if (opts.buildMode === 'production') {
     // server production output
@@ -218,9 +206,10 @@ export function normalizeRollupOutputOptionsObject(
     if (!outputOpts.chunkFileNames) {
       outputOpts.chunkFileNames = 'q-[hash].js';
     }
-    if (!outputOpts.assetFileNames) {
-      outputOpts.assetFileNames = 'assets/[hash].[ext]';
-    }
+  }
+  // all other cases, like lib output
+  if (!outputOpts.assetFileNames) {
+    outputOpts.assetFileNames = 'assets/[hash]-[name].[ext]';
   }
 
   if (opts.target === 'client') {

--- a/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
@@ -70,7 +70,7 @@ test('command: serve, mode: development', async () => {
   assert.deepEqual(build.outDir, normalizePath(resolve(cwd, 'dist')));
   assert.deepEqual(rollupOptions.input, normalizePath(resolve(cwd, 'src', 'entry.dev')));
 
-  assert.deepEqual(outputOptions.assetFileNames, 'build/q-[hash].[ext]');
+  assert.deepEqual(outputOptions.assetFileNames, 'assets/[hash]-[name].[ext]');
   assert.deepEqual(outputOptions.chunkFileNames, 'build/[name].js');
   assert.deepEqual(outputOptions.entryFileNames, 'build/[name].js');
   assert.deepEqual(outputOptions.format, 'es');
@@ -106,8 +106,7 @@ test('command: serve, mode: production', async () => {
   assert.deepEqual(build.outDir, normalizePath(resolve(cwd, 'dist')));
   assert.deepEqual(build.emptyOutDir, undefined);
   assert.deepEqual(rollupOptions.input, normalizePath(resolve(cwd, 'src', 'entry.dev')));
-
-  assert.deepEqual(outputOptions.assetFileNames, 'build/q-[hash].[ext]');
+  assert.deepEqual(outputOptions.assetFileNames, 'assets/[hash]-[name].[ext]');
   assert.deepEqual(outputOptions.chunkFileNames, 'build/q-[hash].js');
   assert.deepEqual(outputOptions.entryFileNames, 'build/q-[hash].js');
   assert.deepEqual(outputOptions.format, 'es');
@@ -144,7 +143,7 @@ test('command: build, mode: development', async () => {
   assert.deepEqual(build.emptyOutDir, undefined);
   assert.deepEqual(rollupOptions.input, [normalizePath(resolve(cwd, 'src', 'root'))]);
 
-  assert.deepEqual(outputOptions.assetFileNames, 'build/q-[hash].[ext]');
+  assert.deepEqual(outputOptions.assetFileNames, 'assets/[hash]-[name].[ext]');
   assert.deepEqual(outputOptions.chunkFileNames, 'build/[name].js');
   assert.deepEqual(outputOptions.entryFileNames, 'build/[name].js');
 
@@ -183,7 +182,7 @@ test('command: build, mode: production', async () => {
   assert.deepEqual(build.emptyOutDir, undefined);
   assert.deepEqual(rollupOptions.input, [normalizePath(resolve(cwd, 'src', 'root'))]);
 
-  assert.deepEqual(outputOptions.assetFileNames, 'build/q-[hash].[ext]');
+  assert.deepEqual(outputOptions.assetFileNames, 'assets/[hash]-[name].[ext]');
   assert.deepEqual(outputOptions.chunkFileNames, 'build/q-[hash].js');
   assert.deepEqual(outputOptions.entryFileNames, 'build/q-[hash].js');
 
@@ -249,7 +248,7 @@ test('command: build, --ssr entry.server.tsx', async () => {
   assert.deepEqual(build.emptyOutDir, undefined);
   assert.deepEqual(rollupOptions.input, [normalizePath(resolve(cwd, 'src', 'entry.server.tsx'))]);
 
-  assert.deepEqual(outputOptions.assetFileNames, 'build/q-[hash].[ext]');
+  assert.deepEqual(outputOptions.assetFileNames, 'assets/[hash]-[name].[ext]');
   assert.deepEqual(outputOptions.chunkFileNames, undefined);
   assert.deepEqual(outputOptions.entryFileNames, undefined);
 
@@ -390,7 +389,7 @@ test('command: build, --mode lib', async () => {
   assert.deepEqual(build.ssr, undefined);
   assert.deepEqual(rollupOptions.input, [normalizePath(resolve(cwd, 'src', 'index.ts'))]);
 
-  assert.deepEqual(outputOptions.assetFileNames, 'build/q-[hash].[ext]');
+  assert.deepEqual(outputOptions.assetFileNames, 'assets/[hash]-[name].[ext]');
   assert.deepEqual(outputOptions.chunkFileNames, undefined);
 
   assert.deepEqual(c.build.outDir, normalizePath(resolve(cwd, 'lib')));
@@ -448,7 +447,7 @@ test('command: build, --mode lib with multiple outputs', async () => {
   assert.lengthOf(outputOptions, 4);
 
   outputOptions.forEach((outputOptionsObj) => {
-    assert.deepEqual(outputOptionsObj.assetFileNames, 'build/q-[hash].[ext]');
+    assert.deepEqual(outputOptionsObj.assetFileNames, 'assets/[hash]-[name].[ext]');
     assert.deepEqual(outputOptionsObj.chunkFileNames, undefined);
   });
 

--- a/starters/dev-server.ts
+++ b/starters/dev-server.ts
@@ -351,8 +351,8 @@ async function main() {
   app.use(`/~partytown`, express.static(partytownPath));
 
   appNames.forEach((appName) => {
-    const buildPath = join(startersAppsDir, appName, "dist", appName, "build");
-    app.use(`/${appName}/build`, express.static(buildPath));
+    const buildPath = join(startersAppsDir, appName, "dist", appName);
+    app.use(`/${appName}`, express.static(buildPath));
 
     const publicPath = join(startersAppsDir, appName, "public");
     app.use(`/${appName}`, express.static(publicPath));


### PR DESCRIPTION
Right now, if `rollupOptions.output.assetFilenames` is not defined, assets will be output as `build/q-[hash].ext`.

This PR changes that default setting to `assets/[hash].[ext]`.

The reasoning is that for post-processing like `$localize` that copies the build files into `/build/[locale]/`, it makes no sense to have to copy `.css` files and others, especially since all css files will be automatically added to the head and so you'll get a per-language copy of the css file.

This is a slightly breaking change, in case some custom scripting is expecting all files to live under `/build`. (Seems unlikely though)