### PR TITLE
feat(starters): error if qwik packages aren't together 

### DIFF
--- a/starters/apps/base/vite.config.ts
+++ b/starters/apps/base/vite.config.ts
@@ -85,6 +85,7 @@ function errorOnDuplicatesPkgDeps(
   );
 
   // any errors for missing "qwik-city-plan"
+  // [PLUGIN_ERROR]: Invalid module "@qwik-city-plan" is not a valid package
   msg = `Move qwik packages ${qwikPkg.join(", ")} to devDependencies`;
 
   if (qwikPkg.length > 0) {

--- a/starters/apps/base/vite.config.ts
+++ b/starters/apps/base/vite.config.ts
@@ -78,6 +78,14 @@ function errorOnDuplicatesPkgDeps(
     (dep) => dependencies[dep],
   );
 
+  const qwikPkg = Object.keys(dependencies).filter((value) => /qwik/i.test(value));
+
+  const message = `Move qwik packages ${qwikPkg.join(", ")} to devDependencies`
+
+  if (qwikPkg.length > 0) {
+    throw new Error(message);
+  }
+
   // Format the error message with the duplicates list.
   // The `join` function is used to represent the elements of the 'duplicateDeps' array as a comma-separated string.
   const msg = `

--- a/starters/apps/base/vite.config.ts
+++ b/starters/apps/base/vite.config.ts
@@ -72,23 +72,26 @@ function errorOnDuplicatesPkgDeps(
   devDependencies: PkgDep,
   dependencies: PkgDep,
 ) {
+  let msg = '';
   // Create an array 'duplicateDeps' by filtering devDependencies.
   // If a dependency also exists in dependencies, it is considered a duplicate.
   const duplicateDeps = Object.keys(devDependencies).filter(
     (dep) => dependencies[dep],
   );
 
-  const qwikPkg = Object.keys(dependencies).filter((value) => /qwik/i.test(value));
+  // include any known qwik packages
+  const qwikPkg = Object.keys(dependencies).filter((value) => /qwik|modular-forms/i.test(value));
 
-  const message = `Move qwik packages ${qwikPkg.join(", ")} to devDependencies`
+  // any errors for missing "qwik-city-plan" 
+  msg = `Move qwik packages ${qwikPkg.join(", ")} to devDependencies`;
 
   if (qwikPkg.length > 0) {
-    throw new Error(message);
+    throw new Error(msg);
   }
 
   // Format the error message with the duplicates list.
   // The `join` function is used to represent the elements of the 'duplicateDeps' array as a comma-separated string.
-  const msg = `
+  msg = `
     Warning: The dependency "${duplicateDeps.join(", ")}" is listed in both "devDependencies" and "dependencies".
     Please move the duplicated dependencies to "devDependencies" only and remove it from "dependencies"
   `;

--- a/starters/apps/base/vite.config.ts
+++ b/starters/apps/base/vite.config.ts
@@ -72,7 +72,7 @@ function errorOnDuplicatesPkgDeps(
   devDependencies: PkgDep,
   dependencies: PkgDep,
 ) {
-  let msg = '';
+  let msg = "";
   // Create an array 'duplicateDeps' by filtering devDependencies.
   // If a dependency also exists in dependencies, it is considered a duplicate.
   const duplicateDeps = Object.keys(devDependencies).filter(
@@ -80,9 +80,11 @@ function errorOnDuplicatesPkgDeps(
   );
 
   // include any known qwik packages
-  const qwikPkg = Object.keys(dependencies).filter((value) => /qwik/i.test(value));
+  const qwikPkg = Object.keys(dependencies).filter((value) =>
+    /qwik/i.test(value),
+  );
 
-  // any errors for missing "qwik-city-plan" 
+  // any errors for missing "qwik-city-plan"
   msg = `Move qwik packages ${qwikPkg.join(", ")} to devDependencies`;
 
   if (qwikPkg.length > 0) {

--- a/starters/apps/base/vite.config.ts
+++ b/starters/apps/base/vite.config.ts
@@ -80,7 +80,7 @@ function errorOnDuplicatesPkgDeps(
   );
 
   // include any known qwik packages
-  const qwikPkg = Object.keys(dependencies).filter((value) => /qwik|modular-forms/i.test(value));
+  const qwikPkg = Object.keys(dependencies).filter((value) => /qwik/i.test(value));
 
   // any errors for missing "qwik-city-plan" 
   msg = `Move qwik packages ${qwikPkg.join(", ")} to devDependencies`;


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Update vite.config file to throw an Error if qwik packages are in dependencies

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
