### PR TITLE
refactor(v2/ssr-container): rename ContainerElementFrame to ElementFrame

### DIFF
--- a/packages/qwik/src/server/v2-ssr-container.ts
+++ b/packages/qwik/src/server/v2-ssr-container.ts
@@ -132,13 +132,13 @@ class StringBufferWriter {
   }
 }
 
-interface ContainerElementFrame {
+interface ElementFrame {
   /*
    * Used during development mode to track the nesting of HTML tags
    * in order provide error messages when the nesting is incorrect.
    */
   tagNesting: TagNesting;
-  parent: ContainerElementFrame | null;
+  parent: ElementFrame | null;
   /** Element name. */
   elementName: string;
   /**
@@ -187,7 +187,7 @@ class SSRContainer extends _SharedContainer implements ISSRContainer {
   private currentComponentNode: ISsrNode | null = null;
   private styleIds = new Set<string>();
 
-  private currentElementFrame: ContainerElementFrame | null = null;
+  private currentElementFrame: ElementFrame | null = null;
 
   private renderTimer: ReturnType<typeof createTimer>;
   /**
@@ -985,11 +985,11 @@ class SSRContainer extends _SharedContainer implements ISSRContainer {
       if (!this.currentElementFrame) {
         tagNesting = initialTag(elementName);
       } else {
-        let frame: ContainerElementFrame | null = this.currentElementFrame;
+        let frame: ElementFrame | null = this.currentElementFrame;
         const previousTagNesting = frame!.tagNesting;
         tagNesting = isTagAllowed(previousTagNesting, elementName);
         if (tagNesting === TagNesting.NOT_ALLOWED) {
-          const frames: ContainerElementFrame[] = [];
+          const frames: ElementFrame[] = [];
           while (frame) {
             frames.unshift(frame);
             frame = frame.parent;
@@ -1021,7 +1021,7 @@ class SSRContainer extends _SharedContainer implements ISSRContainer {
         }
       }
     }
-    const frame: ContainerElementFrame = {
+    const frame: ElementFrame = {
       tagNesting,
       parent: this.currentElementFrame,
       elementName,


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

During a session with @mhevery and @shairez,
@mhevery said that the `Container` prefix is redundant and a bit confusing.
Therefore I created this PR to remove it.


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
