### PR TITLE
feat(core): useConstant, createSignal, createComputed$

### DIFF
--- a/packages/docs/src/routes/api/qwik-city/api.json
+++ b/packages/docs/src/routes/api/qwik-city/api.json
@@ -670,7 +670,7 @@
         }
       ],
       "kind": "Function",
-      "content": "```typescript\nserver$: <T extends ServerFunction>(first: T, options?: ServerConfig | undefined) => ServerQRL<T>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nfirst\n\n\n</td><td>\n\nT\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\noptions\n\n\n</td><td>\n\nServerConfig \\| undefined\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\n[ServerQRL](#serverqrl)<!-- -->&lt;T&gt;",
+      "content": "```typescript\nserver$: <T extends ServerFunction>(qrl: T, options?: ServerConfig | undefined) => ServerQRL<T>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\nT\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\noptions\n\n\n</td><td>\n\nServerConfig \\| undefined\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\n[ServerQRL](#serverqrl)<!-- -->&lt;T&gt;",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-city/runtime/src/server-functions.ts",
       "mdFile": "qwik-city.server_.md"
     },

--- a/packages/docs/src/routes/api/qwik-city/index.md
+++ b/packages/docs/src/routes/api/qwik-city/index.md
@@ -2129,7 +2129,7 @@ RouterOutlet: import("@builder.io/qwik").Component<unknown>;
 
 ```typescript
 server$: <T extends ServerFunction>(
-  first: T,
+  qrl: T,
   options?: ServerConfig | undefined,
 ) => ServerQRL<T>;
 ```
@@ -2149,7 +2149,7 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
-first
+qrl
 
 </td><td>
 

--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -507,6 +507,20 @@
       "mdFile": "qwik.componentqrl.md"
     },
     {
+      "name": "ComputedFn",
+      "id": "computedfn",
+      "hierarchy": [
+        {
+          "name": "ComputedFn",
+          "id": "computedfn"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "```typescript\nexport type ComputedFn<T> = () => T;\n```",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-task.ts",
+      "mdFile": "qwik.computedfn.md"
+    },
+    {
       "name": "ContextId",
       "id": "contextid",
       "hierarchy": [
@@ -549,6 +563,34 @@
       "mdFile": "qwik.correctedtoggleevent.md"
     },
     {
+      "name": "createComputed$",
+      "id": "createcomputed_",
+      "hierarchy": [
+        {
+          "name": "createComputed$",
+          "id": "createcomputed_"
+        }
+      ],
+      "kind": "Function",
+      "content": "Returns read-only signal that updates when signals used in the `ComputedFn` change. Unlike useComputed$, this is not a hook and it always creates a new signal.\n\n\n```typescript\ncreateComputed$: <T>(qrl: ComputedFn<T>) => Signal<Awaited<T>>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\n[ComputedFn](#computedfn)<!-- -->&lt;T&gt;\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\n[Signal](#signal)<!-- -->&lt;Awaited&lt;T&gt;&gt;",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-task.ts",
+      "mdFile": "qwik.createcomputed_.md"
+    },
+    {
+      "name": "createComputedQrl",
+      "id": "createcomputedqrl",
+      "hierarchy": [
+        {
+          "name": "createComputedQrl",
+          "id": "createcomputedqrl"
+        }
+      ],
+      "kind": "Function",
+      "content": "```typescript\ncreateComputedQrl: <T>(qrl: QRL<ComputedFn<T>>) => Signal<Awaited<T>>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\n[QRL](#qrl)<!-- -->&lt;[ComputedFn](#computedfn)<!-- -->&lt;T&gt;&gt;\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\n[Signal](#signal)<!-- -->&lt;Awaited&lt;T&gt;&gt;",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-task.ts",
+      "mdFile": "qwik.createcomputedqrl.md"
+    },
+    {
       "name": "createContextId",
       "id": "createcontextid",
       "hierarchy": [
@@ -561,6 +603,20 @@
       "content": "Create a context ID to be used in your application. The name should be written with no spaces.\n\nContext is a way to pass stores to the child components without prop-drilling.\n\nUse `createContextId()` to create a `ContextId`<!-- -->. A `ContextId` is just a serializable identifier for the context. It is not the context value itself. See `useContextProvider()` and `useContext()` for the values. Qwik needs a serializable ID for the context so that the it can track context providers and consumers in a way that survives resumability.\n\n\\#\\#\\# Example\n\n```tsx\n// Declare the Context type.\ninterface TodosStore {\n  items: string[];\n}\n// Create a Context ID (no data is saved here.)\n// You will use this ID to both create and retrieve the Context.\nexport const TodosContext = createContextId<TodosStore>('Todos');\n\n// Example of providing context to child components.\nexport const App = component$(() => {\n  useContextProvider(\n    TodosContext,\n    useStore<TodosStore>({\n      items: ['Learn Qwik', 'Build Qwik app', 'Profit'],\n    })\n  );\n\n  return <Items />;\n});\n\n// Example of retrieving the context provided by a parent component.\nexport const Items = component$(() => {\n  const todos = useContext(TodosContext);\n  return (\n    <ul>\n      {todos.items.map((item) => (\n        <li>{item}</li>\n      ))}\n    </ul>\n  );\n});\n\n```\n\n\n```typescript\ncreateContextId: <STATE = unknown>(name: string) => ContextId<STATE>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nname\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\nThe name of the context.\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\n[ContextId](#contextid)<!-- -->&lt;STATE&gt;",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-context.ts",
       "mdFile": "qwik.createcontextid.md"
+    },
+    {
+      "name": "createSignal",
+      "id": "createsignal",
+      "hierarchy": [
+        {
+          "name": "createSignal",
+          "id": "createsignal"
+        }
+      ],
+      "kind": "Variable",
+      "content": "Creates a signal.\n\nIf the initial state is a function, the function is invoked to calculate the actual initial state.\n\n\n```typescript\ncreateSignal: UseSignal\n```",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-signal.ts",
+      "mdFile": "qwik.createsignal.md"
     },
     {
       "name": "CSSProperties",
@@ -763,7 +819,7 @@
         }
       ],
       "kind": "Function",
-      "content": "```typescript\nevent$: <T>(first: T) => QRL<T>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nfirst\n\n\n</td><td>\n\nT\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\n[QRL](#qrl)<!-- -->&lt;T&gt;",
+      "content": "```typescript\nevent$: <T>(qrl: T) => QRL<T>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\nT\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\n[QRL](#qrl)<!-- -->&lt;T&gt;",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/qrl/qrl.public.ts",
       "mdFile": "qwik.event_.md"
     },
@@ -1071,7 +1127,7 @@
         }
       ],
       "kind": "Function",
