### PR TITLE
fix(eslint-plugin-qwik): allow loaders in routes with JSX extension

### DIFF
--- a/packages/eslint-plugin-qwik/src/loaderLocation.ts
+++ b/packages/eslint-plugin-qwik/src/loaderLocation.ts
@@ -56,9 +56,9 @@ If you understand this, you can disable this warning with:
   create(context) {
     const routesDir = context.options?.[0]?.routesDir ?? 'src/routes';
     const path = normalizePath(context.getFilename());
-    const isLayout = /\/layout(|!|-.+)\.tsx?$/.test(path);
-    const isIndex = /\/index(|!|@.+)\.tsx?$/.test(path);
-    const isPlugin = /\/plugin(|@.+)\.tsx?$/.test(path);
+    const isLayout = /\/layout(|!|-.+)\.(j|t)sx?$/.test(path);
+    const isIndex = /\/index(|!|@.+)\.(j|t)sx?$/.test(path);
+    const isPlugin = /\/plugin(|@.+)\.(j|t)sx?$/.test(path);
     const isInsideRoutes = new RegExp(`/${routesDir}/`).test(path);
 
     const canContainLoader = isInsideRoutes && (isIndex || isLayout || isPlugin);


### PR DESCRIPTION
fix #6361

# Overview

See related issue: https://github.com/QwikDev/qwik/issues/6361

I suppose we could also update the related doc, but I'm not sure that's necessary.

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

ESLint is triggering an `invalidLoaderLocation` warning when loaders are located in a `.jsx` file instead of `.tsx`.

# Expected behavior

Loaders should be considered valid in `.jsx` files as well.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
