### PR TITLE
docs(v2/ssr-container): add context to tag nesting property

### DIFF
--- a/packages/qwik/src/server/v2-ssr-container.ts
+++ b/packages/qwik/src/server/v2-ssr-container.ts
@@ -127,6 +127,10 @@ class StringBufferWriter {
 }
 
 interface ContainerElementFrame {
+  /*
+   * Used during development mode to track the nesting of HTML tags
+   * in order provide error messages when the nesting is incorrect.
+   */
   tagNesting: TagNesting;
   parent: ContainerElementFrame | null;
   /** Element name. */


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

During a session with @mhevery and @shairez,
we looked at the SSR container class,
@mhevery explained what `tagNesting` means and I found this as something that is not intuitive so went ahead and opened this PR to add some context to it.


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
