### PR TITLE
fix(qwik-city): Removed artificial recursive limiter from recursive path matching

### DIFF
--- a/packages/qwik-city/runtime/src/route-matcher.ts
+++ b/packages/qwik-city/runtime/src/route-matcher.ts
@@ -144,8 +144,7 @@ function recursiveScan(
   }
   let pathIdx = pathLength;
   const sep = suffix + '/';
-  let depthWatchdog = 5;
-  while (pathIdx >= pathStart && depthWatchdog--) {
+  while (pathIdx >= pathStart) {
     const match = matchRoutePart(route, routeStart, routeLength, path, pathIdx, pathLength);
     if (match) {
       let value = path.substring(pathStart, Math.min(pathIdx, pathLength));
@@ -155,7 +154,11 @@ function recursiveScan(
       match[paramName] = decodeURIComponent(value);
       return match;
     }
-    pathIdx = lastIndexOf(path, pathStart, sep, pathIdx, pathStart - 1) + sep.length;
+    const newPathIdx = lastIndexOf(path, pathStart, sep, pathIdx, pathStart - 1) + sep.length;
+    if (pathIdx === newPathIdx) {
+      break;
+    }
+    pathIdx = newPathIdx;
   }
   return null;
 }

--- a/packages/qwik-city/runtime/src/route-matcher.unit.ts
+++ b/packages/qwik-city/runtime/src/route-matcher.unit.ts
@@ -66,6 +66,12 @@ describe('route-matcher', () => {
     assert.deepEqual(matchRoute('/seg/[...rest]', '/seg/a/b/c'), { rest: 'a/b/c' });
   });
 
+  test('should match /seg/[...rest]/a/b/c/d/e', () => {
+    assert.deepEqual(matchRoute('/seg/[...rest]/a/b/c/d/e', '/seg/a/b/c/d/e'), {
+      rest: '',
+    });
+  });
+
   test('should match /seg/[...rest] with trailing slash', () => {
     assert.deepEqual(matchRoute('/seg/[...rest]/', '/seg/a/b/c'), { rest: 'a/b/c' });
   });


### PR DESCRIPTION
# What is it?

- [*] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
For recursive matching of catchall routes, there was an artificial recursion watchdog limiter (set to 5). So, a route like
/[...catchall]/a/b/c/d/e wouldn't work if catchall didn't have a value (for example: /a/b/c/d/e would fail).
To fix this, we just check if there are any chances for the route to still match instead of stopping at the X amount of time.

# Checklist:

- [*] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [*] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [*] Added new tests to cover the fix / functionality
