### PR TITLE
fix(image-size-runtime.html): exclude SVG images from Perf: properly …

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/image-size-runtime.html
+++ b/packages/qwik/src/optimizer/src/plugins/image-size-runtime.html
@@ -321,7 +321,7 @@
         }
         const realArea = info.width && info.height;
         const threshholdArea = realArea * 0.5;
-        const tooBig = browserArea < threshholdArea;
+        const tooBig = browserArea < threshholdArea && info.type !== 'svg';
         skip = false;
         if (layoutInvalidation || tooBig) {
           if (!overlay) {


### PR DESCRIPTION
…size image warnings

SVG is a vector format. Attributes like width, height & viewbox are not relevant to the size in bytes of the image, so the Perf: properly size image warning is incorrect.

# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
