### PR TITLE
fix(starters): Fix vite types referencing in base starter

### DIFF
--- a/packages/qwik/src/optimizer/src/qwik-binding-map.ts
+++ b/packages/qwik/src/optimizer/src/qwik-binding-map.ts
@@ -30,5 +30,15 @@ export const QWIK_BINDING_MAP = {
         "platformArchABI": "qwik.win32-x64-msvc.node"
       }
     ]
+  },
+  "linux": {
+    "x64": [
+      {
+        "platform": "linux",
+        "arch": "x64",
+        "abi": "gnu",
+        "platformArchABI": "qwik.linux-x64-gnu.node"
+      }
+    ]
   }
 };

--- a/starters/apps/base/qwik.env.d.ts
+++ b/starters/apps/base/qwik.env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/starters/apps/base/qwik.env.d.ts
+++ b/starters/apps/base/qwik.env.d.ts
@@ -1,1 +1,4 @@
+// This file can be used to add references for global types like `vite/client`.
+
+// Add global `vite/client` types. For more info, see: https://vitejs.dev/guide/features#client-types
 /// <reference types="vite/client" />

--- a/starters/apps/base/tsconfig.json
+++ b/starters/apps/base/tsconfig.json
@@ -16,11 +16,10 @@
     "isolatedModules": true,
     "outDir": "tmp",
     "noEmit": true,
-    "types": ["node", "vite/client"],
     "paths": {
       "~/*": ["./src/*"]
     }
   },
   "files": ["./.eslintrc.cjs"],
-  "include": ["src", "./*.d.ts", "./*.config.ts"]
+  "include": ["qwik.env.d.ts", "src", "./*.d.ts", "./*.config.ts"]
 }

--- a/starters/apps/base/tsconfig.json
+++ b/starters/apps/base/tsconfig.json
@@ -21,5 +21,5 @@
     }
   },
   "files": ["./.eslintrc.cjs"],
-  "include": ["qwik.env.d.ts", "src", "./*.d.ts", "./*.config.ts"]
+  "include": ["src", "./*.d.ts", "./*.config.ts"]
 }


### PR DESCRIPTION
Closes #6059

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

It's been about a month since [this](https://github.com/QwikDev/qwik/pull/6059) PR was opened and to this point I doubt that it is going somewhere, so I decided to take over and fix this issue, using the same solution I have proposed [here](https://github.com/QwikDev/qwik/pull/6059#discussion_r1543971400), and I was able to verify it is working.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

My [previous](https://github.com/QwikDev/qwik/pull/5942) attempt to fix types for Bun turned out to be incomplete, so this PR fixes the issue. Here's a brief list of changes:

- [x] Move `vite/client` types referencing to a separate file called qwik.env.d.ts. This file can be used for more global typings in a future, if needed.
- [x] Remove `types` field in `compilerOptions` for base app starter with a reference to that file in `includes` field instead.

As I said before, the `types` field narrows the list of the sources where TypeScript will look for typings for global scope, so I don't think it would be a good fit when there's many other typings that can be needed from `node_modules/@types`. In our case, we need to support both `@types/node` and `@types/bun` both of which has global types. See documentation for more info: https://www.typescriptlang.org/tsconfig#types 

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
