### PR TITLE
revert: starter vite config server bundle optimizations

### DIFF
--- a/starters/apps/base/vite.config.ts
+++ b/starters/apps/base/vite.config.ts
@@ -28,20 +28,24 @@ export default defineConfig(({ command, mode }): UserConfig => {
       // For example ['better-sqlite3'] if you use that in server functions.
       exclude: [],
     },
-    // This tells Vite how to bundle the server code.
-    ssr:
-      command === "build" && mode === "production"
-        ? {
-            // All dev dependencies should be bundled in the server build
-            noExternal: Object.keys(devDependencies),
-            // Anything marked as a dependency will not be bundled
-            // These should only be production binary deps (including deps of deps), CLI deps, and their module graph
-            // If a dep-of-dep needs to be external, add it here
-            // For example, if something uses `bcrypt` but you don't have it as a dep, you can write
-            // external: [...Object.keys(dependencies), 'bcrypt']
-            external: Object.keys(dependencies),
-          }
-        : undefined,
+
+    /**
+     * This is an advanced setting. It improves the bundling of your server code. To use it, make sure you understand when your consumed packages are dependencies or dev depencies. (otherwise things will break in production)
+     */
+    // ssr:
+    //   command === "build" && mode === "production"
+    //     ? {
+    //         // All dev dependencies should be bundled in the server build
+    //         noExternal: Object.keys(devDependencies),
+    //         // Anything marked as a dependency will not be bundled
+    //         // These should only be production binary deps (including deps of deps), CLI deps, and their module graph
+    //         // If a dep-of-dep needs to be external, add it here
+    //         // For example, if something uses `bcrypt` but you don't have it as a dep, you can write
+    //         // external: [...Object.keys(dependencies), 'bcrypt']
+    //         external: Object.keys(dependencies),
+    //       }
+    //     : undefined,
+
     server: {
       headers: {
         // Don't cache the server response in dev mode


### PR DESCRIPTION
# Overview

The commented SSR configuration in vite.config.ts intended to enhance server code bundling for production builds by including all development dependencies and excluding specified production dependencies to optimize the server bundling.

This has led to consumers adding packages in the wrong location, and as a result these packages do not work in production.

This PR comments out that code, and labels it as an advanced config for when you understand which dependencies should be consumed either as a dependency, or dev dependency.

In the future, I believe we should uncomment this code by default, but only when better error handling is present, as it was difficult to debug. For example, a CLI message that tells us whether the wrong dependency was bundled or not.

For more context see:
https://discord.com/channels/990511757091033108/1040763063533588562/1237190861985550376

from the Qwikifiers discord

Original change:
https://github.com/QwikDev/qwik/pull/5961

cc @wmertens 

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
