### PR TITLE
feat(qwik-city): append cookie headers to response

### DIFF
--- a/packages/docs/src/routes/api/qwik-city-middleware-request-handler/api.json
+++ b/packages/docs/src/routes/api/qwik-city-middleware-request-handler/api.json
@@ -17,6 +17,23 @@
       "mdFile": "qwik-city.abortmessage.md"
     },
     {
+      "name": "append",
+      "id": "cookie-append",
+      "hierarchy": [
+        {
+          "name": "Cookie",
+          "id": "cookie-append"
+        },
+        {
+          "name": "append",
+          "id": "cookie-append"
+        }
+      ],
+      "kind": "MethodSignature",
+      "content": "Appends a `Response` cookie header using the `Set-Cookie` header.\n\nThe difference between `set()` and `append()` is that if the specified header already exists, `set()` will overwrite the existing value with the new one, whereas `append()` will append the new value onto the end of the set of values.\n\n\n```typescript\nappend(name: string, value: string | number | Record<string, any>, options?: CookieOptions): void;\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nname\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\nvalue\n\n\n</td><td>\n\nstring \\| number \\| Record&lt;string, any&gt;\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\noptions\n\n\n</td><td>\n\n[CookieOptions](#cookieoptions)\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\nvoid",
+      "mdFile": "qwik-city.cookie.append.md"
+    },
+    {
       "name": "CacheControl",
       "id": "cachecontrol",
       "hierarchy": [
@@ -54,7 +71,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface Cookie \n```\n\n\n<table><thead><tr><th>\n\nMethod\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n[delete(name, options)](#cookie-delete)\n\n\n</td><td>\n\nDeletes cookie value by name using the `Response` cookie header.\n\n\n</td></tr>\n<tr><td>\n\n[get(name)](#cookie-get)\n\n\n</td><td>\n\nGets a `Request` cookie header value by name.\n\n\n</td></tr>\n<tr><td>\n\n[getAll()](#cookie-getall)\n\n\n</td><td>\n\nGets all `Request` cookie headers.\n\n\n</td></tr>\n<tr><td>\n\n[has(name)](#cookie-has)\n\n\n</td><td>\n\nChecks if the `Request` cookie header name exists.\n\n\n</td></tr>\n<tr><td>\n\n[headers()](#cookie-headers)\n\n\n</td><td>\n\nReturns an array of all the set `Response` `Set-Cookie` header values.\n\n\n</td></tr>\n<tr><td>\n\n[set(name, value, options)](#cookie-set)\n\n\n</td><td>\n\nSets a `Response` cookie header using the `Set-Cookie` header.\n\n\n</td></tr>\n</tbody></table>",
+      "content": "```typescript\nexport interface Cookie \n```\n\n\n<table><thead><tr><th>\n\nMethod\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n[append(name, value, options)](#cookie-append)\n\n\n</td><td>\n\nAppends a `Response` cookie header using the `Set-Cookie` header.\n\nThe difference between `set()` and `append()` is that if the specified header already exists, `set()` will overwrite the existing value with the new one, whereas `append()` will append the new value onto the end of the set of values.\n\n\n</td></tr>\n<tr><td>\n\n[delete(name, options)](#cookie-delete)\n\n\n</td><td>\n\nDeletes cookie value by name using the `Response` cookie header.\n\n\n</td></tr>\n<tr><td>\n\n[get(name)](#cookie-get)\n\n\n</td><td>\n\nGets a `Request` cookie header value by name.\n\n\n</td></tr>\n<tr><td>\n\n[getAll()](#cookie-getall)\n\n\n</td><td>\n\nGets all `Request` cookie headers.\n\n\n</td></tr>\n<tr><td>\n\n[has(name)](#cookie-has)\n\n\n</td><td>\n\nChecks if the `Request` cookie header name exists.\n\n\n</td></tr>\n<tr><td>\n\n[headers()](#cookie-headers)\n\n\n</td><td>\n\nReturns an array of all the set `Response` `Set-Cookie` header values.\n\n\n</td></tr>\n<tr><td>\n\n[set(name, value, options)](#cookie-set)\n\n\n</td><td>\n\nSets a `Response` cookie header using the `Set-Cookie` header.\n\n\n</td></tr>\n</tbody></table>",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-city/middleware/request-handler/types.ts",
       "mdFile": "qwik-city.cookie.md"
     },

--- a/packages/docs/src/routes/api/qwik-city-middleware-request-handler/index.md
+++ b/packages/docs/src/routes/api/qwik-city-middleware-request-handler/index.md
@@ -12,6 +12,69 @@ export declare class AbortMessage
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-city/middleware/request-handler/redirect-handler.ts)
 
+## append
+
+Appends a `Response` cookie header using the `Set-Cookie` header.
+
+The difference between `set()` and `append()` is that if the specified header already exists, `set()` will overwrite the existing value with the new one, whereas `append()` will append the new value onto the end of the set of values.
+
+```typescript
+append(name: string, value: string | number | Record<string, any>, options?: CookieOptions): void;
+```
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+name
+
+</td><td>
+
+string
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+value
+
+</td><td>
+
+string \| number \| Record&lt;string, any&gt;
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+options
+
+</td><td>
+
+[CookieOptions](#cookieoptions)
+
+</td><td>
+
+_(Optional)_
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+void
+
 ## CacheControl
 
 ```typescript
@@ -102,6 +165,17 @@ Description
 
 </th></tr></thead>
 <tbody><tr><td>
+
+[append(name, value, options)](#cookie-append)
+
+</td><td>
+
+Appends a `Response` cookie header using the `Set-Cookie` header.
+
+The difference between `set()` and `append()` is that if the specified header already exists, `set()` will overwrite the existing value with the new one, whereas `append()` will append the new value onto the end of the set of values.
+
+</td></tr>
+<tr><td>
 
 [delete(name, options)](#cookie-delete)
 

--- a/packages/qwik-city/middleware/request-handler/api.md
+++ b/packages/qwik-city/middleware/request-handler/api.md
@@ -39,6 +39,7 @@ export interface ClientConn {
 
 // @public (undocumented)
 export interface Cookie {
+    append(name: string, value: string | number | Record<string, any>, options?: CookieOptions): void;
     delete(name: string, options?: Pick<CookieOptions, 'path' | 'domain' | 'sameSite'>): void;
     get(name: string): CookieValue | null;
     getAll(): Record<string, CookieValue>;

--- a/packages/qwik-city/middleware/request-handler/cookie.ts
+++ b/packages/qwik-city/middleware/request-handler/cookie.ts
@@ -99,6 +99,7 @@ export class Cookie implements CookieInterface {
   private [REQ_COOKIE]: Record<string, string>;
   private [RES_COOKIE]: Record<string, string> = {};
   private [LIVE_COOKIE]: Record<string, string | null> = {};
+  private appendCounter = 0;
 
   constructor(cookieString?: string | undefined | null) {
     this[REQ_COOKIE] = parseCookieString(cookieString);
@@ -148,6 +149,25 @@ export class Cookie implements CookieInterface {
         ? cookieValue
         : encodeURIComponent(JSON.stringify(cookieValue));
     this[RES_COOKIE][cookieName] = createSetCookieValue(cookieName, resolvedValue, options);
+  }
+
+  append(
+    cookieName: string,
+    cookieValue: string | number | Record<string, any>,
+    options: CookieOptions = {}
+  ) {
+    this[LIVE_COOKIE][cookieName] =
+      typeof cookieValue === 'string' ? cookieValue : JSON.stringify(cookieValue);
+
+    const resolvedValue =
+      typeof cookieValue === 'string'
+        ? cookieValue
+        : encodeURIComponent(JSON.stringify(cookieValue));
+    this[RES_COOKIE][++this.appendCounter] = createSetCookieValue(
+      cookieName,
+      resolvedValue,
+      options
+    );
   }
 
   delete(name: string, options?: Pick<CookieOptions, 'path' | 'domain' | 'sameSite'>) {

--- a/packages/qwik-city/middleware/request-handler/cookie.unit.ts
+++ b/packages/qwik-city/middleware/request-handler/cookie.unit.ts
@@ -99,3 +99,84 @@ test('creates correct headers', () => {
     assert.equal(actual, expected);
   }
 });
+
+test('append cookies all keys are present', () => {
+  const data: TestData[] = [
+    { key: 'a', value: '1', options: {}, expect: 'a=1' },
+    { key: 'a', value: '2', options: { sameSite: 'strict' }, expect: 'a=2; SameSite=Strict' },
+    { key: 'a', value: '2', options: { sameSite: 'lax' }, expect: 'a=2; SameSite=Lax' },
+    { key: 'a', value: '2', options: { sameSite: 'none' }, expect: 'a=2; SameSite=None' },
+    { key: 'a', value: '2', options: { httpOnly: true }, expect: 'a=2; HttpOnly' },
+    { key: 'a', value: '6', options: { secure: true }, expect: 'a=6; Secure' },
+    {
+      key: 'a',
+      value: '7',
+      options: { path: '/qwikcity/overview/' },
+      expect: 'a=7; Path=/qwikcity/overview/',
+    },
+    {
+      key: 'a',
+      value: '8',
+      options: { maxAge: [60, 'minutes'] },
+      expect: `a=8; Max-Age=${60 * 60}`,
+    },
+    { key: 'a', value: '9', options: { maxAge: 60 * 60 }, expect: `a=9; Max-Age=${60 * 60}` },
+    {
+      key: 'a',
+      value: '10',
+      options: { domain: 'https://qwik.dev' },
+      expect: 'a=10; Domain=https://qwik.dev',
+    },
+    {
+      key: 'b',
+      value: '1',
+      options: { expires: 'Wed, 21 Oct 2015 07:28:00 GMT' },
+      expect: 'b=1; Expires=Wed, 21 Oct 2015 07:28:00 GMT',
+    },
+    {
+      key: 'b',
+      value: '1',
+      options: { domain: 'https://qwik.dev' },
+      expect: 'b=1; Domain=https://qwik.dev',
+    },
+    {
+      key: 'b',
+      value: '1',
+      options: { expires: new Date(0) },
+      expect: 'b=1; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
+    },
+    { key: 'c', value: '14', options: { sameSite: 'Strict' }, expect: 'c=14; SameSite=Strict' },
+    { key: 'c', value: '15', options: { sameSite: 'Lax' }, expect: 'c=15; SameSite=Lax' },
+    { key: 'd', value: '16', options: { sameSite: 'None' }, expect: 'd=16; SameSite=None' },
+  ];
+  const cookie = new Cookie('');
+  const expect = data.map(({ expect }) => expect);
+
+  data.forEach(({ key, value, options }) => {
+    cookie.append(key, value, options);
+  });
+
+  const result = cookie.headers();
+  assert.equal(expect.length, result.length);
+  for (let i = 0; i < expect.length; i++) {
+    const expected = expect[i];
+    const actual = result[i];
+    assert.equal(actual, expected);
+  }
+});
+
+test('set cookies only latest key is present', () => {
+  const data: TestData[] = [
+    { key: 'a', value: '1', options: {}, expect: 'a=1' },
+    { key: 'a', value: '2', options: { sameSite: 'strict' }, expect: 'a=2; SameSite=Strict' },
+  ];
+  const cookie = new Cookie('');
+
+  data.forEach(({ key, value, options }) => {
+    cookie.set(key, value, options);
+  });
+
+  const result = cookie.headers();
+  assert.equal(1, result.length);
+  assert.equal(result[0], data[1].expect);
+});

--- a/packages/qwik-city/middleware/request-handler/types.ts
+++ b/packages/qwik-city/middleware/request-handler/types.ts
@@ -493,6 +493,14 @@ export interface Cookie {
   has(name: string): boolean;
   /** Sets a `Response` cookie header using the `Set-Cookie` header. */
   set(name: string, value: string | number | Record<string, any>, options?: CookieOptions): void;
+  /**
+   * Appends a `Response` cookie header using the `Set-Cookie` header.
+   *
+   * The difference between `set()` and `append()` is that if the specified header already exists,
+   * `set()` will overwrite the existing value with the new one, whereas `append()` will append the
+   * new value onto the end of the set of values.
+   */
+  append(name: string, value: string | number | Record<string, any>, options?: CookieOptions): void;
   /** Deletes cookie value by name using the `Response` cookie header. */
   delete(name: string, options?: Pick<CookieOptions, 'path' | 'domain' | 'sameSite'>): void;
   /** Returns an array of all the set `Response` `Set-Cookie` header values. */


### PR DESCRIPTION
# Overview

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Qwik-city lacks ability to append cookie headers to response. See https://developer.mozilla.org/en-US/docs/Web/API/Headers/append


# Use cases and why

In some cases it's valuable to be able to append cookies with the same name but different options.
```
MY_COOKIE=my_value; Expires=Mon, 28 May 2024 09:00:00 GMT; Path=/; Domain=my.domain.com
MY_COOKIE=my_value; Expires=Mon, 29 May 2024 10:00:00 GMT; Path=/account/; Domain=another.my.domain.com
MY_COOKIE=my_value; Expires=Mon, 30 May 2024 11:00:00 GMT; Path=/api/; Domain=.my.domain.com
```

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
