### PR TITLE
docs(contributing): Add `devcontainer/cli` as alternative method for local development setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ Alternatively you can use [devcontainers/cli](https://github.com/devcontainers/c
 
 - Install devcontainers following their documentation.
 - In your terminal navigate to the Qwik's project root directory.
-- Then run `devcontainer up --workspace-folder .`. This command will start a Docker container will all required environment dependencies.
+- Then run `devcontainer up --workspace-folder .`. This command will start a Docker container with all required environment dependencies.
 
 If you want to use Nix:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,12 @@ If you want to use Docker:
 - Install the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension in your VSCode.
 - Once installed you will be prompted to 'Reopen the folder to develop in a container [learn more](https://code.visualstudio.com/docs/devcontainers/containers) or Clone repository in Docker volume for [better I/O performance](https://code.visualstudio.com/docs/devcontainers/containers#_quick-start-open-a-git-repository-or-github-pr-in-an-isolated-container-volume)'. If you're not prompted, you can run the `Dev Containers: Open Folder in Container` command from the [VSCode Command Palette](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette).
 
+Alternatively you can use [devcontainers/cli](https://github.com/devcontainers/cli):
+
+- Install devcontainers following their documentation.
+- In your terminal navigate to the Qwik's project root directory.
+- Then run `devcontainer up --workspace-folder .`. This command will start a Docker container will all required environment dependencies.
+
 If you want to use Nix:
 
 - Install [Nix](https://nixos.org/download.html) on your machine and enable flakes. The [DetSys installer](https://github.com/DeterminateSystems/nix-installer) makes that easy.


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

Recently found an alternative way to use devcontainers other than VSCode extension [devcontainer/cli](https://github.com/devcontainers/cli). It turned out to be useful for my case, because VSCodium does not have this extension. So, I decided to add this piece to the documentation :)

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

This PR updates contributing.md with instruction for local development using devcontainer/cli.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
