### PR TITLE
docs: added traiging process and github actions

### DIFF
--- a/.github/workflows/closing-issues.yml
+++ b/.github/workflows/closing-issues.yml
@@ -1,0 +1,26 @@
+name: Closing Issues For Inactivity
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  close-issues:
+    if: github.repository == 'QwikDev/qwik'
+    runs-on: ubuntu-latest
+    steps:
+      - name: needs reproduction
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'close-issues'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: 'STATUS-2: needs reproduction'
+          inactive-day: 14
+
+      - name: missing info
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'close-issues'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: 'STATUS-2: missing info'
+          inactive-day: 14

--- a/.github/workflows/labeling-issues.yml
+++ b/.github/workflows/labeling-issues.yml
@@ -1,0 +1,40 @@
+name: Labling Issues
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  handle-labeled:
+    if: github.repository == 'QwikDev/qwik'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: remove needs triage
+        if: contains(github.event.issue.labels.*.name, 'STATUS-1') && (contains(github.event.label.name, 'STATUS-2:') || contains(github.event.label.name, 'STATUS-3:'))
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'remove-labels'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          labels: 'STATUS-1: needs triage'
+
+      - name: needs reproduction time limit
+        if: contains(github.event.label.name, 'needs reproduction')
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'create-comment'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Hello @${{ github.event.issue.user.login }}. Please provide a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) using a GitHub repository or [StackBlitz](https://qwik.new). Issues marked with `STATUS-2: needs reproduction` will be automatically closed if they have no activity within 14 days.
+
+      - name: missing info time limit
+        if: contains(github.event.label.name, 'missing info')
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'create-comment'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Hello @${{ github.event.issue.user.login }}. Please provide the missing information requested above. Issues marked with `STATUS-2: missing info` will be automatically closed if they have no activity within 14 days.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,10 @@ Therefore, to solve the problem in the best possible way, please create a minima
 
 Without enough information to reproduce the issue, we will close it because we can't recreate and solve it.
 
+## Triaging Issues
+
+If you're interested in helping out with triaging issues, please follow the [Triaging Guide](./contributing/TRIAGE.md).
+
 ## Submitting a Pull Request (PR)
 
 ### Branch Organization

--- a/contributing/TRIAGE.md
+++ b/contributing/TRIAGE.md
@@ -1,0 +1,92 @@
+# Triage Titans Guide
+
+
+Hey there! Welcome to the wild world of the **Triage Titans**, where we tame bugs and nurture enhancements with the precision of true repository doctors. 
+
+Let's keep the code healthy, the project smooth, and have some fun along the way.
+
+## Note about tags prefixes:
+
+1. **STATUS-1**: The initial `needs triage` gets automatically added to newly created issues
+2. **STATUS-2**: A "waiting for someone/something" status.
+3. **STATUS-3**: The final state of an issue. This is a "resolution" status.
+
+---
+
+👇 *Inspiration for the diagrams below came from the Vite project*
+
+## Bug Triaging Process
+
+Our bug triaging process makes sure every reported issue gets the attention it deserves. We categorize, prioritize, and assign bugs to the right person to squash them quickly. 
+
+Here's how the Triage Titans handle bug reports in the Qwik repository:
+
+
+```mermaid
+flowchart TD
+    start{Missing information?}
+    start --YES--> close1[Tag with\n'STATUS-2: missing info'\n\nBot will auto close if\n no update for 14 days]
+    start --NO--> dupe{Is duplicate?}
+    dupe --YES--> close2[Close, point to duplicate\n and tag with\n'STATUS-3: duplication']
+    dupe --NO--> repro{Has proper\nreproduction?}
+    repro --NO--> close3[Tag with\n 'STATUS-2: needs reproduction'\nBot will auto close if \nno update for 14 days]
+    repro --YES--> real{Is actually a bug?}
+    real --NO--> intended{Is the intended\nbehaviour?}
+    intended --YES--> explain[Explain and close.\nPoint to docs if needed.\nTag with\n'STATUS-3: works as expected']
+    intended --NO--> open[Tag with\n'STATUS-2: requires discussion'\nand either\n'WAITING FOR: team'\n'WAITING FOR: user']
+    real --YES--> real2["1. Tag with 'STATUS-2: team is working on this'\n2. Add related feature label if\napplicable (e.g. 'COMP: runtime')\n3. Add priority labels (see below)"]
+    real2 --> unusable{Does the\nbug make Qwik\nunusable?}
+    unusable --YES--> maj{Does the bug\naffect the majority\nof Qwik users?}
+    maj --YES--> P4[P4: urgent]
+    maj --NO--> P3[P3: important]
+    unusable --NO--> workarounds{Are there\nworkarounds for\nthe bug?}
+    workarounds --NO--> P2[P2: minor bug]
+    workarounds --YES--> P1[P1: nice to have / fix]
+```
+
+---
+
+## Enhancement Triaging Process
+
+Alright, Triage Titans! Somebody got a cool new feature idea or an awesome improvement to boost Qwik? 
+
+It's our job to make sure these enhancements are properly evaluated, prioritized, and brought to life. 
+
+What helps the team to prioritize work is the number of 👍 votes by the community on the a specific issue.
+
+### A note about enhancements to the core:
+
+We are very careful of which features we introduce into the Qwik core, because we know that every new feature adds complexity and maintenance tasks to the codebase.
+
+Every feature is being carefully evaluated based on our vision and philosophy of "automatic optimization".
+
+That's why we'll often encourage the the community to implement a certain feature and evaluate its adoption over time to see if it should actually be part of the core.
+
+.
+
+Now, let's dive into how we handle enhancement requests in the Qwik repository:
+
+
+
+
+```mermaid
+flowchart TD
+    start{Missing information?}
+    start --YES--> close1[Tag with\n'STATUS-2: missing info'\n\nBot will auto close if\n no update for 14 days]
+    start --NO--> dupe{Is duplicate?}
+    dupe --YES--> close2[Close, point to duplicate\n and tag with\n'STATUS-3: duplication']
+    dupe --NO--> discussion{Requires further\ndiscussion?}
+    discussion --YES--> close3[Tag with\n 'STATUS-2: requires discussion'\nand 'WAITING FOR: team'\nor 'WAITING FOR: user']
+    discussion --NO--> implement{Should it be\nimplemented by core?}
+    implement --NO--> community{Should it be implemented\nby the community?}
+    community --YES--> incubate[Close and tag with\n'STATUS-3: incubation']
+    community --NO--> wontfix[Close and tag with\n'STATUS-3: won't be worked on']
+    implement --YES--> doimplement["1. Tag with 'STATUS-2: team is working on this'\n2. Add related feature label if\napplicable (e.g. 'COMP: runtime')\n3. Add version \nlabels (e.g. 'VERSION: upcoming major')"]
+```
+
+
+## Thank You!
+
+A big shoutout to all our amazing contributors and Triage Titans! Your dedication, creativity, and hard work help keep Qwik running smoothly and evolving with exciting new features. We couldn't do it without you. 
+
+Thanks for being a part of our journey and making Qwik awesome. Keep up the great work, and let's continue to build something amazing together!

--- a/contributing/TRIAGE.md
+++ b/contributing/TRIAGE.md
@@ -1,7 +1,6 @@
 # Triage Titans Guide
 
-
-Hey there! Welcome to the wild world of the **Triage Titans**, where we tame bugs and nurture enhancements with the precision of true repository doctors. 
+Hey there! Welcome to the wild world of the **Triage Titans**, where we tame bugs and nurture enhancements with the precision of true repository doctors.
 
 Let's keep the code healthy, the project smooth, and have some fun along the way.
 
@@ -13,14 +12,13 @@ Let's keep the code healthy, the project smooth, and have some fun along the way
 
 ---
 
-👇 *Inspiration for the diagrams below came from the Vite project*
+👇 _Inspiration for the diagrams below came from the Vite project_
 
 ## Bug Triaging Process
 
-Our bug triaging process makes sure every reported issue gets the attention it deserves. We categorize, prioritize, and assign bugs to the right person to squash them quickly. 
+Our bug triaging process makes sure every reported issue gets the attention it deserves. We categorize, prioritize, and assign bugs to the right person to squash them quickly.
 
 Here's how the Triage Titans handle bug reports in the Qwik repository:
-
 
 ```mermaid
 flowchart TD
@@ -48,9 +46,9 @@ flowchart TD
 
 ## Enhancement Triaging Process
 
-Alright, Triage Titans! Somebody got a cool new feature idea or an awesome improvement to boost Qwik? 
+Alright, Triage Titans! Somebody got a cool new feature idea or an awesome improvement to boost Qwik?
 
-It's our job to make sure these enhancements are properly evaluated, prioritized, and brought to life. 
+It's our job to make sure these enhancements are properly evaluated, prioritized, and brought to life.
 
 What helps the team to prioritize work is the number of 👍 votes by the community on the a specific issue.
 
@@ -65,9 +63,6 @@ That's why we'll often encourage the the community to implement a certain featur
 .
 
 Now, let's dive into how we handle enhancement requests in the Qwik repository:
-
-
-
 
 ```mermaid
 flowchart TD
@@ -84,9 +79,8 @@ flowchart TD
     implement --YES--> doimplement["1. Tag with 'STATUS-2: team is working on this'\n2. Add related feature label if\napplicable (e.g. 'COMP: runtime')\n3. Add version \nlabels (e.g. 'VERSION: upcoming major')"]
 ```
 
-
 ## Thank You!
 
-A big shoutout to all our amazing contributors and Triage Titans! Your dedication, creativity, and hard work help keep Qwik running smoothly and evolving with exciting new features. We couldn't do it without you. 
+A big shoutout to all our amazing contributors and Triage Titans! Your dedication, creativity, and hard work help keep Qwik running smoothly and evolving with exciting new features. We couldn't do it without you.
 
 Thanks for being a part of our journey and making Qwik awesome. Keep up the great work, and let's continue to build something amazing together!


### PR DESCRIPTION
# Overview


# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Added a "Triage Process" guide

Plus added 2 ci workflows - 

1. Auto closing stale issues that needs reproduction or missing info and haven't got any response for 14 days

2. Adding a comment on "missing info" and "needs reproduction" labeled issues to notify it will be automatically be closed after 14 days.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