-      "content": "Create a `____$(...)` convenience method from `___(...)`<!-- -->.\n\nIt is very common for functions to take a lazy-loadable resource as a first argument. For this reason, the Qwik Optimizer automatically extracts the first argument from any function which ends in `$`<!-- -->.\n\nThis means that `foo$(arg0)` and `foo($(arg0))` are equivalent with respect to Qwik Optimizer. The former is just a shorthand for the latter.\n\nFor example, these function calls are equivalent:\n\n- `component$(() => {...})` is same as `component($(() => {...}))`\n\n```tsx\nexport function myApi(callback: QRL<() => void>): void {\n  // ...\n}\n\nexport const myApi$ = implicit$FirstArg(myApi);\n// type of myApi$: (callback: () => void): void\n\n// can be used as:\nmyApi$(() => console.log('callback'));\n\n// will be transpiled to:\n// FILE: <current file>\nmyApi(qrl('./chunk-abc.js', 'callback'));\n\n// FILE: chunk-abc.js\nexport const callback = () => console.log('callback');\n```\n\n\n```typescript\nimplicit$FirstArg: <FIRST, REST extends any[], RET>(fn: (first: QRL<FIRST>, ...rest: REST) => RET) => ((first: FIRST, ...rest: REST) => RET)\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nfn\n\n\n</td><td>\n\n(first: [QRL](#qrl)<!-- -->&lt;FIRST&gt;, ...rest: REST) =&gt; RET\n\n\n</td><td>\n\nA function that should have its first argument automatically `$`<!-- -->.\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\n((first: FIRST, ...rest: REST) =&gt; RET)",
+      "content": "Create a `____$(...)` convenience method from `___(...)`<!-- -->.\n\nIt is very common for functions to take a lazy-loadable resource as a first argument. For this reason, the Qwik Optimizer automatically extracts the first argument from any function which ends in `$`<!-- -->.\n\nThis means that `foo$(arg0)` and `foo($(arg0))` are equivalent with respect to Qwik Optimizer. The former is just a shorthand for the latter.\n\nFor example, these function calls are equivalent:\n\n- `component$(() => {...})` is same as `component($(() => {...}))`\n\n```tsx\nexport function myApi(callback: QRL<() => void>): void {\n  // ...\n}\n\nexport const myApi$ = implicit$FirstArg(myApi);\n// type of myApi$: (callback: () => void): void\n\n// can be used as:\nmyApi$(() => console.log('callback'));\n\n// will be transpiled to:\n// FILE: <current file>\nmyApi(qrl('./chunk-abc.js', 'callback'));\n\n// FILE: chunk-abc.js\nexport const callback = () => console.log('callback');\n```\n\n\n```typescript\nimplicit$FirstArg: <FIRST, REST extends any[], RET>(fn: (qrl: QRL<FIRST>, ...rest: REST) => RET) => ((qrl: FIRST, ...rest: REST) => RET)\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nfn\n\n\n</td><td>\n\n(qrl: [QRL](#qrl)<!-- -->&lt;FIRST&gt;, ...rest: REST) =&gt; RET\n\n\n</td><td>\n\nA function that should have its first argument automatically `$`<!-- -->.\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\n((qrl: FIRST, ...rest: REST) =&gt; RET)",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/util/implicit_dollar.ts",
       "mdFile": "qwik.implicit_firstarg.md"
     },
@@ -2474,7 +2530,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface Signal<T = any> \n```\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n[value](#)\n\n\n</td><td>\n\n\n</td><td>\n\nT\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>",
+      "content": "A signal is a reactive value which can be read and written. When the signal is written, all tasks which are tracking the signal will be re-run and all components that read the signal will be re-rendered.\n\nFurthermore, when a signal value is passed as a prop to a component, the optimizer will automatically forward the signal. This means that `return <div title={signal.value}>hi</div>` will update the `title` attribute when the signal changes without having to re-render the component.\n\n\n```typescript\nexport interface Signal<T = any> \n```\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n[value](#)\n\n\n</td><td>\n\n\n</td><td>\n\nT\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/state/signal.ts",
       "mdFile": "qwik.signal.md"
     },
@@ -2963,8 +3019,8 @@
           "id": "usecomputed_"
         }
       ],
-      "kind": "Variable",
-      "content": "```typescript\nuseComputed$: Computed\n```",
+      "kind": "Function",
+      "content": "Hook that returns a read-only signal that updates when signals used in the `ComputedFn` change.\n\n\n```typescript\nuseComputed$: <T>(qrl: ComputedFn<T>) => Signal<Awaited<T>>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\n[ComputedFn](#computedfn)<!-- -->&lt;T&gt;\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\n[Signal](#signal)<!-- -->&lt;Awaited&lt;T&gt;&gt;",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-task.ts",
       "mdFile": "qwik.usecomputed_.md"
     },
@@ -2977,10 +3033,24 @@
           "id": "usecomputedqrl"
         }
       ],
-      "kind": "Variable",
-      "content": "```typescript\nuseComputedQrl: ComputedQRL\n```",
+      "kind": "Function",
+      "content": "```typescript\nuseComputedQrl: <T>(qrl: QRL<ComputedFn<T>>) => Signal<Awaited<T>>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\n[QRL](#qrl)<!-- -->&lt;[ComputedFn](#computedfn)<!-- -->&lt;T&gt;&gt;\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\n[Signal](#signal)<!-- -->&lt;Awaited&lt;T&gt;&gt;",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-task.ts",
       "mdFile": "qwik.usecomputedqrl.md"
+    },
+    {
+      "name": "useConst",
+      "id": "useconst",
+      "hierarchy": [
+        {
+          "name": "useConst",
+          "id": "useconst"
+        }
+      ],
+      "kind": "Function",
+      "content": "Stores a value which is retained for the lifetime of the component.\n\nIf the value is a function, the function is invoked to calculate the actual value.\n\n\n```typescript\nuseConst: <T>(value: (() => T) | T) => T\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nvalue\n\n\n</td><td>\n\n(() =&gt; T) \\| T\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\nT",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-signal.ts",
+      "mdFile": "qwik.useconst.md"
     },
     {
       "name": "useContext",
@@ -3132,7 +3202,7 @@
         }
       ],
       "kind": "Variable",
-      "content": "```typescript\nuseSignal: UseSignal\n```",
+      "content": "Hook that creates a signal that is retained for the lifetime of the component.\n\n\n```typescript\nuseSignal: UseSignal\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-signal.ts",
       "mdFile": "qwik.usesignal.md"
     },
