### PR TITLE
feat(qwikVite): add possibility to define multiple outputs

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/rollup.ts
+++ b/packages/qwik/src/optimizer/src/plugins/rollup.ts
@@ -175,6 +175,11 @@ export function normalizeRollupOutputOptions(
     : // use the existing rollupOutputOpts object or create a new one
       [rollupOutputOpts || {}];
 
+  // make sure at least one output is present in every case
+  if (!outputOpts.length) {
+    outputOpts.push({});
+  }
+
   return outputOpts.map((outputOptsObj) =>
     normalizeRollupOutputOptionsObject(path, opts, outputOptsObj)
   );

--- a/packages/qwik/src/optimizer/src/plugins/rollup.ts
+++ b/packages/qwik/src/optimizer/src/plugins/rollup.ts
@@ -190,56 +190,56 @@ export function normalizeRollupOutputOptionsObject(
   opts: NormalizedQwikPluginOptions,
   rollupOutputOptsObj: Rollup.OutputOptions | undefined
 ): Rollup.OutputOptions {
-  const outputOptsObj: Rollup.OutputOptions = { ...rollupOutputOptsObj };
+  const outputOpts: Rollup.OutputOptions = { ...rollupOutputOptsObj };
 
-  if (!outputOptsObj.assetFileNames) {
-    outputOptsObj.assetFileNames = 'build/q-[hash].[ext]';
+  if (!outputOpts.assetFileNames) {
+    outputOpts.assetFileNames = 'build/q-[hash].[ext]';
   }
   if (opts.target === 'client') {
     // client output
 
     if (opts.buildMode === 'production') {
       // client production output
-      if (!outputOptsObj.entryFileNames) {
-        outputOptsObj.entryFileNames = 'build/q-[hash].js';
+      if (!outputOpts.entryFileNames) {
+        outputOpts.entryFileNames = 'build/q-[hash].js';
       }
-      if (!outputOptsObj.chunkFileNames) {
-        outputOptsObj.chunkFileNames = 'build/q-[hash].js';
+      if (!outputOpts.chunkFileNames) {
+        outputOpts.chunkFileNames = 'build/q-[hash].js';
       }
     } else {
       // client development output
-      if (!outputOptsObj.entryFileNames) {
-        outputOptsObj.entryFileNames = 'build/[name].js';
+      if (!outputOpts.entryFileNames) {
+        outputOpts.entryFileNames = 'build/[name].js';
       }
-      if (!outputOptsObj.chunkFileNames) {
-        outputOptsObj.chunkFileNames = 'build/[name].js';
+      if (!outputOpts.chunkFileNames) {
+        outputOpts.chunkFileNames = 'build/[name].js';
       }
     }
   } else if (opts.buildMode === 'production') {
     // server production output
     // everything in same dir so './@qwik-city...' imports work from entry and chunks
-    if (!outputOptsObj.chunkFileNames) {
-      outputOptsObj.chunkFileNames = 'q-[hash].js';
+    if (!outputOpts.chunkFileNames) {
+      outputOpts.chunkFileNames = 'q-[hash].js';
     }
-    if (!outputOptsObj.assetFileNames) {
-      outputOptsObj.assetFileNames = 'assets/[hash].[ext]';
+    if (!outputOpts.assetFileNames) {
+      outputOpts.assetFileNames = 'assets/[hash].[ext]';
     }
   }
 
   if (opts.target === 'client') {
     // client should always be es
-    outputOptsObj.format = 'es';
+    outputOpts.format = 'es';
   }
 
-  if (!outputOptsObj.dir) {
-    outputOptsObj.dir = opts.outDir;
+  if (!outputOpts.dir) {
+    outputOpts.dir = opts.outDir;
   }
 
-  if (outputOptsObj.format === 'cjs' && typeof outputOptsObj.exports !== 'string') {
-    outputOptsObj.exports = 'auto';
+  if (outputOpts.format === 'cjs' && typeof outputOpts.exports !== 'string') {
+    outputOpts.exports = 'auto';
   }
 
-  return outputOptsObj;
+  return outputOpts;
 }
 
 export function createRollupError(id: string, diagnostic: Diagnostic) {

--- a/packages/qwik/src/optimizer/src/plugins/rollup.ts
+++ b/packages/qwik/src/optimizer/src/plugins/rollup.ts
@@ -169,13 +169,11 @@ export function normalizeRollupOutputOptions(
   opts: NormalizedQwikPluginOptions,
   rollupOutputOpts: Rollup.OutputOptions | Rollup.OutputOptions[] | undefined
 ): Rollup.OutputOptions[] {
-  const outputOpts: Rollup.OutputOptions[] = rollupOutputOpts
-    ? // fill the `outputOpts` array with the existing option entries
-      Array.isArray(rollupOutputOpts)
-      ? rollupOutputOpts
-      : [rollupOutputOpts]
-    : // if there are no existing option entries, create a single new option entry
-      [{}];
+  const outputOpts: Rollup.OutputOptions[] = Array.isArray(rollupOutputOpts)
+    ? // fill the `outputOpts` array with all existing option entries
+      [...rollupOutputOpts]
+    : // use the existing rollupOutputOpts object or create a new one
+      [rollupOutputOpts || {}];
 
   return outputOpts.map((outputOptsObj) =>
     normalizeRollupOutputOptionsObject(path, opts, outputOptsObj)

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -335,10 +335,14 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
         updatedViteConfig.build!.outDir = buildOutputDir;
         updatedViteConfig.build!.rollupOptions = {
           input: opts.input,
-          output: {
-            ...normalizeRollupOutputOptions(path, opts, viteConfig.build?.rollupOptions?.output),
-            dir: buildOutputDir,
-          },
+          output: normalizeRollupOutputOptions(
+            path,
+            opts,
+            viteConfig.build?.rollupOptions?.output
+          ).map((outputOptsObj) => {
+            outputOptsObj.dir = buildOutputDir;
+            return outputOptsObj;
+          }),
           preserveEntrySignatures: 'exports-only',
           onwarn: (warning, warn) => {
             if (warning.plugin === 'typescript' && warning.message.includes('outputToFilesystem')) {

--- a/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
@@ -63,7 +63,7 @@ test('command: serve, mode: development', async () => {
   assert.deepEqual(rollupOptions.input, normalizePath(resolve(cwd, 'src', 'entry.dev')));
 
   assert.ok(Array.isArray(outputOptions));
-  assert.isNotEmpty(outputOptions);
+  assert.lengthOf(outputOptions, 1);
 
   outputOptions.forEach((outputOptionsObj) => {
     assert.deepEqual(outputOptionsObj.assetFileNames, 'build/q-[hash].[ext]');
@@ -105,7 +105,7 @@ test('command: serve, mode: production', async () => {
   assert.deepEqual(rollupOptions.input, normalizePath(resolve(cwd, 'src', 'entry.dev')));
 
   assert.ok(Array.isArray(outputOptions));
-  assert.isNotEmpty(outputOptions);
+  assert.lengthOf(outputOptions, 1);
 
   outputOptions.forEach((outputOptionsObj) => {
     assert.deepEqual(outputOptionsObj.assetFileNames, 'build/q-[hash].[ext]');
@@ -147,7 +147,7 @@ test('command: build, mode: development', async () => {
   assert.deepEqual(rollupOptions.input, [normalizePath(resolve(cwd, 'src', 'root'))]);
 
   assert.ok(Array.isArray(outputOptions));
-  assert.isNotEmpty(outputOptions);
+  assert.lengthOf(outputOptions, 1);
 
   outputOptions.forEach((outputOptionsObj) => {
     assert.deepEqual(outputOptionsObj.assetFileNames, 'build/q-[hash].[ext]');
@@ -191,7 +191,7 @@ test('command: build, mode: production', async () => {
   assert.deepEqual(rollupOptions.input, [normalizePath(resolve(cwd, 'src', 'root'))]);
 
   assert.ok(Array.isArray(outputOptions));
-  assert.isNotEmpty(outputOptions);
+  assert.lengthOf(outputOptions, 1);
 
   outputOptions.forEach((outputOptionsObj) => {
     assert.deepEqual(outputOptionsObj.assetFileNames, 'build/q-[hash].[ext]');
@@ -262,7 +262,7 @@ test('command: build, --ssr entry.server.tsx', async () => {
   assert.deepEqual(rollupOptions.input, [normalizePath(resolve(cwd, 'src', 'entry.server.tsx'))]);
 
   assert.ok(Array.isArray(outputOptions));
-  assert.isNotEmpty(outputOptions);
+  assert.lengthOf(outputOptions, 1);
 
   outputOptions.forEach((outputOptionsObj) => {
     assert.deepEqual(outputOptionsObj.assetFileNames, 'build/q-[hash].[ext]');
@@ -392,7 +392,7 @@ test('command: build, --mode lib', async () => {
   assert.deepEqual(rollupOptions.input, [normalizePath(resolve(cwd, 'src', 'index.ts'))]);
 
   assert.ok(Array.isArray(outputOptions));
-  assert.isNotEmpty(outputOptions);
+  assert.lengthOf(outputOptions, 1);
 
   outputOptions.forEach((outputOptionsObj) => {
     assert.deepEqual(outputOptionsObj.assetFileNames, 'build/q-[hash].[ext]');
@@ -451,7 +451,7 @@ test('command: build, --mode lib with multiple outputs', async () => {
   assert.deepEqual(rollupOptions.input, [normalizePath(resolve(cwd, 'src', 'index.ts'))]);
 
   assert.ok(Array.isArray(outputOptions));
-  assert.isNotEmpty(outputOptions);
+  assert.lengthOf(outputOptions, 4);
 
   outputOptions.forEach((outputOptionsObj) => {
     assert.deepEqual(outputOptionsObj.assetFileNames, 'build/q-[hash].[ext]');

--- a/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
@@ -408,7 +408,7 @@ test('command: build, --mode lib with multiple outputs', async () => {
   const initOpts = {
     optimizerOptions: mockOptimizerOptions(),
   };
-  const plugin = qwikVite(initOpts);
+  const plugin = qwikVite(initOpts)[0];
   const c: any = (await plugin.config(
     {
       build: {

--- a/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
@@ -52,7 +52,7 @@ test('command: serve, mode: development', async () => {
   const opts = await plugin.api?.getOptions();
   const build = c.build!;
   const rollupOptions = build!.rollupOptions!;
-  const outputOptions = rollupOptions.output as Rollup.OutputOptions;
+  const outputOptions = rollupOptions.output as Rollup.OutputOptions[];
 
   assert.deepEqual(opts.target, 'client');
   assert.deepEqual(opts.buildMode, 'development');
@@ -61,10 +61,17 @@ test('command: serve, mode: development', async () => {
 
   assert.deepEqual(build.outDir, normalizePath(resolve(cwd, 'dist')));
   assert.deepEqual(rollupOptions.input, normalizePath(resolve(cwd, 'src', 'entry.dev')));
-  assert.deepEqual(outputOptions.assetFileNames, 'build/q-[hash].[ext]');
-  assert.deepEqual(outputOptions.chunkFileNames, 'build/[name].js');
-  assert.deepEqual(outputOptions.entryFileNames, 'build/[name].js');
-  assert.deepEqual(outputOptions.format, 'es');
+
+  assert.ok(Array.isArray(outputOptions));
+  assert.isNotEmpty(outputOptions);
+
+  outputOptions.forEach((outputOptionsObj) => {
+    assert.deepEqual(outputOptionsObj.assetFileNames, 'build/q-[hash].[ext]');
+    assert.deepEqual(outputOptionsObj.chunkFileNames, 'build/[name].js');
+    assert.deepEqual(outputOptionsObj.entryFileNames, 'build/[name].js');
+    assert.deepEqual(outputOptionsObj.format, 'es');
+  });
+
   assert.deepEqual(build.dynamicImportVarsOptions?.exclude, [/./]);
   assert.deepEqual(build.ssr, undefined);
   assert.deepEqual(c.optimizeDeps?.include, includeDeps);
@@ -85,7 +92,7 @@ test('command: serve, mode: production', async () => {
   const opts = await plugin.api?.getOptions();
   const build = c.build!;
   const rollupOptions = build!.rollupOptions!;
-  const outputOptions = rollupOptions.output as Rollup.OutputOptions;
+  const outputOptions = rollupOptions.output as Rollup.OutputOptions[];
 
   assert.deepEqual(opts.target, 'client');
   assert.deepEqual(opts.buildMode, 'production');
@@ -96,10 +103,17 @@ test('command: serve, mode: production', async () => {
   assert.deepEqual(build.outDir, normalizePath(resolve(cwd, 'dist')));
   assert.deepEqual(build.emptyOutDir, undefined);
   assert.deepEqual(rollupOptions.input, normalizePath(resolve(cwd, 'src', 'entry.dev')));
-  assert.deepEqual(outputOptions.assetFileNames, 'build/q-[hash].[ext]');
-  assert.deepEqual(outputOptions.chunkFileNames, 'build/q-[hash].js');
-  assert.deepEqual(outputOptions.entryFileNames, 'build/q-[hash].js');
-  assert.deepEqual(outputOptions.format, 'es');
+
+  assert.ok(Array.isArray(outputOptions));
+  assert.isNotEmpty(outputOptions);
+
+  outputOptions.forEach((outputOptionsObj) => {
+    assert.deepEqual(outputOptionsObj.assetFileNames, 'build/q-[hash].[ext]');
+    assert.deepEqual(outputOptionsObj.chunkFileNames, 'build/q-[hash].js');
+    assert.deepEqual(outputOptionsObj.entryFileNames, 'build/q-[hash].js');
+    assert.deepEqual(outputOptionsObj.format, 'es');
+  });
+
   assert.deepEqual(build.dynamicImportVarsOptions?.exclude, [/./]);
   assert.deepEqual(build.ssr, undefined);
   assert.deepEqual(c.optimizeDeps?.include, includeDeps);
@@ -119,7 +133,7 @@ test('command: build, mode: development', async () => {
   const opts = await plugin.api?.getOptions();
   const build = c.build!;
   const rollupOptions = build!.rollupOptions!;
-  const outputOptions = rollupOptions.output as Rollup.OutputOptions;
+  const outputOptions = rollupOptions.output as Rollup.OutputOptions[];
 
   assert.deepEqual(opts.target, 'client');
   assert.deepEqual(opts.buildMode, 'development');
@@ -131,9 +145,16 @@ test('command: build, mode: development', async () => {
   assert.deepEqual(build.outDir, normalizePath(resolve(cwd, 'dist')));
   assert.deepEqual(build.emptyOutDir, undefined);
   assert.deepEqual(rollupOptions.input, [normalizePath(resolve(cwd, 'src', 'root'))]);
-  assert.deepEqual(outputOptions.assetFileNames, 'build/q-[hash].[ext]');
-  assert.deepEqual(outputOptions.chunkFileNames, 'build/[name].js');
-  assert.deepEqual(outputOptions.entryFileNames, 'build/[name].js');
+
+  assert.ok(Array.isArray(outputOptions));
+  assert.isNotEmpty(outputOptions);
+
+  outputOptions.forEach((outputOptionsObj) => {
+    assert.deepEqual(outputOptionsObj.assetFileNames, 'build/q-[hash].[ext]');
+    assert.deepEqual(outputOptionsObj.chunkFileNames, 'build/[name].js');
+    assert.deepEqual(outputOptionsObj.entryFileNames, 'build/[name].js');
+  });
+
   assert.deepEqual(build.dynamicImportVarsOptions?.exclude, [/./]);
   assert.deepEqual(build.ssr, undefined);
   assert.deepEqual(c.optimizeDeps?.include, includeDeps);
@@ -156,7 +177,7 @@ test('command: build, mode: production', async () => {
   const opts = await plugin.api?.getOptions();
   const build = c.build!;
   const rollupOptions = build!.rollupOptions!;
-  const outputOptions = rollupOptions.output as Rollup.OutputOptions;
+  const outputOptions = rollupOptions.output as Rollup.OutputOptions[];
 
   assert.deepEqual(opts.target, 'client');
   assert.deepEqual(opts.buildMode, 'production');
@@ -168,9 +189,16 @@ test('command: build, mode: production', async () => {
   assert.deepEqual(build.outDir, normalizePath(resolve(cwd, 'dist')));
   assert.deepEqual(build.emptyOutDir, undefined);
   assert.deepEqual(rollupOptions.input, [normalizePath(resolve(cwd, 'src', 'root'))]);
-  assert.deepEqual(outputOptions.assetFileNames, 'build/q-[hash].[ext]');
-  assert.deepEqual(outputOptions.chunkFileNames, 'build/q-[hash].js');
-  assert.deepEqual(outputOptions.entryFileNames, 'build/q-[hash].js');
+
+  assert.ok(Array.isArray(outputOptions));
+  assert.isNotEmpty(outputOptions);
+
+  outputOptions.forEach((outputOptionsObj) => {
+    assert.deepEqual(outputOptionsObj.assetFileNames, 'build/q-[hash].[ext]');
+    assert.deepEqual(outputOptionsObj.chunkFileNames, 'build/q-[hash].js');
+    assert.deepEqual(outputOptionsObj.entryFileNames, 'build/q-[hash].js');
+  });
+
   assert.deepEqual(build.outDir, normalizePath(resolve(cwd, 'dist')));
   assert.deepEqual(build.dynamicImportVarsOptions?.exclude, [/./]);
   assert.deepEqual(build.ssr, undefined);
@@ -220,7 +248,7 @@ test('command: build, --ssr entry.server.tsx', async () => {
   const opts = await plugin.api?.getOptions();
   const build = c.build!;
   const rollupOptions = build!.rollupOptions!;
-  const outputOptions = rollupOptions.output as Rollup.OutputOptions;
+  const outputOptions = rollupOptions.output as Rollup.OutputOptions[];
 
   assert.deepEqual(opts.target, 'ssr');
   assert.deepEqual(opts.buildMode, 'development');
@@ -232,9 +260,16 @@ test('command: build, --ssr entry.server.tsx', async () => {
   assert.deepEqual(build.outDir, normalizePath(resolve(cwd, 'server')));
   assert.deepEqual(build.emptyOutDir, undefined);
   assert.deepEqual(rollupOptions.input, [normalizePath(resolve(cwd, 'src', 'entry.server.tsx'))]);
-  assert.deepEqual(outputOptions.assetFileNames, 'build/q-[hash].[ext]');
-  assert.deepEqual(outputOptions.chunkFileNames, undefined);
-  assert.deepEqual(outputOptions.entryFileNames, undefined);
+
+  assert.ok(Array.isArray(outputOptions));
+  assert.isNotEmpty(outputOptions);
+
+  outputOptions.forEach((outputOptionsObj) => {
+    assert.deepEqual(outputOptionsObj.assetFileNames, 'build/q-[hash].[ext]');
+    assert.deepEqual(outputOptionsObj.chunkFileNames, undefined);
+    assert.deepEqual(outputOptionsObj.entryFileNames, undefined);
+  });
+
   assert.deepEqual(build.outDir, normalizePath(resolve(cwd, 'server')));
   assert.deepEqual(build.dynamicImportVarsOptions?.exclude, [/./]);
   assert.deepEqual(build.ssr, true);
@@ -348,12 +383,81 @@ test('command: build, --mode lib', async () => {
   const opts = await plugin.api?.getOptions();
   const build = c.build!;
   const rollupOptions = build!.rollupOptions!;
+  const outputOptions = rollupOptions.output as Rollup.OutputOptions[];
 
   assert.deepEqual(opts.target, 'lib');
   assert.deepEqual(opts.buildMode, 'development');
   assert.deepEqual(build.minify, false);
   assert.deepEqual(build.ssr, undefined);
   assert.deepEqual(rollupOptions.input, [normalizePath(resolve(cwd, 'src', 'index.ts'))]);
+
+  assert.ok(Array.isArray(outputOptions));
+  assert.isNotEmpty(outputOptions);
+
+  outputOptions.forEach((outputOptionsObj) => {
+    assert.deepEqual(outputOptionsObj.assetFileNames, 'build/q-[hash].[ext]');
+    assert.deepEqual(outputOptionsObj.chunkFileNames, undefined);
+  });
+
+  assert.deepEqual(c.build.outDir, normalizePath(resolve(cwd, 'lib')));
+  assert.deepEqual(build.emptyOutDir, undefined);
+  assert.deepEqual(opts.resolveQwikBuild, true);
+});
+
+test('command: build, --mode lib with multiple outputs', async () => {
+  const initOpts = {
+    optimizerOptions: mockOptimizerOptions(),
+  };
+  const plugin = qwikVite(initOpts);
+  const c: any = (await plugin.config(
+    {
+      build: {
+        lib: {
+          entry: './src/index.ts',
+        },
+        rollupOptions: {
+          output: [
+            {
+              format: 'es',
+              entryFileNames: 'index.esm.js',
+            },
+            {
+              format: 'es',
+              entryFileNames: 'index.mjs',
+            },
+            {
+              format: 'cjs',
+              entryFileNames: 'index.cjs.js',
+            },
+            {
+              format: 'cjs',
+              entryFileNames: 'index.cjs',
+            },
+          ],
+        },
+      },
+    },
+    { command: 'build', mode: 'lib' }
+  ))!;
+  const opts = await plugin.api?.getOptions();
+  const build = c.build!;
+  const rollupOptions = build!.rollupOptions!;
+  const outputOptions = rollupOptions.output as Rollup.OutputOptions[];
+
+  assert.deepEqual(opts.target, 'lib');
+  assert.deepEqual(opts.buildMode, 'development');
+  assert.deepEqual(build.minify, false);
+  assert.deepEqual(build.ssr, undefined);
+  assert.deepEqual(rollupOptions.input, [normalizePath(resolve(cwd, 'src', 'index.ts'))]);
+
+  assert.ok(Array.isArray(outputOptions));
+  assert.isNotEmpty(outputOptions);
+
+  outputOptions.forEach((outputOptionsObj) => {
+    assert.deepEqual(outputOptionsObj.assetFileNames, 'build/q-[hash].[ext]');
+    assert.deepEqual(outputOptionsObj.chunkFileNames, undefined);
+  });
+
   assert.deepEqual(c.build.outDir, normalizePath(resolve(cwd, 'lib')));
   assert.deepEqual(build.emptyOutDir, undefined);
   assert.deepEqual(opts.resolveQwikBuild, true);


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

I'm using `qwikVite` to bundle my library. Because my setup requires multiple output files per format, I've tried to use the `rollupOptions.output` field to achieve this:

```js
{
  build: {
    lib: {
      entry: './src/index.ts',
    },
    rollupOptions: {
      output: [
        {
          format: 'es',
          entryFileNames: 'index.esm.js',
        },
        {
          format: 'es',
          entryFileNames: 'index.mjs',
        },
        {
          format: 'cjs',
          entryFileNames: 'index.cjs.js',
        },
        {
          format: 'cjs',
          entryFileNames: 'index.cjs',
        },
      ],
    },
  }
}
```

This did work but always created one additional output file which I didn't specify in the config. That happens because the `qwikVite` plugin is not handling output arrays correctly.

# Use cases and why

The possibility to achieve multiple outputs for library authors.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
