### PR TITLE
docs(polymorphism): changed hi to slot

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/components/overview/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/overview/index.mdx
@@ -392,7 +392,7 @@ When you want to output a different type of element depending on props but defau
         ...props
       }: { as?: C } & PropsOf<string extends C ? 'div' : C>) => {
         const Cmp = as || 'div';
-        return <Cmp {...props}>hi</Cmp>;
+        return <Cmp {...props}><Slot /></Cmp>;
       }
     );
 

--- a/packages/docs/src/routes/docs/(qwik)/components/overview/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/overview/index.mdx
@@ -386,23 +386,33 @@ bundled with the parent component.
 When you want to output a different type of element depending on props but default to a `<div>`, you can do it using something like this:
 
 ```tsx
-    const Poly = component$(
-      <C extends string | FunctionComponent = 'div'>({
-        as,
-        ...props
-      }: { as?: C } & PropsOf<string extends C ? 'div' : C>) => {
-        const Cmp = as || 'div';
-        return <Cmp {...props}><Slot /></Cmp>;
-      }
+const Poly = component$(
+  <C extends string | FunctionComponent = 'div'>({
+    as,
+    ...props
+  }: { as?: C } & PropsOf<string extends C ? 'div' : C>) => {
+    const Cmp = as || 'div';
+    return (
+      <Cmp {...props}>
+        <Slot />
+      </Cmp>
     );
+  }
+);
 
-// These all work with correct types
-<>
-  <Poly>Hello from a div</Poly>
-  <Poly as="a" href="/blog">Blog</Poly>
-  <Poly as="input" onInput$={(ev, el) => console.log(el.value)} />
-  <Poly as={OtherComponent} someProp />
-</>
+export const TestComponent = component$(() => {
+  // These all work with correct types
+  return (
+    <>
+      <Poly>Hello from a div</Poly>
+      <Poly as="a" href="/blog">
+        Blog
+      </Poly>
+      <Poly as="input" onInput$={(ev, el) => console.log(el.value)} />
+      <Poly as={OtherComponent} someProp />
+    </>
+  );
+});
 ```
 
 Note the `string extends C`, this is only true when TypeScript cannot infer the type from the `as` prop allowing you to specify the default type.


### PR DESCRIPTION
The examples were wrong, because <Slot/> was missing

# Overview

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos
