### PR TITLE
chore: disabled strict check on package manager

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,3 +4,4 @@ shell-emulator=true
 auto-install-peers=false
 ignore-workspace-root-check=true
 link-workspace-packages=false
+package-manager-strict=false


### PR DESCRIPTION
# Overview

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos
- [x] Infra

# Description
In `package.json` the `packageManager` option is set to a specific version which makes it harder to work with. 

By disabling the strict check but enabling the `engine-strict` check we still verify that pnpm has the right minimum version but not limit newer pnpm versions.



# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