@@ -3146,7 +3216,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nuseSignal: UseSignal\n```",
+      "content": "Hook that creates a signal that is retained for the lifetime of the component.\n\n\n```typescript\nuseSignal: UseSignal\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-signal.ts",
       "mdFile": "qwik.usesignal.md"
     },
@@ -3188,7 +3258,7 @@
         }
       ],
       "kind": "Function",
-      "content": "A lazy-loadable reference to a component's styles.\n\nComponent styles allow Qwik to lazy load the style information for the component only when needed. (And avoid double loading it in case of SSR hydration.)\n\n```tsx\nimport styles from './code-block.css?inline';\n\nexport const CmpStyles = component$(() => {\n  useStyles$(styles);\n\n  return <div>Some text</div>;\n});\n```\n\n\n```typescript\nuseStyles$: (first: string) => void\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nfirst\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\nvoid",
+      "content": "A lazy-loadable reference to a component's styles.\n\nComponent styles allow Qwik to lazy load the style information for the component only when needed. (And avoid double loading it in case of SSR hydration.)\n\n```tsx\nimport styles from './code-block.css?inline';\n\nexport const CmpStyles = component$(() => {\n  useStyles$(styles);\n\n  return <div>Some text</div>;\n});\n```\n\n\n```typescript\nuseStyles$: (qrl: string) => void\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\nvoid",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-styles.ts",
       "mdFile": "qwik.usestyles_.md"
     },
@@ -3230,7 +3300,7 @@
         }
       ],
       "kind": "Function",
-      "content": "A lazy-loadable reference to a component's styles, that is scoped to the component.\n\nComponent styles allow Qwik to lazy load the style information for the component only when needed. (And avoid double loading it in case of SSR hydration.)\n\n```tsx\nimport scoped from './code-block.css?inline';\n\nexport const CmpScopedStyles = component$(() => {\n  useStylesScoped$(scoped);\n\n  return <div>Some text</div>;\n});\n```\n\n\n```typescript\nuseStylesScoped$: (first: string) => UseStylesScoped\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nfirst\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\n[UseStylesScoped](#usestylesscoped)",
+      "content": "A lazy-loadable reference to a component's styles, that is scoped to the component.\n\nComponent styles allow Qwik to lazy load the style information for the component only when needed. (And avoid double loading it in case of SSR hydration.)\n\n```tsx\nimport scoped from './code-block.css?inline';\n\nexport const CmpScopedStyles = component$(() => {\n  useStylesScoped$(scoped);\n\n  return <div>Some text</div>;\n});\n```\n\n\n```typescript\nuseStylesScoped$: (qrl: string) => UseStylesScoped\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\n[UseStylesScoped](#usestylesscoped)",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-styles.ts",
       "mdFile": "qwik.usestylesscoped_.md"
     },
@@ -3258,7 +3328,7 @@
         }
       ],
       "kind": "Function",
-      "content": "Reruns the `taskFn` when the observed inputs change.\n\nUse `useTask` to observe changes on a set of inputs, and then re-execute the `taskFn` when those inputs change.\n\nThe `taskFn` only executes if the observed inputs change. To observe the inputs, use the `obs` function to wrap property reads. This creates subscriptions that will trigger the `taskFn` to rerun.\n\n\n```typescript\nuseTask$: (first: TaskFn, opts?: UseTaskOptions | undefined) => void\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nfirst\n\n\n</td><td>\n\n[TaskFn](#taskfn)\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\nopts\n\n\n</td><td>\n\n[UseTaskOptions](#usetaskoptions) \\| undefined\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\nvoid",
+      "content": "Reruns the `taskFn` when the observed inputs change.\n\nUse `useTask` to observe changes on a set of inputs, and then re-execute the `taskFn` when those inputs change.\n\nThe `taskFn` only executes if the observed inputs change. To observe the inputs, use the `obs` function to wrap property reads. This creates subscriptions that will trigger the `taskFn` to rerun.\n\n\n```typescript\nuseTask$: (qrl: TaskFn, opts?: UseTaskOptions | undefined) => void\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\n[TaskFn](#taskfn)\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\nopts\n\n\n</td><td>\n\n[UseTaskOptions](#usetaskoptions) \\| undefined\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\nvoid",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-task.ts",
       "mdFile": "qwik.usetask_.md"
     },
@@ -3300,7 +3370,7 @@
         }
       ],
       "kind": "Function",
-      "content": "```tsx\nconst Timer = component$(() => {\n  const store = useStore({\n    count: 0,\n  });\n\n  useVisibleTask$(() => {\n    // Only runs in the client\n    const timer = setInterval(() => {\n      store.count++;\n    }, 500);\n    return () => {\n      clearInterval(timer);\n    };\n  });\n\n  return <div>{store.count}</div>;\n});\n```\n\n\n```typescript\nuseVisibleTask$: (first: TaskFn, opts?: OnVisibleTaskOptions | undefined) => void\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nfirst\n\n\n</td><td>\n\n[TaskFn](#taskfn)\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\nopts\n\n\n</td><td>\n\n[OnVisibleTaskOptions](#onvisibletaskoptions) \\| undefined\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\nvoid",
+      "content": "```tsx\nconst Timer = component$(() => {\n  const store = useStore({\n    count: 0,\n  });\n\n  useVisibleTask$(() => {\n    // Only runs in the client\n    const timer = setInterval(() => {\n      store.count++;\n    }, 500);\n    return () => {\n      clearInterval(timer);\n    };\n  });\n\n  return <div>{store.count}</div>;\n});\n```\n\n\n```typescript\nuseVisibleTask$: (qrl: TaskFn, opts?: OnVisibleTaskOptions | undefined) => void\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\n[TaskFn](#taskfn)\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\nopts\n\n\n</td><td>\n\n[OnVisibleTaskOptions](#onvisibletaskoptions) \\| undefined\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\nvoid",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-task.ts",
       "mdFile": "qwik.usevisibletask_.md"
     },

