### PR TITLE
docs: advanced dollar

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/advanced/dollar/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/advanced/dollar/index.mdx
@@ -263,6 +263,8 @@ The original file:
 const MyComp = component(qrl('./chunk-a.js', 'MyComp_onMount'));
 ```
 
+and a chunk
+
 ```tsx title="chunk-a.js"
 export const MyComp_onMount = () => {
   /* my component definition */


### PR DESCRIPTION
add a clarification to denote the 2 files

# Overview
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests / types / typos

# Description
Small clarification to denote one file from the other (as the on file has a ts title="chunk..." and the other does not so for a moment there it looks like there's a missing file)
# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
