### PR TITLE
feat(qwik-city): expose MDX transformer and context

### DIFF
--- a/packages/qwik-city/buildtime/vite/plugin.ts
+++ b/packages/qwik-city/buildtime/vite/plugin.ts
@@ -55,6 +55,8 @@ function qwikCityPlugin(userOpts?: QwikCityVitePluginOptions): any {
     getServiceWorkers: () => {
       return ctx?.serviceWorkers.slice() ?? [];
     },
+    getContext: () => Object.freeze(ctx),
+    getMdxTransformer: () => mdxTransform,
   };
 
   const plugin: Plugin = {

--- a/packages/qwik-city/buildtime/vite/types.ts
+++ b/packages/qwik-city/buildtime/vite/types.ts
@@ -50,4 +50,6 @@ export interface QwikCityPluginApi {
   getBasePathname: () => string;
   getRoutes: () => BuildRoute[];
   getServiceWorkers: () => BuildEntry[];
+  getContext: () => BuildContext | null;
+  getMdxTransformer: () => MdxTransform | null;
 }


### PR DESCRIPTION
# Overview

Helps with integrations that want to use the already configured MDX transformer, by simply accessing the plugin's API. Additionally, exposes the build context so that any other transformer could use it.

# What is it?

- Feature / enhancement

# Description

While building a Vite plugin that uses MDX transformations, I ran into the complexity where I was using imports to get the transformed state. Ideally, I do not want to set up an alternative MDX transformer and just let the project define one. The basic import transformation works when retrieving content, albeit for more complex features, like breaking the markdown files into blocks, edit files and save them, I would need a deeper integration.

# Use cases and why

1. Split MDX content into blocks to inject any additional content in-between blocks like references, ads, summaries and allow Markdown editors to display small portions of each file as an independent section.
2. Setting up an alternative transformer with the available Context so that any alternatives to remark/rehype might be used for their different API or performance.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code

- ~~[ ] I have made corresponding changes to the documentation~~
> [!NOTE]
> There is no documentation around how to integrate with the plugin itself, nor any comment blocks for it.

- ~~[ ] Added new tests to cover the fix / functionality~~
> [!NOTE]
> There are no tests for this portion of the code, and adding one would be a type-check instead of any
> sort of functionality check, which I would rather not do when Typescript is already enforcing it.


