### PR TITLE
fix(v2): correct handling of async code loading with use-computed

### DIFF
--- a/packages/qwik/src/core/use/use-task.ts
+++ b/packages/qwik/src/core/use/use-task.ts
@@ -442,61 +442,34 @@ interface Computed {
 
 /** @public */
 export const useComputedQrl: ComputedQRL = <T>(qrl: QRL<ComputedFn<T>>): Signal<Awaited<T>> => {
-  const { val, set, iCtx, i, elCtx } = useSequentialScope<Signal<Awaited<T>>>();
+  const { val, set, iCtx, i } = useSequentialScope<Signal<Awaited<T>>>();
   if (val) {
     return val;
   }
   assertQrl(qrl);
 
-  if (iCtx.$container2$) {
-    const host = iCtx.$hostElement$ as unknown as HostElement;
-    const signal = _createSignal(
-      undefined as Awaited<T>,
-      iCtx.$container2$.$subsManager$,
-      SIGNAL_UNASSIGNED | SIGNAL_IMMUTABLE,
-      undefined
-    );
-
-    const task = new Task(
-      TaskFlagsIsDirty | TaskFlagsIsTask | TaskFlagsIsComputed,
-      i,
-      iCtx.$hostElement$,
-      qrl,
-      signal,
-      null
-    );
-    const result = runComputed2(task, iCtx.$container2$, host);
-    if (isPromise(result)) {
-      throw result;
-    }
-    qrl.$resolveLazy$(host as fixMeAny);
-    return set(signal);
-  } else {
-    const containerState = iCtx.$renderCtx$.$static$.$containerState$;
-    const signal = _createSignal(
-      undefined as Awaited<T>,
-      containerState.$subsManager$,
-      SIGNAL_UNASSIGNED | SIGNAL_IMMUTABLE,
-      undefined
-    );
-
-    const task = new Task(
-      TaskFlagsIsDirty | TaskFlagsIsTask | TaskFlagsIsComputed,
-      i,
-      elCtx.$element$,
-      qrl,
-      signal,
-      null
-    );
-    qrl.$resolveLazy$(containerState.$containerEl$);
-    if (!elCtx.$tasks$) {
-      elCtx.$tasks$ = [];
-    }
-    elCtx.$tasks$.push(task);
-
-    waitAndRun(iCtx, () => runComputed(task, containerState, iCtx.$renderCtx$));
-    return set(signal);
+  const host = iCtx.$hostElement$ as unknown as HostElement;
+  const signal = _createSignal(
+    undefined as Awaited<T>,
+    iCtx.$container2$.$subsManager$,
+    SIGNAL_UNASSIGNED | SIGNAL_IMMUTABLE,
+    undefined
+  );
+  const task = new Task(
+    TaskFlagsIsDirty | TaskFlagsIsTask | TaskFlagsIsComputed,
+    i,
+    iCtx.$hostElement$,
+    qrl,
+    signal,
+    null
+  );
+  set(signal);
+  qrl.$resolveLazy$(host as fixMeAny);
+  const result = runComputed2(task, iCtx.$container2$, host);
+  if (isPromise(result)) {
+    throw result;
   }
+  return signal;
 };
 
 /** @public */


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
