### PR TITLE
docs(insights): location change to qwikdev

### DIFF
--- a/packages/docs/src/routes/docs/labs/index.mdx
+++ b/packages/docs/src/routes/docs/labs/index.mdx
@@ -39,7 +39,7 @@ Qwik labs are distributed as a separate node package. Because Qwik Labs is "work
 
 
 ```sh
-npm install github:BuilderIo/qwik-labs-build#main
+npm install github:QwikDev/qwik-labs-build#main
 ```
 
 Or just add this to your `package.json`
@@ -49,7 +49,7 @@ Or just add this to your `package.json`
   ...
   "dependencies": {
     ...
-    "@builder.io/qwik-labs": "github:BuilderIo/qwik-labs-build#main",
+    "@builder.io/qwik-labs": "github:QwikDev/qwik-labs-build#main",
   }
 }
 ```

--- a/packages/docs/src/routes/docs/labs/typed-routes/index.mdx
+++ b/packages/docs/src/routes/docs/labs/typed-routes/index.mdx
@@ -14,7 +14,7 @@ Provides type safe way of building URLs within the application.
 
 ## Installation
 
-1. `npm install github:BuilderIo/qwik-labs-build#main`
+1. `npm install github:QwikDev/qwik-labs-build#main`
 2. update `vite.config.ts`
    ```typescript
    // ...


### PR DESCRIPTION
I changed the references to install directly from GitHub to the right repository

Currently working on a local version without turso and stumbled across this little doc problem.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