--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -3039,18 +3039,18 @@
       "mdFile": "qwik.usecomputedqrl.md"
     },
     {
-      "name": "useConst",
-      "id": "useconst",
+      "name": "useConstant",
+      "id": "useconstant",
       "hierarchy": [
         {
-          "name": "useConst",
-          "id": "useconst"
+          "name": "useConstant",
+          "id": "useconstant"
         }
       ],
       "kind": "Function",
-      "content": "Stores a value which is retained for the lifetime of the component.\n\nIf the value is a function, the function is invoked to calculate the actual value.\n\n\n```typescript\nuseConst: <T>(value: (() => T) | T) => T\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nvalue\n\n\n</td><td>\n\n(() =&gt; T) \\| T\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\nT",
+      "content": "Stores a value which is retained for the lifetime of the component.\n\nIf the value is a function, the function is invoked to calculate the actual value.\n\n\n```typescript\nuseConstant: <T>(value: (() => T) | T) => T\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nvalue\n\n\n</td><td>\n\n(() =&gt; T) \\| T\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\nT",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-signal.ts",
-      "mdFile": "qwik.useconst.md"
+      "mdFile": "qwik.useconstant.md"
     },
     {
       "name": "useContext",

--- a/packages/docs/src/routes/api/qwik/index.md
+++ b/packages/docs/src/routes/api/qwik/index.md
@@ -1408,6 +1408,14 @@ componentQrl
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/component/component.public.ts)
 
+## ComputedFn
+
+```typescript
+export type ComputedFn<T> = () => T;
+```
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-task.ts)
+
 ## ContextId
 
 ContextId is a typesafe ID for your context.
@@ -1688,6 +1696,82 @@ Description
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts)
 
+## createComputed$
+
+Returns read-only signal that updates when signals used in the `ComputedFn` change. Unlike useComputed$, this is not a hook and it always creates a new signal.
+
+```typescript
+createComputed$: <T>(qrl: ComputedFn<T>) => Signal<Awaited<T>>;
+```
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+qrl
+
+</td><td>
+
+[ComputedFn](#computedfn)&lt;T&gt;
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Signal](#signal)&lt;Awaited&lt;T&gt;&gt;
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-task.ts)
+
+## createComputedQrl
+
+```typescript
+createComputedQrl: <T>(qrl: QRL<ComputedFn<T>>) => Signal<Awaited<T>>;
+```
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+qrl
+
+</td><td>
+
+[QRL](#qrl)&lt;[ComputedFn](#computedfn)&lt;T&gt;&gt;
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Signal](#signal)&lt;Awaited&lt;T&gt;&gt;
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-task.ts)
+
 ## createContextId
 
 Create a context ID to be used in your application. The name should be written with no spaces.
@@ -1768,6 +1852,18 @@ The name of the context.
 [ContextId](#contextid)&lt;STATE&gt;
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-context.ts)
+
+## createSignal
+
+Creates a signal.
+
+If the initial state is a function, the function is invoked to calculate the actual initial state.
+
+```typescript
+createSignal: UseSignal;
+```
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-signal.ts)
 
 ## CSSProperties
 
@@ -2061,7 +2157,7 @@ any \| undefined
 ## event$
 
 ```typescript
-event$: <T>(first: T) => QRL<T>;
+event$: <T>(qrl: T) => QRL<T>;
 ```
 
 <table><thead><tr><th>
@@ -2079,7 +2175,7 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
-first
+qrl
 
 </td><td>
 
@@ -2571,9 +2667,9 @@ export const callback = () => console.log("callback");
 
 ```typescript
 implicit$FirstArg: <FIRST, REST extends any[], RET>(
-    fn: (first: QRL<FIRST>, ...rest: REST) => RET,
+    fn: (qrl: QRL<FIRST>, ...rest: REST) => RET,
   ) =>
-  (first: FIRST, ...rest: REST) =>
+  (qrl: FIRST, ...rest: REST) =>
     RET;
 ```
 
@@ -2596,7 +2692,7 @@ fn
 
 </td><td>
 
