### PR TITLE
docs(examples/apps): fixing a typo in runtime-less app description

### DIFF
--- a/packages/docs/src/routes/examples/apps/examples-menu.json
+++ b/packages/docs/src/routes/examples/apps/examples-menu.json
@@ -12,7 +12,7 @@
       {
         "id": "runtime-less",
         "title": "Runtime-less",
-        "description": "An app interactive app without runtime.",
+        "description": "An interactive app without runtime.",
         "icon": "🪶"
       }
     ]


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Removed an extra word in runtime-less app description in docs package

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
