### PR TITLE
docs(qwik-nutshell): remove onInput$ reference to React onChange

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/guides/qwik-nutshell/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/qwik-nutshell/index.mdx
@@ -25,12 +25,11 @@ created_at: '2023-03-30T19:49:50Z'
 
 ## Components
 
-Qwik components are very similar to React components. They are functions that return JSX. However, `component$(...)` needs to be used, event handlers must have the `$` suffix, state is created using `useSignal()` , `class` is used instead of `className` and some other differences.
+Qwik components are very similar to React components. They are functions that return JSX. However, `component$(...)` needs to be used, event handlers must have the `$` suffix, state is created using `useSignal()`, `class` is used instead of `className` and some other differences.
 
 - Components are always declared with the `component$` function.
 - Components can use the `useSignal` hook to create reactive state.
 - Event handlers are declared with the `$` suffix.
-- For `<input>`, the `onChange` event is called `onInput$` in Qwik.
 - JSX prefers HTML attributes. `class` instead of `className`. `for` instead of `htmlFor`.
 - Conditional rendering is done with the ternary operator `?` and the `&&` operator, just like React.
 


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

The line deleted
> For `<input>`, the `onChange` event is called `onInput$` in Qwik.

assumes people are coming from React, where `onChange` is like html's `oninput` . Whereas Qwik's `onChange$` and `onInput$` actually reflect html's `onchange` and `oninput`, respectively 🕺.

Ref: 
https://www.w3schools.com/tags/att_onchange.asp
https://www.w3schools.com/tags/att_oninput.asp

I don't think it's a core API of Qwik so I just removed it from "Qwik in a nutshell".

# Use cases and why



<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
