### PR TITLE
fix(qwikloader): stopPropagation for any async handlers

### DIFF
--- a/packages/qwik/src/qwikloader.ts
+++ b/packages/qwik/src/qwikloader.ts
@@ -28,7 +28,7 @@ export const qwikLoader = (doc: Document, hasInitialized?: number) => {
     return doc.querySelectorAll(query);
   };
 
-  const isPromise = (promise) => promise && typeof promise.then === 'function';
+  const isPromise = (promise: Promise<any>) => promise && typeof promise.then === 'function';
 
   const broadcast = (infix: string, ev: Event, type = ev.type) => {
     querySelectorAll('[on' + infix + '\\:' + type + ']')[forEach]((el) =>
@@ -67,7 +67,7 @@ export const qwikLoader = (doc: Document, hasInitialized?: number) => {
     if (relevantListeners && relevantListeners.length > 0) {
       for (const listener of relevantListeners) {
         // listener[1] holds the QRL
-        const results = listener[1].getFn([element, ev], () => element[isConnected])(ev, element);
+        const result = listener[1].getFn([element, ev], () => element[isConnected])(ev, element);
         let cancelBubble = ev.cancelBubble;
         if (isPromise(result)) {
           await result;
@@ -142,14 +142,12 @@ export const qwikLoader = (doc: Document, hasInitialized?: number) => {
     while (element && element[getAttribute]) {
       const results = dispatch(element, '', ev, type);
       let cancelBubble = ev.cancelBubble;
-      if (isPromise(results) {
+      if (isPromise(results)) {
         await results;
       }
       // if another async handler stopPropagation
       cancelBubble =
-          cancelBubble ||
-          ev.cancelBubble ||
-          element.hasAttribute("stoppropagation:" + ev.type);
+        cancelBubble || ev.cancelBubble || element.hasAttribute('stoppropagation:' + ev.type);
       element = ev.bubbles && ev.cancelBubble !== true ? element.parentElement : null;
     }
   };

--- a/packages/qwik/src/qwikloader.ts
+++ b/packages/qwik/src/qwikloader.ts
@@ -99,7 +99,11 @@ export const qwikLoader = (doc: Document, hasInitialized?: number) => {
                 element: element,
                 reqTime,
               });
-            await handler(ev, element);
+            const results = handler(ev, element);
+            // sync$ may not be async function and e.stopPropagation() won't work unless it's fired immediately
+            if (results && typeof results.then === 'function') {
+              await results;
+            }
           } finally {
             (doc as any)[Q_CONTEXT] = previousCtx;
           }

--- a/packages/qwik/src/qwikloader.ts
+++ b/packages/qwik/src/qwikloader.ts
@@ -72,6 +72,7 @@ export const qwikLoader = (doc: Document, hasInitialized?: number) => {
         if (isPromise(result)) {
           await result;
         }
+        // forcing async with await resets ev.cancelBubble to false
         if (cancelBubble) {
           ev.stopPropagation();
         }
@@ -106,7 +107,7 @@ export const qwikLoader = (doc: Document, hasInitialized?: number) => {
                 reqTime,
               });
             const results = handler(ev, element);
-            // sync$ may not be async function and e.stopPropagation() won't work unless it's fired immediately
+            // only await if there is a promise returned
             if (isPromise(results)) {
               await results;
             }

--- a/packages/qwik/src/qwikloader.ts
+++ b/packages/qwik/src/qwikloader.ts
@@ -67,10 +67,10 @@ export const qwikLoader = (doc: Document, hasInitialized?: number) => {
     if (relevantListeners && relevantListeners.length > 0) {
       for (const listener of relevantListeners) {
         // listener[1] holds the QRL
-        const result = listener[1].getFn([element, ev], () => element[isConnected])(ev, element);
-        let cancelBubble = ev.cancelBubble;
-        if (isPromise(result)) {
-          await result;
+        const results = listener[1].getFn([element, ev], () => element[isConnected])(ev, element);
+        const cancelBubble = ev.cancelBubble;
+        if (isPromise(results)) {
+          await results;
         }
         // forcing async with await resets ev.cancelBubble to false
         if (cancelBubble) {


### PR DESCRIPTION
sync$ may not be async function and e.stopPropagation() won't work unless it's fired immediately

fixes https://github.com/QwikDev/qwik/issues/5322

used this repo with the fix in a custom qwik loader
https://github.com/PatrickJS/bug-qwik-loader-stopPropagation