### PR TITLE
docs: update docs for `deep` property of `useStore` to match the new default

### DIFF
--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -3174,7 +3174,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface UseStoreOptions \n```\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n[deep?](#)\n\n\n</td><td>\n\n\n</td><td>\n\nboolean\n\n\n</td><td>\n\n_(Optional)_ If `true` then all nested objects and arrays will be tracked as well. Default is `false`<!-- -->.\n\n\n</td></tr>\n<tr><td>\n\n[reactive?](#)\n\n\n</td><td>\n\n\n</td><td>\n\nboolean\n\n\n</td><td>\n\n_(Optional)_ If `false` then the object will not be tracked for changes. Default is `true`<!-- -->.\n\n\n</td></tr>\n</tbody></table>",
+      "content": "```typescript\nexport interface UseStoreOptions \n```\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n[deep?](#)\n\n\n</td><td>\n\n\n</td><td>\n\nboolean\n\n\n</td><td>\n\n_(Optional)_ If `true` then all nested objects and arrays will be tracked as well. Default is `true`<!-- -->.\n\n\n</td></tr>\n<tr><td>\n\n[reactive?](#)\n\n\n</td><td>\n\n\n</td><td>\n\nboolean\n\n\n</td><td>\n\n_(Optional)_ If `false` then the object will not be tracked for changes. Default is `true`<!-- -->.\n\n\n</td></tr>\n</tbody></table>",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-store.public.ts",
       "mdFile": "qwik.usestoreoptions.md"
     },

--- a/packages/docs/src/routes/api/qwik/index.md
+++ b/packages/docs/src/routes/api/qwik/index.md
@@ -10726,7 +10726,7 @@ boolean
 
 </td><td>
 
-_(Optional)_ If `true` then all nested objects and arrays will be tracked as well. Default is `false`.
+_(Optional)_ If `true` then all nested objects and arrays will be tracked as well. Default is `true`.
 
 </td></tr>
 <tr><td>

--- a/packages/qwik/src/core/use/use-store.public.ts
+++ b/packages/qwik/src/core/use/use-store.public.ts
@@ -6,7 +6,7 @@ import { useSequentialScope } from './use-sequential-scope';
 
 /** @public */
 export interface UseStoreOptions {
-  /** If `true` then all nested objects and arrays will be tracked as well. Default is `false`. */
+  /** If `true` then all nested objects and arrays will be tracked as well. Default is `true`. */
   deep?: boolean;
 
   /** If `false` then the object will not be tracked for changes. Default is `true`. */


### PR DESCRIPTION
# Overview
Changes are made in JSDoc, API json and API docs.
<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

In #3678 the `useStore` is made recursive by default. The JSDoc and API description for the `deep` property of `UseStoreOptions` were not yet updated to match this.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

The conflicting docs can be confusing as it insinuates that deep reactivity still has to be enabled manually. Especially the outdated JSDoc makes for a confusing IntelliSense in code editors.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
