### PR TITLE
fix(bun): Rewrite TextEncoderStream polyfill implementation for Bun middleware

### DIFF
--- a/packages/qwik-city/middleware/bun/index.ts
+++ b/packages/qwik-city/middleware/bun/index.ts
@@ -48,7 +48,7 @@ class TextEncoderStream_polyfill {
 
 /** @public */
 export function createQwikCity(opts: QwikCityBunOptions) {
-  globalThis.TextEncoderStream = TextEncoderStream || TextEncoderStream_polyfill as any;
+  globalThis.TextEncoderStream = TextEncoderStream || (TextEncoderStream_polyfill as any);
 
   const qwikSerializer = {
     _deserializeData,

--- a/packages/qwik-city/middleware/bun/index.ts
+++ b/packages/qwik-city/middleware/bun/index.ts
@@ -27,10 +27,10 @@ class TextEncoderStream {
   public closed = false;
 
   public readable = new ReadableStream({
-    start: controller => {
+    start: (controller) => {
       this._reader = controller;
-    }
-  })
+    },
+  });
 
   public writable = new WritableStream({
     write: async (chunk) => {
@@ -46,7 +46,7 @@ class TextEncoderStream {
     abort: (reason) => {
       this._reader?.error(reason);
       this.closed = true;
-    }
+    },
   });
 }
 

--- a/packages/qwik-city/middleware/bun/index.ts
+++ b/packages/qwik-city/middleware/bun/index.ts
@@ -16,16 +16,12 @@ import { MIME_TYPES } from '../request-handler/mime-types';
 import { join, extname } from 'node:path';
 
 // @builder.io/qwik-city/middleware/bun
-
-class TextEncoderStream {
+// still missing from bun: last check was bun version 1.1.8
+class TextEncoderStream_polyfill {
   private _encoder = new TextEncoder();
-
   private _reader: ReadableStreamDefaultController<any> | null = null;
-
   public ready = Promise.resolve();
-
   public closed = false;
-
   public readable = new ReadableStream({
     start: (controller) => {
       this._reader = controller;
@@ -52,7 +48,7 @@ class TextEncoderStream {
 
 /** @public */
 export function createQwikCity(opts: QwikCityBunOptions) {
-  globalThis.TextEncoderStream ||= TextEncoderStream as any;
+  globalThis.TextEncoderStream = TextEncoderStream || TextEncoderStream_polyfill as any;
 
   const qwikSerializer = {
     _deserializeData,


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

Closes #5929

The implementation of bun adapter implemented in #5129 has also introduced a polyfill for [TextEncoderStream](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoderStream). While the adapter itself works, this polyfill introduced a bug, caused on attempt to close a response stream (see #5929 for more info). This PR fixes this issue by rewriting the polyfill based on this comment: https://github.com/QwikDev/qwik/issues/5929#issuecomment-2108951045

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