-(first: [QRL](#qrl)&lt;FIRST&gt;, ...rest: REST) =&gt; RET
+(qrl: [QRL](#qrl)&lt;FIRST&gt;, ...rest: REST) =&gt; RET
 
 </td><td>
 
@@ -2606,7 +2702,7 @@ A function that should have its first argument automatically `$`.
 </tbody></table>
 **Returns:**
 
-((first: FIRST, ...rest: REST) =&gt; RET)
+((qrl: FIRST, ...rest: REST) =&gt; RET)
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/util/implicit_dollar.ts)
 
@@ -5222,6 +5318,10 @@ plt
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/platform/platform.ts)
 
 ## Signal
+
+A signal is a reactive value which can be read and written. When the signal is written, all tasks which are tracking the signal will be re-run and all components that read the signal will be re-rendered.
+
+Furthermore, when a signal value is passed as a prop to a component, the optimizer will automatically forward the signal. This means that `return <div title={signal.value}>hi</div>` will update the `title` attribute when the signal changes without having to re-render the component.
 
 ```typescript
 export interface Signal<T = any>
@@ -10009,19 +10109,120 @@ T
 
 ## useComputed$
 
+Hook that returns a read-only signal that updates when signals used in the `ComputedFn` change.
+
 ```typescript
-useComputed$: Computed;
+useComputed$: <T>(qrl: ComputedFn<T>) => Signal<Awaited<T>>;
 ```
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+qrl
+
+</td><td>
+
+[ComputedFn](#computedfn)&lt;T&gt;
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Signal](#signal)&lt;Awaited&lt;T&gt;&gt;
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-task.ts)
 
 ## useComputedQrl
 
 ```typescript
-useComputedQrl: ComputedQRL;
+useComputedQrl: <T>(qrl: QRL<ComputedFn<T>>) => Signal<Awaited<T>>;
 ```
 
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+qrl
+
+</td><td>
+
+[QRL](#qrl)&lt;[ComputedFn](#computedfn)&lt;T&gt;&gt;
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[Signal](#signal)&lt;Awaited&lt;T&gt;&gt;
+
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-task.ts)
+
+## useConst
+
+Stores a value which is retained for the lifetime of the component.
+
+If the value is a function, the function is invoked to calculate the actual value.
+
+```typescript
+useConst: <T>(value: (() => T) | T) => T;
+```
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+value
+
+</td><td>
+
+(() =&gt; T) \| T
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+T
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-signal.ts)
 
 ## useContext
 
@@ -10566,6 +10767,8 @@ T \| undefined
 
 ## useSignal
 
+Hook that creates a signal that is retained for the lifetime of the component.
+
 ```typescript
 useSignal: UseSignal;
 ```
@@ -10573,6 +10776,8 @@ useSignal: UseSignal;
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-signal.ts)
 
 ## UseSignal
+
+Hook that creates a signal that is retained for the lifetime of the component.
 
 ```typescript
 useSignal: UseSignal;
@@ -10762,7 +10967,7 @@ export const CmpStyles = component$(() => {
 ```
 
 ```typescript
-useStyles$: (first: string) => void
+useStyles$: (qrl: string) => void
 ```
 
 <table><thead><tr><th>
@@ -10780,7 +10985,7 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
-first
+qrl
 
 </td><td>
 
@@ -10904,7 +11109,7 @@ export const CmpScopedStyles = component$(() => {
 ```
 
 ```typescript
-useStylesScoped$: (first: string) => UseStylesScoped;
+useStylesScoped$: (qrl: string) => UseStylesScoped;
 ```
 
 <table><thead><tr><th>
@@ -10922,7 +11127,7 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
-first
+qrl
 
 </td><td>
 
@@ -10998,7 +11203,7 @@ Use `useTask` to observe changes on a set of inputs, and then re-execute the `ta
 The `taskFn` only executes if the observed inputs change. To observe the inputs, use the `obs` function to wrap property reads. This creates subscriptions that will trigger the `taskFn` to rerun.
 
 ```typescript
-useTask$: (first: TaskFn, opts?: UseTaskOptions | undefined) => void
+useTask$: (qrl: TaskFn, opts?: UseTaskOptions | undefined) => void
 ```
 
 <table><thead><tr><th>
@@ -11016,7 +11221,7 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
-first
+qrl
 
 </td><td>
 
@@ -11166,7 +11371,7 @@ const Timer = component$(() => {
 ```
 
 ```typescript
-useVisibleTask$: (first: TaskFn, opts?: OnVisibleTaskOptions | undefined) => void
+useVisibleTask$: (qrl: TaskFn, opts?: OnVisibleTaskOptions | undefined) => void
 ```
 
 <table><thead><tr><th>
@@ -11184,7 +11389,7 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
-first
+qrl
 
 </td><td>
 

--- a/packages/docs/src/routes/api/qwik/index.md
+++ b/packages/docs/src/routes/api/qwik/index.md
@@ -10183,14 +10183,14 @@ qrl
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-task.ts)
 
-## useConst
+## useConstant
 
 Stores a value which is retained for the lifetime of the component.
 
 If the value is a function, the function is invoked to calculate the actual value.
 
 ```typescript
-useConst: <T>(value: (() => T) | T) => T;
+useConstant: <T>(value: (() => T) | T) => T;
 ```
 
 <table><thead><tr><th>

--- a/packages/qwik-city/runtime/src/api.md
+++ b/packages/qwik-city/runtime/src/api.md
@@ -415,7 +415,7 @@ export const RouterOutlet: Component<unknown>;
 // Warning: (ae-forgotten-export) The symbol "ServerConfig" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export const server$: <T extends ServerFunction>(first: T, options?: ServerConfig | undefined) => ServerQRL<T>;
+export const server$: <T extends ServerFunction>(qrl: T, options?: ServerConfig | undefined) => ServerQRL<T>;
 
 // @public (undocumented)
 export type ServerFunction = {

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -1628,7 +1628,7 @@ export const useComputed$: <T>(qrl: ComputedFn<T>) => Signal<Awaited<T>>;
 export const useComputedQrl: <T>(qrl: QRL<ComputedFn<T>>) => Signal<Awaited<T>>;
 
 // @public
-export const useConst: <T>(value: (() => T) | T) => T;
+export const useConstant: <T>(value: (() => T) | T) => T;
 
 // Warning: (ae-forgotten-export) The symbol "UseContext" needs to be exported by the entry point index.d.ts
 //

--- a/packages/qwik/src/core/api.md
+++ b/packages/qwik/src/core/api.md
@@ -131,6 +131,9 @@ export interface ComponentBaseProps {
 // @public
 export const componentQrl: <PROPS extends Record<any, any>>(componentQrl: QRL<OnRenderFn<PROPS>>) => Component<PROPS>;
 
+// @public (undocumented)
+export type ComputedFn<T> = () => T;
+
 // @public
 export interface ContextId<STATE> {
     readonly __brand_context_type__: STATE;
@@ -155,7 +158,16 @@ export interface CorrectedToggleEvent extends Event {
 }
 
 // @public
+export const createComputed$: <T>(qrl: ComputedFn<T>) => Signal<Awaited<T>>;
+
+// @public (undocumented)
+export const createComputedQrl: <T>(qrl: QRL<ComputedFn<T>>) => Signal<Awaited<T>>;
+
+// @public
 export const createContextId: <STATE = unknown>(name: string) => ContextId<STATE>;
+
+// @public
+export const createSignal: UseSignal;
 
 // @public (undocumented)
 export interface CSSProperties extends CSS_2.Properties<string | number>, CSS_2.PropertiesHyphen<string | number> {
@@ -216,7 +228,7 @@ export interface ErrorBoundaryStore {
 }
 
 // @public (undocumented)
-export const event$: <T>(first: T) => QRL<T>;
+export const event$: <T>(qrl: T) => QRL<T>;
 
 // @public
 export type EventHandler<EV = Event, EL = Element> = {
@@ -342,7 +354,7 @@ export interface ImgHTMLAttributes<T extends Element> extends Attrs<'img', T> {
 export const _IMMUTABLE: unique symbol;
 
 // @public
-export const implicit$FirstArg: <FIRST, REST extends any[], RET>(fn: (first: QRL<FIRST>, ...rest: REST) => RET) => ((first: FIRST, ...rest: REST) => RET);
+export const implicit$FirstArg: <FIRST, REST extends any[], RET>(fn: (qrl: QRL<FIRST>, ...rest: REST) => RET) => ((qrl: FIRST, ...rest: REST) => RET);
 
 // Warning: (ae-internal-missing-underscore) The name "inlinedQrl" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -903,7 +915,7 @@ export const _serializeData: (data: any, pureQRL?: boolean) => Promise<string>;
 // @public
 export const setPlatform: (plt: CorePlatform) => CorePlatform;
 
-// @public (undocumented)
+// @public
 export interface Signal<T = any> {
     // (undocumented)
     value: T;
@@ -1609,15 +1621,14 @@ export interface TrackHTMLAttributes<T extends Element> extends Attrs<'track', T
 // @public
 export const untrack: <T>(fn: () => T) => T;
 
-// Warning: (ae-forgotten-export) The symbol "Computed" needs to be exported by the entry point index.d.ts
-//
-// @public (undocumented)
-export const useComputed$: Computed;
+// @public
+export const useComputed$: <T>(qrl: ComputedFn<T>) => Signal<Awaited<T>>;
 
-// Warning: (ae-forgotten-export) The symbol "ComputedQRL" needs to be exported by the entry point index.d.ts
-//
 // @public (undocumented)
-export const useComputedQrl: ComputedQRL;
+export const useComputedQrl: <T>(qrl: QRL<ComputedFn<T>>) => Signal<Awaited<T>>;
+
+// @public
+export const useConst: <T>(value: (() => T) | T) => T;
 
 // Warning: (ae-forgotten-export) The symbol "UseContext" needs to be exported by the entry point index.d.ts
 //
@@ -1669,7 +1680,7 @@ export interface UseSignal {
     <T>(value: T | (() => T)): Signal<T>;
 }
 
-// @public (undocumented)
+// @public
 export const useSignal: UseSignal;
 
 // @public
@@ -1682,13 +1693,13 @@ export interface UseStoreOptions {
 }
 
 // @public
-export const useStyles$: (first: string) => void;
+export const useStyles$: (qrl: string) => void;
 
 // @public
 export const useStylesQrl: (styles: QRL<string>) => void;
 
 // @public
-export const useStylesScoped$: (first: string) => UseStylesScoped;
+export const useStylesScoped$: (qrl: string) => UseStylesScoped;
 
 // @public (undocumented)
 export interface UseStylesScoped {
@@ -1700,7 +1711,7 @@ export interface UseStylesScoped {
 export const useStylesScopedQrl: (styles: QRL<string>) => UseStylesScoped;
 
 // @public
-export const useTask$: (first: TaskFn, opts?: UseTaskOptions | undefined) => void;
+export const useTask$: (qrl: TaskFn, opts?: UseTaskOptions | undefined) => void;
 
 // @public (undocumented)
 export interface UseTaskOptions {
@@ -1711,7 +1722,7 @@ export interface UseTaskOptions {
 export const useTaskQrl: (qrl: QRL<TaskFn>, opts?: UseTaskOptions) => void;
 
 // @public
-export const useVisibleTask$: (first: TaskFn, opts?: OnVisibleTaskOptions | undefined) => void;
+export const useVisibleTask$: (qrl: TaskFn, opts?: OnVisibleTaskOptions | undefined) => void;
 
 // @public
 export const useVisibleTaskQrl: (qrl: QRL<TaskFn>, opts?: OnVisibleTaskOptions) => void;

--- a/packages/qwik/src/core/index.ts
+++ b/packages/qwik/src/core/index.ts
@@ -87,7 +87,7 @@ export { useContext, useContextProvider, createContextId } from './use/use-conte
 export { useServerData } from './use/use-env-data';
 export { useStylesQrl, useStyles$, useStylesScopedQrl, useStylesScoped$ } from './use/use-styles';
 export { useOn, useOnDocument, useOnWindow } from './use/use-on';
-export { useSignal } from './use/use-signal';
+export { useSignal, useConst, createSignal } from './use/use-signal';
 export { withLocale, getLocale } from './use/use-locale';
 
 export type { UseStylesScoped } from './use/use-styles';
@@ -95,25 +95,26 @@ export type { UseSignal } from './use/use-signal';
 export type { ContextId } from './use/use-context';
 export type { UseStoreOptions } from './use/use-store.public';
 export type {
-  Tracker,
-  TaskFn,
-  OnVisibleTaskOptions,
-  VisibleTaskStrategy,
+  ComputedFn,
   EagernessOptions,
-  ResourceReturn,
+  OnVisibleTaskOptions,
   ResourceCtx,
+  ResourceFn,
   ResourcePending,
   ResourceRejected,
   ResourceResolved,
+  ResourceReturn,
   TaskCtx,
+  TaskFn,
+  Tracker,
   UseTaskOptions,
-  ResourceFn,
+  VisibleTaskStrategy,
 } from './use/use-task';
 export type { ResourceProps, ResourceOptions } from './use/use-resource';
 export { useResource$, useResourceQrl, Resource } from './use/use-resource';
 export { useTask$, useTaskQrl } from './use/use-task';
 export { useVisibleTask$, useVisibleTaskQrl } from './use/use-task';
-export { useComputed$, useComputedQrl } from './use/use-task';
+export { useComputed$, useComputedQrl, createComputed$, createComputedQrl } from './use/use-task';
 export { useErrorBoundary } from './use/use-error-boundary';
 export type { ErrorBoundaryStore } from './render/error-handling';
 

--- a/packages/qwik/src/core/index.ts
+++ b/packages/qwik/src/core/index.ts
@@ -87,7 +87,7 @@ export { useContext, useContextProvider, createContextId } from './use/use-conte
 export { useServerData } from './use/use-env-data';
 export { useStylesQrl, useStyles$, useStylesScopedQrl, useStylesScoped$ } from './use/use-styles';
 export { useOn, useOnDocument, useOnWindow } from './use/use-on';
-export { useSignal, useConst, createSignal } from './use/use-signal';
+export { useSignal, useConstant, createSignal } from './use/use-signal';
 export { withLocale, getLocale } from './use/use-locale';
 
 export type { UseStylesScoped } from './use/use-styles';

--- a/packages/qwik/src/core/state/signal.ts
+++ b/packages/qwik/src/core/state/signal.ts
@@ -15,7 +15,18 @@ import {
 import { QObjectManagerSymbol, _IMMUTABLE, _IMMUTABLE_PREFIX } from './constants';
 import { _fnSignal } from '../qrl/inlined-fn';
 
-/** @public */
+/**
+ * A signal is a reactive value which can be read and written. When the signal is written, all tasks
+ * which are tracking the signal will be re-run and all components that read the signal will be
+ * re-rendered.
+ *
+ * Furthermore, when a signal value is passed as a prop to a component, the optimizer will
+ * automatically forward the signal. This means that `return <div title={signal.value}>hi</div>`
+ * will update the `title` attribute when the signal changes without having to re-render the
+ * component.
+ *
+ * @public
+ */
 export interface Signal<T = any> {
   value: T;
 }

--- a/packages/qwik/src/core/use/use-core.ts
+++ b/packages/qwik/src/core/use/use-core.ts
@@ -123,6 +123,10 @@ export const useInvokeContext = (): RenderInvokeContext => {
 
   return ctx as RenderInvokeContext;
 };
+export const useContainerState = () => {
+  const ctx = useInvokeContext();
+  return ctx.$renderCtx$.$static$.$containerState$;
+};
 
 export function useBindInvokeContext<FN extends (...args: any) => any>(
   this: unknown,

--- a/packages/qwik/src/core/use/use-signal.ts
+++ b/packages/qwik/src/core/use/use-signal.ts
@@ -34,7 +34,7 @@ export const createSignal: UseSignal = <STATE>(initialState?: STATE): Signal<STA
  *
  * @public
  */
-export const useConst = <T>(value: (() => T) | T): T => {
+export const useConstant = <T>(value: (() => T) | T): T => {
   const { val, set } = useSequentialScope<T>();
   if (val != null) {
     return val;
@@ -50,5 +50,5 @@ export const useConst = <T>(value: (() => T) | T): T => {
  * @public
  */
 export const useSignal: UseSignal = (initialState?: any) => {
-  return useConst(() => createSignal(initialState));
+  return useConstant(() => createSignal(initialState));
 };

--- a/packages/qwik/src/core/use/use-signal.ts
+++ b/packages/qwik/src/core/use/use-signal.ts
@@ -1,7 +1,7 @@
 import { isQwikComponent } from '../component/component.public';
 import { _createSignal, type Signal } from '../state/signal';
 import { isFunction } from '../util/types';
-import { invoke } from './use-core';
+import { invoke, useContainerState } from './use-core';
 import { useSequentialScope } from './use-sequential-scope';
 
 /** @public */
@@ -10,18 +10,45 @@ export interface UseSignal {
   <T>(value: T | (() => T)): Signal<T>;
 }
 
-/** @public */
-export const useSignal: UseSignal = <STATE>(initialState?: STATE): Signal<STATE> => {
-  const { val, set, iCtx } = useSequentialScope<Signal<STATE>>();
-  if (val != null) {
-    return val;
-  }
-
-  const containerState = iCtx.$renderCtx$.$static$.$containerState$;
+/**
+ * Creates a signal.
+ *
+ * If the initial state is a function, the function is invoked to calculate the actual initial
+ * state.
+ *
+ * @public
+ */
+export const createSignal: UseSignal = <STATE>(initialState?: STATE): Signal<STATE> => {
+  const containerState = useContainerState();
   const value =
     isFunction(initialState) && !isQwikComponent(initialState)
       ? invoke(undefined, initialState as any)
       : initialState;
-  const signal = _createSignal(value, containerState, 0, undefined) as Signal<STATE>;
-  return set(signal);
+  return _createSignal(value, containerState, 0) as Signal<STATE>;
+};
+
+/**
+ * Stores a value which is retained for the lifetime of the component.
+ *
+ * If the value is a function, the function is invoked to calculate the actual value.
+ *
+ * @public
+ */
+export const useConst = <T>(value: (() => T) | T): T => {
+  const { val, set } = useSequentialScope<T>();
+  if (val != null) {
+    return val;
+  }
+  // Note: We are not using `invoke` here because we don't want to clear the context
+  value = isFunction(value) && !isQwikComponent(value) ? value() : value;
+  return set(value as T);
+};
+
+/**
+ * Hook that creates a signal that is retained for the lifetime of the component.
+ *
+ * @public
+ */
+export const useSignal: UseSignal = (initialState?: any) => {
+  return useConst(() => createSignal(initialState));
 };

--- a/packages/qwik/src/core/use/use-task.ts
+++ b/packages/qwik/src/core/use/use-task.ts
@@ -34,7 +34,7 @@ import {
 import { QObjectManagerSymbol } from '../state/constants';
 import { ComputedEvent, TaskEvent } from '../util/markers';
 import { getContext } from '../state/context';
-import { useConst } from './use-signal';
+import { useConstant } from './use-signal';
 
 export const TaskFlagsIsVisibleTask = 1 << 0;
 export const TaskFlagsIsTask = 1 << 1;
@@ -328,7 +328,7 @@ export const createComputedQrl = <T>(qrl: QRL<ComputedFn<T>>): Signal<Awaited<T>
 };
 /** @public */
 export const useComputedQrl = <T>(qrl: QRL<ComputedFn<T>>): Signal<Awaited<T>> => {
-  return useConst(() => createComputedQrl(qrl));
+  return useConstant(() => createComputedQrl(qrl));
 };
 
 /**

--- a/packages/qwik/src/core/use/use-task.ts
+++ b/packages/qwik/src/core/use/use-task.ts
@@ -1,4 +1,4 @@
-import { newInvokeContext, invoke, waitAndRun, untrack } from './use-core';
+import { newInvokeContext, invoke, waitAndRun, untrack, useInvokeContext } from './use-core';
 import { logError, logErrorAndStop } from '../util/log';
 import { delay, safeCall, maybeThen } from '../util/promises';
 import { isFunction, isObject, type ValueOrPromise } from '../util/types';
@@ -33,6 +33,8 @@ import {
 } from '../state/signal';
 import { QObjectManagerSymbol } from '../state/constants';
 import { ComputedEvent, TaskEvent } from '../util/markers';
+import { getContext } from '../state/context';
+import { useConst } from './use-signal';
 
 export const TaskFlagsIsVisibleTask = 1 << 0;
 export const TaskFlagsIsTask = 1 << 1;
@@ -296,22 +298,13 @@ export const useTaskQrl = (qrl: QRL<TaskFn>, opts?: UseTaskOptions): void => {
   }
 };
 
-interface ComputedQRL {
-  <T>(qrl: QRL<ComputedFn<T>>): ReadonlySignal<Awaited<T>>;
-}
-
-interface Computed {
-  <T>(qrl: ComputedFn<T>): ReadonlySignal<Awaited<T>>;
-}
-
 /** @public */
-export const useComputedQrl: ComputedQRL = <T>(qrl: QRL<ComputedFn<T>>): Signal<Awaited<T>> => {
-  const { val, set, iCtx, i, elCtx } = useSequentialScope<Signal<Awaited<T>>>();
-  if (val) {
-    return val;
-  }
+export const createComputedQrl = <T>(qrl: QRL<ComputedFn<T>>): Signal<Awaited<T>> => {
   assertQrl(qrl);
+  const iCtx = useInvokeContext();
+  const hostElement = iCtx.$hostElement$;
   const containerState = iCtx.$renderCtx$.$static$.$containerState$;
+  const elCtx = getContext(hostElement, containerState);
   const signal = _createSignal(
     undefined as Awaited<T>,
     containerState,
@@ -321,23 +314,36 @@ export const useComputedQrl: ComputedQRL = <T>(qrl: QRL<ComputedFn<T>>): Signal<
 
   const task = new Task(
     TaskFlagsIsDirty | TaskFlagsIsTask | TaskFlagsIsComputed,
-    i,
+    // Computed signals should update immediately
+    0,
     elCtx.$element$,
     qrl,
     signal
   );
   qrl.$resolveLazy$(containerState.$containerEl$);
-  if (!elCtx.$tasks$) {
-    elCtx.$tasks$ = [];
-  }
-  elCtx.$tasks$.push(task);
+  (elCtx.$tasks$ ||= []).push(task);
 
   waitAndRun(iCtx, () => runComputed(task, containerState, iCtx.$renderCtx$));
-  return set(signal);
+  return signal as ReadonlySignal<Awaited<T>>;
+};
+/** @public */
+export const useComputedQrl = <T>(qrl: QRL<ComputedFn<T>>): Signal<Awaited<T>> => {
+  return useConst(() => createComputedQrl(qrl));
 };
 
-/** @public */
-export const useComputed$: Computed = implicit$FirstArg(useComputedQrl);
+/**
+ * Hook that returns a read-only signal that updates when signals used in the `ComputedFn` change.
+ *
+ * @public
+ */
+export const useComputed$ = implicit$FirstArg(useComputedQrl);
+/**
+ * Returns read-only signal that updates when signals used in the `ComputedFn` change. Unlike
+ * useComputed$, this is not a hook and it always creates a new signal.
+ *
+ * @public
+ */
+export const createComputed$ = implicit$FirstArg(createComputedQrl);
 
 // <docs markdown="../readme.md#useTask">
 // !!DO NOT EDIT THIS COMMENT DIRECTLY!!!

--- a/packages/qwik/src/core/util/implicit_dollar.ts
+++ b/packages/qwik/src/core/util/implicit_dollar.ts
@@ -41,8 +41,8 @@ import { $, type QRL } from '../qrl/qrl.public';
  */
 // </docs>
 export const implicit$FirstArg = <FIRST, REST extends any[], RET>(
-  fn: (first: QRL<FIRST>, ...rest: REST) => RET
-): ((first: FIRST, ...rest: REST) => RET) => {
+  fn: (qrl: QRL<FIRST>, ...rest: REST) => RET
+): ((qrl: FIRST, ...rest: REST) => RET) => {
   return function (first: FIRST, ...rest: REST): RET {
     return fn.call(null, $(first), ...rest);
   };

--- a/starters/apps/e2e/src/components/signals/signals.tsx
+++ b/starters/apps/e2e/src/components/signals/signals.tsx
@@ -2,6 +2,8 @@ import {
   component$,
   type Signal,
   useSignal,
+  createSignal,
+  useConst,
   useStore,
   useVisibleTask$,
   useTask$,
@@ -11,6 +13,7 @@ import {
   type QwikIntrinsicElements,
   Resource,
   useComputed$,
+  createComputed$,
 } from "@builder.io/qwik";
 import { delay } from "../resource/resource";
 import {
@@ -134,6 +137,7 @@ export const SignalsChildren = component$(() => {
       <Issue4228 />
       <Issue4368 />
       <Issue4868 />
+      <ManySignals />
     </div>
   );
 });
@@ -1236,5 +1240,40 @@ export const Issue4868Card = component$((props: { src: string }) => {
       <p id="issue-4868-props">Card props.src: {src}</p>
       <p id="issue-4868-usecomputed">Card useComputed$: {src$.value}</p>
     </div>
+  );
+});
+
+export const ManySignals = component$(() => {
+  const signals = useConst(() => {
+    const arr: (Signal<number> | string)[] = [];
+    for (let i = 0; i < 10; i++) {
+      arr.push(createSignal(0));
+      arr.push(", ");
+    }
+    return arr;
+  });
+  const doubles = useConst(() =>
+    signals.map((s) =>
+      typeof s === "string" ? s : createComputed$(() => s.value * 2),
+    ),
+  );
+
+  return (
+    <>
+      <button
+        id="many-signals-button"
+        onClick$={() => {
+          for (const s of signals) {
+            if (typeof s !== "string") {
+              s.value++;
+            }
+          }
+        }}
+      >
+        Increment
+      </button>
+      <div id="many-signals-result">{signals}</div>
+      <div id="many-doubles-result">{doubles}</div>
+    </>
   );
 });

--- a/starters/apps/e2e/src/components/signals/signals.tsx
+++ b/starters/apps/e2e/src/components/signals/signals.tsx
@@ -3,7 +3,7 @@ import {
   type Signal,
   useSignal,
   createSignal,
-  useConst,
+  useConstant,
   useStore,
   useVisibleTask$,
   useTask$,
@@ -1244,7 +1244,7 @@ export const Issue4868Card = component$((props: { src: string }) => {
 });
 
 export const ManySignals = component$(() => {
-  const signals = useConst(() => {
+  const signals = useConstant(() => {
     const arr: (Signal<number> | string)[] = [];
     for (let i = 0; i < 10; i++) {
       arr.push(createSignal(0));
@@ -1252,8 +1252,8 @@ export const ManySignals = component$(() => {
     }
     return arr;
   });
-  const doubles = useConst(() =>
-    signals.map((s) =>
+  const doubles = useConstant(() =>
+    signals.map((s: Signal<number> | string) =>
       typeof s === "string" ? s : createComputed$(() => s.value * 2),
     ),
   );

--- a/starters/e2e/e2e.signals.spec.ts
+++ b/starters/e2e/e2e.signals.spec.ts
@@ -555,6 +555,17 @@ test.describe("signals", () => {
         `Card useComputed$: https://placehold.co/400x400?text=1&useComputed$`,
       );
     });
+
+    test("createSignal/createComputed$", async ({ page }) => {
+      const button = page.locator("#many-signals-button");
+      const result = page.locator("#many-signals-result");
+      const doubles = page.locator("#many-doubles-result");
+      await expect(result).toHaveText("0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ");
+      await expect(doubles).toHaveText("0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ");
+      await button.click();
+      await expect(result).toHaveText("1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ");
+      await expect(doubles).toHaveText("2, 2, 2, 2, 2, 2, 2, 2, 2, 2, ");
+    });
   }
 
   tests();


### PR DESCRIPTION
This adds the following APIs:

- `useConstant(value)`: stores a fixed value for the lifetime of the component
- `createSignal(value)`: same as useSignal but can be called a variable amount of times and always returns a new Signal
- `createComputed$(cb)`: same as createSignal but for computed signals

Note that the create* API calls still need to run within the component context. This is only available inside the render function and the useConst callback.

Perhaps we should also make the context available inside tasks, as long as we forbid calling hooks (by forbidding useSequentialContext).

Example:

```tsx
  const signals = useConstant(() => {
    const arr: (Signal<number> | string)[] = [];
    for (let i = 0; i < 10; i++) {
      arr.push(createSignal(0));
      arr.push(", ");
    }
    return arr;
  });
  const doubles = useConstant(() =>
    signals.map((s: Signal<number> | string) =>
      typeof s === "string" ? s : createComputed$(() => s.value * 2),
    ),
  );
```

# TODO

- [ ] make `createSignal` work at any time. Does it really need the container context?
- [ ] make `createComputed$` not need a Task so it's not bound to an element, or else don't add this yet. Ideally, the qrl is called and cached in the getter, and when one of the used signals changes the cache is cleared and subs triggered.
