### PR TITLE
fix(http): ignore ERR_HTTP2_INVALID_STREAM

### DIFF
--- a/packages/qwik-city/middleware/node/http.ts
+++ b/packages/qwik-city/middleware/node/http.ts
@@ -103,7 +103,7 @@ export async function fromNodeHttp(
             return;
           }
           res.write(chunk, (error) => {
-            if (error) {
+            if (error && !/ERR_HTTP2_INVALID_STREAM/.test(error.message)) {
               console.error(error);
             }
           });

--- a/packages/qwik-city/middleware/node/http.ts
+++ b/packages/qwik-city/middleware/node/http.ts
@@ -34,13 +34,9 @@ const DOUBLE_SLASH_REG = /\/\/|\\\\/g;
 
 // when the user refreshes or cancels the stream there will be an error
 function isIgnoredError(message = '') {
-  const ignoredErrors = [
-    'The stream has been destroyed',
-    'write after end'
-  ];
-  return ignoredErrors.some(ignored => message.includes(ignored));
+  const ignoredErrors = ['The stream has been destroyed', 'write after end'];
+  return ignoredErrors.some((ignored) => message.includes(ignored));
 }
-
 
 export function normalizeUrl(url: string, base: string) {
   // do not allow the url to have a relative protocol url


### PR DESCRIPTION
when refreshing the page mid-stream or when a user changes view and disrupts server$ we may see this error

fixes https://github.com/QwikDev/qwik/issues/5028
fixes https://github.com/QwikDev/qwik/issues/4805