### PR TITLE
docs(sync$): adding note pointing to preventDefault docs

### DIFF
--- a/packages/docs/src/routes/docs/cookbook/sync-events/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/sync-events/index.mdx
@@ -2,6 +2,7 @@
 title: Cookbook | Synchronous Events with State
 contributors:
   - mhevery
+  - RumNCodeDev
 ---
 
 import CodeSandbox, {CodeFile} from '../../../../components/code-sandbox/index.tsx';
@@ -19,6 +20,7 @@ A typical way to deal with these limitations is to split the event handling into
 2. `$()` which is called asynchronously and can close over the state and call other functions, and has no restriction on the size.
 
 Because `sync$()` can't access the state what is the best strategy to deal with it? The answer is to use element attributes to pass state into the `sync$()` function.
+> **NOTE:** If you only need to prevent the default behavior, you can simply use the standard [`preventDefault:{eventName}`](/docs/components/events/#prevent-default) syntax. This is strictly for when you need to chain events together synchronously
 
 ## Example: `sync$()` with state
 


### PR DESCRIPTION
In the event that people might find the sync$() docs when attempting to find out how to do `preventDefault`, I have added a note before the example with a redirect to the preventDefault documentation

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests / types / typos

# Description

In the event that people might find the sync$() docs when attempting to find out how to do `preventDefault`, I have added a note before the example with a redirect to the preventDefault documentation

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
