### PR TITLE
feat(core): Add support to shadow DOM for QwikLoader.

### DIFF
--- a/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-qwik-attributes.ts
@@ -241,6 +241,7 @@ export interface QwikIntrinsicAttributes {
 
   /** Corresponding slot name used to project the element into. */
   'q:slot'?: string;
+  'q:shadowRoot'?: boolean;
   fetchPriority?: 'auto' | 'high' | 'low';
 }
 

--- a/starters/apps/e2e/src/components/containers/container.tsx
+++ b/starters/apps/e2e/src/components/containers/container.tsx
@@ -56,18 +56,38 @@ export const Container = component$((props: ContainerProps) => {
   );
 
   return (
-    <div class="container">
-      <Resource
-        value={resource}
-        onResolved={({ url, html }) => {
-          return (
-            <>
-              <div class="url">{url}</div>
-              <div class="frame" dangerouslySetInnerHTML={html} />
-            </>
-          );
-        }}
-      />
+    <div>
+      <div class="inline-container">
+        <Resource
+          value={resource}
+          onResolved={({ url, html }) => {
+            return (
+              <>
+                <div class="url">{url}</div>
+                <div class="frame" dangerouslySetInnerHTML={html} />
+              </>
+            );
+          }}
+        />
+      </div>
+      <div style={{ border: "1px solid red" }}>
+        Shadow DOM
+        <div q:shadowRoot>
+          <template shadowRootMode="open">
+            <Resource
+              value={resource}
+              onResolved={({ url, html }) => {
+                return (
+                  <>
+                    <div class="url">{url}</div>
+                    <div class="frame" dangerouslySetInnerHTML={html} />
+                  </>
+                );
+              }}
+            />
+          </template>
+        </div>
+      </div>
     </div>
   );
 });

--- a/starters/e2e/e2e.containers.spec.ts
+++ b/starters/e2e/e2e.containers.spec.ts
@@ -20,7 +20,17 @@ test.describe("container", () => {
   });
 
   test("should handle inner counter", async ({ page }) => {
-    const anchor = page.locator("a");
+    const container = page.locator(".inline-container");
+    const anchor = container.locator("a");
+
+    await expect(anchor).toHaveText("1 / 1");
+    await anchor.click();
+    await expect(anchor).toHaveText("2 / 3");
+  });
+
+  test("should handle shadow-dom counter", async ({ page }) => {
+    const shadowHost = page.locator("[q\\:shadowroot]");
+    const anchor = shadowHost.locator("a");
 
     await expect(anchor).toHaveText("1 / 1");
     await anchor.click();


### PR DESCRIPTION
feat(core): Add support to shadow DOM for QwikLoader.

Shadow DOM can be used to isolate an application. The isolation also
includes:
- Events don't bubble across shadow boundaries.
- QuerySelector doesn't cross shadow boundaries.

QwikLoader relies on both event bubbling and querySelector to process
events such as `on:click` and dispatch such as `on-window:resize`.

To enable QwikLoader to work with shadow DOM, it is necessary to tell
qwikloader that when it is registering an event listener, as well as
performing querySelector, it should do so not just on document but also
inside the shadow DOM. To do that it is the responsibility of the
developer to tell qwikloader about the shadow DOM roots.

CONSTRAINTS:
The qwikloader applications `q:container` must be fully inside the
shadow root. (i.e. the application itself must not cross the shadow DOM
boundaries.)

Developer responsibility: (choose one)

- Have qwik loader find the roots by annotate the elements which have 
  shadow DOM with `q:shadowRoot` attribute.
- Manually insert a `<script>` tag into HTML which will add the shadow DOM
  root into the qwikloader's `qwikevents` array.

Example:
Possible implementation
```html
<div id="my-child" q:shadowRoot>
  <template shadowrootmode="open">
     <div q:container="..." q:base="..."...>qwik-container here</div>
  </template>
</div>
```

Fixes: #6546
