### PR TITLE
fix: utf-8 lowercase

### DIFF
--- a/packages/docs/public/repl/~repl-server-host.html
+++ b/packages/docs/public/repl/~repl-server-host.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="utf-8" />
     <title>Qwik REPL Server</title>
     <style>
       body {

--- a/packages/docs/src/root.tsx
+++ b/packages/docs/src/root.tsx
@@ -52,7 +52,7 @@ export default component$(() => {
     <QwikCityProvider>
       <head>
         <script dangerouslySetInnerHTML={uwu} />
-        <meta charset="UTF-8" />
+        <meta charset="utf-8" />
         <RouterHead />
         <ServiceWorkerRegister />
         {/* <script dangerouslySetInnerHTML={`(${collectSymbols})()`} /> */}

--- a/packages/insights/src/root.tsx
+++ b/packages/insights/src/root.tsx
@@ -1,26 +1,79 @@
-import './global.css';
-
-import { component$ } from '@builder.io/qwik';
+import { component$, useContextProvider, useStore } from '@builder.io/qwik';
 import { QwikCityProvider, RouterOutlet, ServiceWorkerRegister } from '@builder.io/qwik-city';
 import { Insights } from '@builder.io/qwik-labs';
-import { RouterHead } from './components/router-head/router-head';
 
+import RealMetricsOptimization from './components/real-metrics-optimization/real-metrics-optimization';
+import { RouterHead } from './components/router-head/router-head';
+import { GlobalStore, type SiteStore } from './context';
+import { BUILDER_PUBLIC_API_KEY } from './constants';
+
+import './global.css';
+
+export const uwu = /*javascript*/ `
+;(function () {
+  try {
+    var preferredUwu;
+    try {
+      preferredUwu = localStorage.getItem('uwu');
+    } catch (err) { }
+
+    const isUwuValue = window.location
+      && window.location.search
+      && window.location.search.match(/uwu=(true|false)/);
+
+    if (isUwuValue) {
+      const isUwu = isUwuValue[1] === 'true';
+      if (isUwu) {
+        try {
+          localStorage.setItem('uwu', true);
+        } catch (err) { }
+        document.documentElement.classList.add('uwu');
+        console.log('uwu mode enabled. turn off with ?uwu=false')
+        console.log('logo credit to @sawaratsuki1004 via https://github.com/SAWARATSUKI/ServiceLogos');
+      } else {
+        try {
+          localStorage.removeItem('uwu', false);
+        } catch (err) { }
+      }
+    } else if (preferredUwu) {
+      document.documentElement.classList.add('uwu');
+    }
+  } catch (err) { }
+})();
+`;
 export default component$(() => {
+  const store = useStore<SiteStore>({
+    headerMenuOpen: false,
+    sideMenuOpen: false,
+    theme: 'auto',
+  });
+
+  useContextProvider(GlobalStore, store);
+
   return (
     <QwikCityProvider>
       <head>
-        <meta charset="UTF-8" />
-        <link rel="manifest" href="/manifest.json" />
+        <script dangerouslySetInnerHTML={uwu} />
+        <meta charset="utf-8" />
         <RouterHead />
-        <Insights
-          publicApiKey={import.meta.env.PUBLIC_QWIK_INSIGHTS_KEY}
-          postUrl="/api/v1/${publicApiKey}/post/"
-        />
-      </head>
-      <body lang="en">
-        <RouterOutlet />
         <ServiceWorkerRegister />
+        {/* <script dangerouslySetInnerHTML={`(${collectSymbols})()`} /> */}
+        <Insights publicApiKey={import.meta.env.PUBLIC_QWIK_INSIGHTS_KEY} />
+      </head>
+      <body
+        class={{
+          'header-open': store.headerMenuOpen,
+          'menu-open': store.sideMenuOpen,
+        }}
+      >
+        <RouterOutlet />
+        <RealMetricsOptimization builderApiKey={BUILDER_PUBLIC_API_KEY} />
       </body>
     </QwikCityProvider>
   );
 });
+
+export function collectSymbols() {
+  (window as any).symbols = [];
+  document.addEventListener('qsymbol', (e) => (window as any).symbols.push((e as any).detail));
+}

--- a/packages/insights/src/root.tsx
+++ b/packages/insights/src/root.tsx
@@ -1,5 +1,5 @@
 import './global.css';
-import { component$, useContextProvider, useStore } from '@builder.io/qwik';
+import { component$ } from '@builder.io/qwik';
 import { QwikCityProvider, RouterOutlet, ServiceWorkerRegister } from '@builder.io/qwik-city';
 import { Insights } from '@builder.io/qwik-labs';
 import { RouterHead } from './components/router-head/router-head';

--- a/packages/insights/src/root.tsx
+++ b/packages/insights/src/root.tsx
@@ -3,57 +3,19 @@ import { component$ } from '@builder.io/qwik';
 import { QwikCityProvider, RouterOutlet, ServiceWorkerRegister } from '@builder.io/qwik-city';
 import { Insights } from '@builder.io/qwik-labs';
 import { RouterHead } from './components/router-head/router-head';
-
-export const uwu = /*javascript*/ `
-;(function () {
-  try {
-    var preferredUwu;
-    try {
-      preferredUwu = localStorage.getItem('uwu');
-    } catch (err) { }
-
-    const isUwuValue = window.location
-      && window.location.search
-      && window.location.search.match(/uwu=(true|false)/);
-
-    if (isUwuValue) {
-      const isUwu = isUwuValue[1] === 'true';
-      if (isUwu) {
-        try {
-          localStorage.setItem('uwu', true);
-        } catch (err) { }
-        document.documentElement.classList.add('uwu');
-        console.log('uwu mode enabled. turn off with ?uwu=false')
-        console.log('logo credit to @sawaratsuki1004 via https://github.com/SAWARATSUKI/ServiceLogos');
-      } else {
-        try {
-          localStorage.removeItem('uwu', false);
-        } catch (err) { }
-      }
-    } else if (preferredUwu) {
-      document.documentElement.classList.add('uwu');
-    }
-  } catch (err) { }
-})();
-`;
 export default component$(() => {
   return (
     <QwikCityProvider>
       <head>
         <meta charset="utf-8" />
-        <script dangerouslySetInnerHTML={uwu} />
+        <link rel="manifest" href="/manifest.json" />
         <RouterHead />
         <Insights
           publicApiKey={import.meta.env.PUBLIC_QWIK_INSIGHTS_KEY}
           postUrl="/api/v1/${publicApiKey}/post/"
         />
       </head>
-      <body
-        class={{
-          'header-open': store.headerMenuOpen,
-          'menu-open': store.sideMenuOpen,
-        }}
-      >
+      <body lang="en">
         <RouterOutlet />
         <ServiceWorkerRegister />
       </body>

--- a/packages/insights/src/root.tsx
+++ b/packages/insights/src/root.tsx
@@ -1,13 +1,8 @@
+import './global.css';
 import { component$, useContextProvider, useStore } from '@builder.io/qwik';
 import { QwikCityProvider, RouterOutlet, ServiceWorkerRegister } from '@builder.io/qwik-city';
 import { Insights } from '@builder.io/qwik-labs';
-
-import RealMetricsOptimization from './components/real-metrics-optimization/real-metrics-optimization';
 import { RouterHead } from './components/router-head/router-head';
-import { GlobalStore, type SiteStore } from './context';
-import { BUILDER_PUBLIC_API_KEY } from './constants';
-
-import './global.css';
 
 export const uwu = /*javascript*/ `
 ;(function () {
@@ -42,23 +37,16 @@ export const uwu = /*javascript*/ `
 })();
 `;
 export default component$(() => {
-  const store = useStore<SiteStore>({
-    headerMenuOpen: false,
-    sideMenuOpen: false,
-    theme: 'auto',
-  });
-
-  useContextProvider(GlobalStore, store);
-
   return (
     <QwikCityProvider>
       <head>
-        <script dangerouslySetInnerHTML={uwu} />
         <meta charset="utf-8" />
+        <script dangerouslySetInnerHTML={uwu} />
         <RouterHead />
-        <ServiceWorkerRegister />
-        {/* <script dangerouslySetInnerHTML={`(${collectSymbols})()`} /> */}
-        <Insights publicApiKey={import.meta.env.PUBLIC_QWIK_INSIGHTS_KEY} />
+        <Insights
+          publicApiKey={import.meta.env.PUBLIC_QWIK_INSIGHTS_KEY}
+          postUrl="/api/v1/${publicApiKey}/post/"
+        />
       </head>
       <body
         class={{
@@ -67,13 +55,8 @@ export default component$(() => {
         }}
       >
         <RouterOutlet />
-        <RealMetricsOptimization builderApiKey={BUILDER_PUBLIC_API_KEY} />
+        <ServiceWorkerRegister />
       </body>
     </QwikCityProvider>
   );
 });
-
-export function collectSymbols() {
-  (window as any).symbols = [];
-  document.addEventListener('qsymbol', (e) => (window as any).symbols.push((e as any).detail));
-}

--- a/packages/qwik-city/buildtime/vite/dev-server.ts
+++ b/packages/qwik-city/buildtime/vite/dev-server.ts
@@ -324,7 +324,7 @@ export function getUnmatchedRouteHtml(url: URL, ctx: BuildContext): string {
   return `
   <html>
     <head>
-      <meta charset="UTF-8">
+      <meta charset="utf-8">
       <meta http-equiv="Status" content="404">
       <title>404 Not Found</title>
       <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/packages/qwik-city/middleware/request-handler/error-handler.ts
+++ b/packages/qwik-city/middleware/request-handler/error-handler.ts
@@ -45,7 +45,7 @@ export function minimalHtmlResponse(status: number, message?: string) {
   const color = status >= 500 ? COLOR_500 : COLOR_400;
   return `
 <head>
-  <meta charset="UTF-8">
+  <meta charset="utf-8">
   <meta http-equiv="Status" content="${status}">
   <title>${status} ${message}</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">

--- a/packages/qwik-city/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/runtime/src/qwik-city-component.tsx
@@ -68,7 +68,7 @@ export interface QwikCityProps {
   //  * ```tsx
   //  * <QwikCityProvider>
   //  *   <head>
-  //  *     <meta charset="UTF-8" />
+  //  *     <meta charset="utf-8" />
   //  *   </head>
   //  *   <body lang="en"></body>
   //  * </QwikCityProvider>

--- a/packages/qwik-labs/src/root.tsx
+++ b/packages/qwik-labs/src/root.tsx
@@ -2,7 +2,7 @@ export default () => {
   return (
     <>
       <head>
-        <meta charset="UTF-8" />
+        <meta charset="utf-8" />
         <title>Qwik Blank App</title>
         <script type="module" src="/src/debug/index.ts" />
       </head>

--- a/packages/qwik-react/src/root.tsx
+++ b/packages/qwik-react/src/root.tsx
@@ -5,7 +5,7 @@ export const Root = component$(() => {
   return (
     <>
       <head>
-        <meta charset="UTF-8" />
+        <meta charset="utf-8" />
         <title>Qwik Blank App</title>
         <style>
           {`

--- a/packages/qwik/src/core/container/index.html
+++ b/packages/qwik/src/core/container/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en" q:container>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Document</title>

--- a/packages/qwik/src/core/render/jsx/types/jsx-generated.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-generated.ts
@@ -648,7 +648,7 @@ type SpecialAttrs = {
     children?: undefined;
   };
   meta: {
-    charset?: 'UTF-8' | undefined;
+    charset?: 'utf-8' | undefined;
     children?: undefined;
   };
   meter: {

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -1450,7 +1450,7 @@ test('html slot', async () => {
   await testSSR(
     <HtmlContext>
       <head>
-        <meta charset="UTF-8" />
+        <meta charset="utf-8" />
         <title>Qwik</title>
       </head>
       <body>
@@ -1462,7 +1462,7 @@ test('html slot', async () => {
       <!--qv q:id=0 q:key=sX:-->
       <!--qv q:s q:sref=0 q:key=-->
       <head q:head>
-        <meta charset="UTF-8" q:head />
+        <meta charset="utf-8" q:head />
         <title q:head>Qwik</title>
         <link rel="stylesheet" href="/global.css" />
         <style q:style="fio5tb-1" hidden>

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__issue_476.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__issue_476.snap
@@ -12,7 +12,7 @@ export const Root = () => {
     return (
         <html>
             <head>
-                <meta charset="UTF-8" />
+                <meta charset="utf-8" />
                 <title>Qwik Blank App</title>
             </head>
             <body>
@@ -30,7 +30,7 @@ export const Root = ()=>{
 
             <head>
 
-                <meta charset="UTF-8"/>
+                <meta charset="utf-8"/>
 
                 <title>Qwik Blank App</title>
 

--- a/packages/qwik/src/optimizer/core/src/test.rs
+++ b/packages/qwik/src/optimizer/core/src/test.rs
@@ -1979,7 +1979,7 @@ export const Root = () => {
     return (
         <html>
             <head>
-                <meta charset="UTF-8" />
+                <meta charset="utf-8" />
                 <title>Qwik Blank App</title>
             </head>
             <body>

--- a/starters/apps/basic/src/root.tsx
+++ b/starters/apps/basic/src/root.tsx
@@ -19,7 +19,7 @@ export default component$(() => {
   return (
     <QwikCityProvider>
       <head>
-        <meta charset="UTF-8" />
+        <meta charset="utf-8" />
         <link rel="manifest" href="/manifest.json" />
         <RouterHead />
         <ServiceWorkerRegister />

--- a/starters/apps/e2e/src/entry.ssr.tsx
+++ b/starters/apps/e2e/src/entry.ssr.tsx
@@ -108,7 +108,7 @@ export default function (opts: RenderToStreamOptions) {
   return renderToStream(
     <>
       <head>
-        <meta charset="UTF-8" />
+        <meta charset="utf-8" />
         <title>Qwik Blank App</title>
       </head>
       <body>

--- a/starters/apps/empty/src/root.tsx
+++ b/starters/apps/empty/src/root.tsx
@@ -19,7 +19,7 @@ export default component$(() => {
   return (
     <QwikCityProvider>
       <head>
-        <meta charset="UTF-8" />
+        <meta charset="utf-8" />
         <link rel="manifest" href="/manifest.json" />
         <RouterHead />
       </head>

--- a/starters/apps/library/src/root.tsx
+++ b/starters/apps/library/src/root.tsx
@@ -5,7 +5,7 @@ export default () => {
   return (
     <>
       <head>
-        <meta charset="UTF-8" />
+        <meta charset="utf-8" />
         <title>Qwik Blank App</title>
       </head>
       <body>

--- a/starters/apps/perf.prod/src/root.tsx
+++ b/starters/apps/perf.prod/src/root.tsx
@@ -6,7 +6,7 @@ export default () => {
   return (
     <html>
       <head>
-        <meta charset="UTF-8" />
+        <meta charset="utf-8" />
         <title>Qwik Blank App</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       </head>

--- a/starters/apps/qwikcity-test/src/root.tsx
+++ b/starters/apps/qwikcity-test/src/root.tsx
@@ -8,7 +8,7 @@ export default function Root() {
     <SomeProvider>
       <QwikCityProvider>
         <head>
-          <meta charset="UTF-8" />
+          <meta charset="utf-8" />
           <RouterHead />
         </head>
         <body>

--- a/starters/apps/site-with-visual-cms/src/root.tsx
+++ b/starters/apps/site-with-visual-cms/src/root.tsx
@@ -19,7 +19,7 @@ export default component$(() => {
   return (
     <QwikCityProvider>
       <head>
-        <meta charset="UTF-8" />
+        <meta charset="utf-8" />
         <link rel="manifest" href="/manifest.json" />
         <RouterHead />
         <ServiceWorkerRegister />

--- a/starters/apps/starter-partytown-test/src/root.tsx
+++ b/starters/apps/starter-partytown-test/src/root.tsx
@@ -7,7 +7,7 @@ export default () => {
   return (
     <>
       <head>
-        <meta charset="UTF-8" />
+        <meta charset="utf-8" />
         <title>Qwik + Partytown Blank App</title>
         <script dangerouslySetInnerHTML={partytownSnippet({ debug: true })} />
       </head>

--- a/starters/apps/todo-old-test/src/root.tsx
+++ b/starters/apps/todo-old-test/src/root.tsx
@@ -4,7 +4,7 @@ export const Root = () => {
   return (
     <>
       <head>
-        <meta charset="UTF-8" />
+        <meta charset="utf-8" />
         <title>Qwik Demo: Todo</title>
       </head>
       <body>

--- a/starters/apps/todo-test/src/root.tsx
+++ b/starters/apps/todo-test/src/root.tsx
@@ -4,7 +4,7 @@ export const Root = () => {
   return (
     <>
       <head>
-        <meta charset="UTF-8" />
+        <meta charset="utf-8" />
         <title>Qwik Demo: Todo</title>
       </head>
       <body>

--- a/starters/features/cypress/cypress/support/component-index.html
+++ b/starters/features/cypress/cypress/support/component-index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
     <title>Components App</title>


### PR DESCRIPTION
fix utf-8 lowercase


> The default character encoding used in HTML5 is UTF-8. This means if you include <!DOCTYPE html> at the top of your HTML file (which declares that it's an HTML5 file), it'll automatically use UTF-8 unless specified otherwise.

> Most browsers use UTF-8 by default if no character encoding is specified. But because that's not guaranteed, it's better to just include a character encoding specification using the <meta> tag in your HTML file.