### PR TITLE
docs: Document exposing gtag for custom events in Qwik Partytown setup

### DIFF
--- a/packages/docs/src/routes/docs/integrations/partytown/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/partytown/index.mdx
@@ -43,11 +43,22 @@ export default component$(() => {
     <QwikCityProvider>
       <head>
         <meta charSet="utf-8" />
-        <QwikPartytown forward={['dataLayer.push']} />
+        <QwikPartytown forward={['gtag','dataLayer.push']} />
         <script
           async
           type="text/partytown"
           src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXX"
+        />
+        <script
+          type="text/partytown"
+          dangerouslySetInnerHTML={`
+            window.dataLayer = window.dataLayer || [];
+            window.gtag = function() {
+              dataLayer.push(arguments);
+            }
+            gtag('js', new Date());
+            gtag('config', 'G-XXXXXX');
+          `}
         />
       </head>
       <body lang="en"></body>


### PR DESCRIPTION
This update enhances the Qwik application's integration with Google Analytics via Partytown by ensuring the `gtag` function is exposed for use in components, enabling the sending of custom events directly from the component level.

Key changes:
1. Updated the Partytown script configuration to expose `gtag` globally, allowing for direct invocation in component logic.
2. Added the complete Google Analytics integration script as recommended by Google, ensuring comprehensive tracking capabilities.
3. Documented this integration pattern to assist others in setting up Google Analytics with Partytown in Qwik applications, addressing a common challenge found during implementation.

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
