### PR TITLE
fix: SSG ignoring the index page when trailingSlash is false

### DIFF
--- a/packages/qwik-city/utils/fs.ts
+++ b/packages/qwik-city/utils/fs.ts
@@ -33,7 +33,7 @@ export function getPathnameFromDirPath(opts: NormalizedPluginOptions, dirPath: s
     // remove grouped layout segments
     .filter((segment) => !isGroupedLayoutName(segment))
     .join('/');
-
+  if (pathname === '') return '/';
   return pathname;
 }
 

--- a/packages/qwik-city/utils/fs.ts
+++ b/packages/qwik-city/utils/fs.ts
@@ -33,7 +33,9 @@ export function getPathnameFromDirPath(opts: NormalizedPluginOptions, dirPath: s
     // remove grouped layout segments
     .filter((segment) => !isGroupedLayoutName(segment))
     .join('/');
-  if (pathname === '') return '/';
+  if (pathname === '') {
+    return '/';
+  }
   return pathname;
 }
 


### PR DESCRIPTION
# Overview

fix:#6247

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [x] Feature / enhancement
- [x] Bug
- [x] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
