### PR TITLE
refactor: remove references to `currentScript`

### DIFF
--- a/packages/qwik-city/runtime/src/router-outlet-component.tsx
+++ b/packages/qwik-city/runtime/src/router-outlet-component.tsx
@@ -13,8 +13,12 @@ import shim from './spa-shim';
 
 /** @public */
 export const RouterOutlet = component$(() => {
+  const serverData = useServerData<Record<string, string>>('containerAttributes');
+  if (!serverData) {
+    throw new Error('PrefetchServiceWorker component must be rendered on the server.');
+  }
   // TODO Option to remove this shim, especially for MFEs.
-  const shimScript = shim();
+  const shimScript = shim(serverData['q:base']);
 
   _jsxBranch();
 

--- a/packages/qwik-city/runtime/src/spa-init.ts
+++ b/packages/qwik-city/runtime/src/spa-init.ts
@@ -14,7 +14,7 @@ import { $ } from '@builder.io/qwik';
 // - Robust, fully relies only on history. (scrollRestoration = 'manual')
 
 // ! DO NOT IMPORT OR USE ANY EXTERNAL REFERENCES IN THIS SCRIPT.
-export default $((currentScript: HTMLScriptElement) => {
+export default $((container: HTMLElement) => {
   const win: ClientSPAWindow = window;
 
   const currentPath = location.pathname + location.search;
@@ -74,7 +74,6 @@ export default $((currentScript: HTMLScriptElement) => {
         // Hook into useNavigate context, if available.
         // We hijack a <Link> here, goes through the loader, resumes, app, etc. Simple.
         // TODO Will only work with <Link>, is there a better way?
-        const container = currentScript!.closest('[q\\:container]')!;
         const link = container.querySelector('a[q\\:link]');
 
         if (link) {

--- a/packages/qwik-city/runtime/src/spa-shim.ts
+++ b/packages/qwik-city/runtime/src/spa-shim.ts
@@ -6,10 +6,11 @@ import { getPlatform } from '@builder.io/qwik';
 
 import init from './spa-init';
 
-export default () => {
+export default (base: string) => {
   if (isServer) {
     const [symbol, bundle] = getPlatform().chunkForSymbol(init.getSymbol(), null)!;
-    return `(${shim.toString()})('${bundle}','${symbol}');`;
+    const args = [base, bundle, symbol].map((x) => JSON.stringify(x)).join(',');
+    return `(${shim.toString()})('${args}');`;
   }
 };
 
@@ -20,7 +21,7 @@ export default () => {
 // - If the check here doesn't pass, your page was never SPA. (no SPA pops possible)
 
 // ! DO NOT IMPORT OR USE ANY EXTERNAL REFERENCES IN THIS SCRIPT.
-const shim = async (path: string, symbol: string) => {
+const shim = async (base: string, path: string, symbol: string) => {
   if (!(window as ClientSPAWindow)._qcs && history.scrollRestoration === 'manual') {
     // TODO Option to remove this shim especially for MFEs, like loader, for now we only run once.
     (window as ClientSPAWindow)._qcs = true;
@@ -30,19 +31,21 @@ const shim = async (path: string, symbol: string) => {
       window.scrollTo(scrollState.x, scrollState.y);
     }
 
-    const currentScript = document.currentScript as HTMLScriptElement;
+    const script = document.currentScript as HTMLScriptElement;
+    if (script) {
+      // Inside shadow DOM, we can't get a hold of a container. So we can't
+      // load the SPA shim.
+      const container = script!.closest('[q\\:container]')!;
+      const url = new URL(path, new URL(base, document.baseURI));
 
-    const container = currentScript.closest('[q\\:container]')!;
-    const base = new URL(container.getAttribute('q:base')!, document.baseURI);
-    const url = new URL(path, base);
-
-    if (isDev) {
-      // Bypass dev import hijack. (not going to work here)
-      // eslint-disable-next-line no-new-func
-      const imp = new Function('url', 'return import(url)');
-      (await imp(url.href))[symbol](currentScript);
-    } else {
-      (await import(url.href))[symbol](currentScript);
+      if (isDev) {
+        // Bypass dev import hijack. (not going to work here)
+        // eslint-disable-next-line no-new-func
+        const imp = new Function('url', 'return import(url)');
+        (await imp(url.href))[symbol](container);
+      } else {
+        (await import(url.href))[symbol](container);
+      }
     }
   }
 };

--- a/packages/qwik-city/runtime/src/spa-shim.ts
+++ b/packages/qwik-city/runtime/src/spa-shim.ts
@@ -10,7 +10,7 @@ export default (base: string) => {
   if (isServer) {
     const [symbol, bundle] = getPlatform().chunkForSymbol(init.getSymbol(), null)!;
     const args = [base, bundle, symbol].map((x) => JSON.stringify(x)).join(',');
-    return `(${shim.toString()})('${args}');`;
+    return `(${shim.toString()})(${args});`;
   }
 };
 

--- a/packages/qwik/src/core/components/prefetch.ts
+++ b/packages/qwik/src/core/components/prefetch.ts
@@ -30,10 +30,7 @@ export const PrefetchServiceWorker = (opts: {
   fetchBundleGraph?: boolean;
   nonce?: string;
 }): JSXNode<'script'> => {
-  const serverData = useServerData<Record<string, string>>('containerAttributes');
-  if (!serverData) {
-    throw new Error('PrefetchServiceWorker component must be rendered on the server.');
-  }
+  const serverData = useServerData<Record<string, string>>('containerAttributes', {});
   const resolvedOpts = {
     base: serverData['q:base'],
     manifestHash: serverData['q:manifest-hash'],
@@ -141,10 +138,7 @@ const PREFETCH_CODE = /*#__PURE__*/ ((
 export const PrefetchGraph = (
   opts: { base?: string; manifestHash?: string; manifestURL?: string; nonce?: string } = {}
 ) => {
-  const serverData = useServerData<Record<string, string>>('containerAttributes');
-  if (!serverData) {
-    throw new Error('PrefetchServiceWorker component must be rendered on the server.');
-  }
+  const serverData = useServerData<Record<string, string>>('containerAttributes', {});
   const resolvedOpts = {
     base: serverData['q:base'],
     manifestHash: serverData['q:manifest-hash'],

--- a/packages/qwik/src/core/components/prefetch.ts
+++ b/packages/qwik/src/core/components/prefetch.ts
@@ -1,6 +1,7 @@
 import { isDev } from '@builder.io/qwik/build';
 import { _jsxC } from '../internal';
 import type { JSXNode } from '@builder.io/qwik/jsx-runtime';
+import { useServerData } from '../use/use-env-data';
 
 /**
  * Install a service worker which will prefetch the bundles.
@@ -29,8 +30,13 @@ export const PrefetchServiceWorker = (opts: {
   fetchBundleGraph?: boolean;
   nonce?: string;
 }): JSXNode<'script'> => {
+  const serverData = useServerData<Record<string, string>>('containerAttributes');
+  if (!serverData) {
+    throw new Error('PrefetchServiceWorker component must be rendered on the server.');
+  }
   const resolvedOpts = {
-    base: import.meta.env.BASE_URL || '/',
+    base: serverData['q:base'],
+    manifestHash: serverData['q:manifest-hash'],
     scope: '/',
     verbose: false,
     path: 'qwik-prefetch-service-worker.js',
@@ -78,7 +84,8 @@ export const PrefetchServiceWorker = (opts: {
     dangerouslySetInnerHTML: [
       '(' + code + ')(',
       [
-        "document.currentScript.closest('[q\\\\:container]')",
+        JSON.stringify(resolvedOpts.base),
+        JSON.stringify(resolvedOpts.manifestHash),
         'navigator.serviceWorker',
         'window.qwikPrefetchSW||(window.qwikPrefetchSW=[])',
         resolvedOpts.verbose,
@@ -91,15 +98,12 @@ export const PrefetchServiceWorker = (opts: {
 };
 
 const PREFETCH_CODE = /*#__PURE__*/ ((
-  qc: HTMLElement, // QwikContainer Element
+  b: string, // base
+  h: string, // manifest hash
   c: ServiceWorkerContainer, // Service worker container
   q: Array<any[]>, // Queue of messages to send to the service worker.
-  v: boolean, // Verbose mode
-  b?: string,
-  h?: string
+  v: boolean // Verbose mode
 ) => {
-  b = qc.getAttribute('q:base')!;
-  h = qc.getAttribute('q:manifest-hash')!;
   c.register('URL', { scope: 'SCOPE' }).then(
     (sw: ServiceWorkerRegistration, onReady?: () => void) => {
       onReady = () => q.forEach((q.push = (v) => sw.active!.postMessage(v) as any));
@@ -137,39 +141,29 @@ const PREFETCH_CODE = /*#__PURE__*/ ((
 export const PrefetchGraph = (
   opts: { base?: string; manifestHash?: string; manifestURL?: string; nonce?: string } = {}
 ) => {
+  const serverData = useServerData<Record<string, string>>('containerAttributes');
+  if (!serverData) {
+    throw new Error('PrefetchServiceWorker component must be rendered on the server.');
+  }
   const resolvedOpts = {
-    base: `${import.meta.env.BASE_URL}build/`,
-    manifestHash: null,
-    manifestURL: null,
+    base: serverData['q:base'],
+    manifestHash: serverData['q:manifest-hash'],
+    scope: '/',
+    verbose: false,
+    path: 'qwik-prefetch-service-worker.js',
     ...opts,
   };
-  let code = PREFETCH_GRAPH_CODE;
-  if (!isDev) {
-    code = code.replaceAll(/\s+/gm, '');
-  }
+  const args = [
+    'graph-url',
+    resolvedOpts.base,
+    resolvedOpts.base + `q-bundle-graph-${resolvedOpts.manifestHash}.json`,
+  ]
+    .map((x) => JSON.stringify(x))
+    .join(',');
+  const code = `(window.qwikPrefetchSW||(window.qwikPrefetchSW=[])).push(${args})`;
   const props = {
-    dangerouslySetInnerHTML: [
-      '(' + code + ')(',
-      [
-        "document.currentScript.closest('[q\\\\:container]')",
-        'window.qwikPrefetchSW||(window.qwikPrefetchSW=[])',
-        JSON.stringify(resolvedOpts.base),
-        JSON.stringify(resolvedOpts.manifestHash),
-        JSON.stringify(resolvedOpts.manifestURL),
-      ].join(','),
-      ');',
-    ].join(''),
+    dangerouslySetInnerHTML: code,
     nonce: opts.nonce,
   };
   return _jsxC('script', props, 0, 'prefetch-graph');
 };
-
-const PREFETCH_GRAPH_CODE = /*#__PURE__*/ ((
-  qc: HTMLElement, // QwikContainer Element
-  q: Array<any[]>, // Queue of messages to send to the service worker.
-  b: string, // Base URL
-  h: string | null, // Manifest hash
-  u: string | null // Manifest URL
-) => {
-  q.push(['graph-url', b, u || `q-bundle-graph-${h || qc.getAttribute('q:manifest-hash')}.json`]);
-}).toString();

--- a/packages/qwik/src/core/components/prefetch.unit.tsx
+++ b/packages/qwik/src/core/components/prefetch.unit.tsx
@@ -2,13 +2,19 @@ import { describe, expect, it } from 'vitest';
 import { PrefetchServiceWorker, PrefetchGraph } from './prefetch';
 import { renderToString } from '../../server/render';
 
+const DEBUG = false;
+function log(...args: any[]) {
+  if (DEBUG) {
+    // eslint-disable-next-line no-console
+    console.log(...args);
+  }
+}
+
 describe('PrefetchServiceWorker', () => {
   describe('render', () => {
     it('should render', async () => {
-      // eslint-disable-next-line no-console
       const output = await renderToString(<PrefetchServiceWorker />, { containerTagName: 'div' });
-      // eslint-disable-next-line no-console
-      console.log('>>>>', output.html);
+      log('>>>>', output.html);
     });
 
     it('should render with a nonce', async () => {
@@ -24,8 +30,7 @@ describe('PrefetchServiceWorker', () => {
           containerTagName: 'div',
         }
       );
-      // eslint-disable-next-line no-console
-      console.log('>>>>', output.html);
+      log('>>>>', output.html);
       expect(output.html).to.includes('scope: "/en/"');
       expect(output.html).to.includes('"/build/en/qwik-prefetch-service-worker.js"');
     });
@@ -33,8 +38,7 @@ describe('PrefetchServiceWorker', () => {
       const output = await renderToString(<PrefetchServiceWorker base="/build/en/" />, {
         containerTagName: 'div',
       });
-      // eslint-disable-next-line no-console
-      console.log('>>>>', output.html);
+      log('>>>>', output.html);
       expect(output.html).to.includes('scope: "/"');
       expect(output.html).to.includes('"/build/en/qwik-prefetch-service-worker.js"');
     });
@@ -43,10 +47,9 @@ describe('PrefetchServiceWorker', () => {
         base: '/build/en/',
         containerTagName: 'div',
       });
-      // eslint-disable-next-line no-console
-      console.log('>>>>', output.html);
+      log('>>>>', output.html);
       expect(output.html).to.includes('scope: "/"');
-      expect(output.html).to.includes('"/qwik-prefetch-service-worker.js"');
+      expect(output.html).to.includes('/qwik-prefetch-service-worker.js');
     });
     it('should render script with a custom service-worker path', async () => {
       const output = await renderToString(
@@ -55,10 +58,9 @@ describe('PrefetchServiceWorker', () => {
           containerTagName: 'div',
         }
       );
-      // eslint-disable-next-line no-console
-      console.log('>>>>', output.html);
+      log('>>>>', output.html);
       expect(output.html).to.includes('scope: "/"');
-      expect(output.html).to.includes('"/patrickjs-service-worker.js"');
+      expect(output.html).to.includes('/patrickjs-service-worker.js');
     });
     it('should render script with a custom service-worker path with different base', async () => {
       const output = await renderToString(
@@ -67,8 +69,7 @@ describe('PrefetchServiceWorker', () => {
           containerTagName: 'div',
         }
       );
-      // eslint-disable-next-line no-console
-      console.log('>>>>', output.html);
+      log('>>>>', output.html);
       expect(output.html).to.includes('scope: "/"');
       expect(output.html).to.includes('"/build2/patrickjs-service-worker.js"');
     });
@@ -83,8 +84,7 @@ describe('PrefetchServiceWorker', () => {
           containerTagName: 'div',
         }
       );
-      // eslint-disable-next-line no-console
-      console.log('>>>>', output.html);
+      log('>>>>', output.html);
       expect(output.html).to.includes('scope: "/"');
       expect(output.html).to.includes('"/build/patrickjs-service-worker.js"');
     });
@@ -94,10 +94,8 @@ describe('PrefetchServiceWorker', () => {
 describe('PrefetchGraph', () => {
   describe('render', () => {
     it('should render', async () => {
-      // eslint-disable-next-line no-console
       const output = await renderToString(<PrefetchGraph />, { containerTagName: 'div' });
-      // eslint-disable-next-line no-console
-      console.log('>>>>', output.html);
+      log('>>>>', output.html);
     });
 
     it('should render with a nonce', async () => {

--- a/packages/qwik/src/core/container/container.ts
+++ b/packages/qwik/src/core/container/container.ts
@@ -109,6 +109,16 @@ export const _getContainerState = (containerEl: Element): ContainerState => {
 };
 
 export const createContainerState = (containerEl: Element, base: string) => {
+  const containerAttributes: Record<string, string> = {};
+  if (containerEl) {
+    const attrs = containerEl.attributes;
+    if (attrs) {
+      for (let index = 0; index < attrs.length; index++) {
+        const attr = attrs[index];
+        containerAttributes[attr.name] = attr.value;
+      }
+    }
+  }
   const containerState: ContainerState = {
     $containerEl$: containerEl,
 
@@ -128,7 +138,7 @@ export const createContainerState = (containerEl: Element, base: string) => {
     $styleIds$: new Set(),
     $events$: new Set(),
 
-    $serverData$: {},
+    $serverData$: { containerAttributes },
     $base$: base,
     $renderPromise$: undefined,
     $hostsRendering$: undefined,

--- a/packages/qwik/src/core/container/container.ts
+++ b/packages/qwik/src/core/container/container.ts
@@ -188,6 +188,5 @@ export const getEventName = (attribute: string) => {
 };
 
 export interface QContainerElement extends Element {
-  qFuncs?: Function[];
   _qwikjson_?: any;
 }

--- a/packages/qwik/src/core/container/pause.ts
+++ b/packages/qwik/src/core/container/pause.ts
@@ -144,6 +144,7 @@ export const _serializeData = async (data: any, pureQRL?: boolean) => {
 // (edit ../readme.md#pauseContainer instead)
 // </docs>
 /** This pauses a running container in the browser. It is not used for SSR */
+// TODO(mhevery): this is a remnant when you could have paused on client. Should be deleted.
 export const pauseContainer = async (
   elmOrDoc: Element | Document,
   defaultParentJSON?: Element

--- a/packages/qwik/src/core/container/resume.ts
+++ b/packages/qwik/src/core/container/resume.ts
@@ -2,7 +2,7 @@ import { assertDefined, assertTrue } from '../error/assert';
 import { getDocument } from '../util/dom';
 import { isComment, isElement, isNode, isQwikElement, isText } from '../util/element';
 import { logDebug, logWarn } from '../util/log';
-import { ELEMENT_ID, QContainerAttr, QManifestHash, getQFuncs } from '../util/markers';
+import { ELEMENT_ID, QContainerAttr, QInstance, getQFuncs } from '../util/markers';
 
 import { emitEvent } from '../util/event';
 
@@ -99,7 +99,7 @@ export const resumeContainer = (containerEl: Element) => {
   }
 
   const doc = getDocument(containerEl);
-  const hash = containerEl.getAttribute(QManifestHash)!;
+  const hash = containerEl.getAttribute(QInstance)!;
   const isDocElement = containerEl === doc.documentElement;
   const parentJSON = isDocElement ? doc.body : containerEl;
   if (qDev) {

--- a/packages/qwik/src/core/container/resume.ts
+++ b/packages/qwik/src/core/container/resume.ts
@@ -2,7 +2,7 @@ import { assertDefined, assertTrue } from '../error/assert';
 import { getDocument } from '../util/dom';
 import { isComment, isElement, isNode, isQwikElement, isText } from '../util/element';
 import { logDebug, logWarn } from '../util/log';
-import { ELEMENT_ID, QContainerAttr } from '../util/markers';
+import { ELEMENT_ID, QContainerAttr, QManifestHash, getQFuncs } from '../util/markers';
 
 import { emitEvent } from '../util/event';
 
@@ -17,7 +17,6 @@ import {
   SHOW_COMMENT,
   type SnapshotState,
   strToInt,
-  type QContainerElement,
 } from './container';
 import { getVirtualElement } from '../render/dom/virtual-element';
 import { getSubscriptionManager, parseSubscription, type Subscriptions } from '../state/common';
@@ -27,7 +26,6 @@ import { pauseContainer } from './pause';
 import { isPrimitive } from '../render/dom/render-dom';
 import { getWrappingContainer } from '../use/use-core';
 import { getContext } from '../state/context';
-import { EMPTY_ARRAY } from '../util/flyweight';
 
 export const resumeIfNeeded = (containerEl: Element): void => {
   const isResumed = directGetAttribute(containerEl, QContainerAttr);
@@ -101,6 +99,7 @@ export const resumeContainer = (containerEl: Element) => {
   }
 
   const doc = getDocument(containerEl);
+  const hash = containerEl.getAttribute(QManifestHash)!;
   const isDocElement = containerEl === doc.documentElement;
   const parentJSON = isDocElement ? doc.body : containerEl;
   if (qDev) {
@@ -111,7 +110,7 @@ export const resumeContainer = (containerEl: Element) => {
     }
   }
 
-  const inlinedFunctions = getQwikInlinedFuncs(containerEl);
+  const inlinedFunctions = getQFuncs(doc, hash);
   const containerState = _getContainerState(containerEl);
 
   // Collect all elements
@@ -310,10 +309,6 @@ const reviveNestedObjects = (obj: unknown, getObject: GetObject, parser: Parser)
 
 const unescapeText = (str: string) => {
   return str.replace(/\\x3C(\/?script)/gi, '<$1');
-};
-
-export const getQwikInlinedFuncs = (containerEl: Element): Function[] => {
-  return (containerEl as QContainerElement).qFuncs ?? EMPTY_ARRAY;
 };
 
 export const getQwikJSON = (

--- a/packages/qwik/src/core/qrl/qrl-class.ts
+++ b/packages/qwik/src/core/qrl/qrl-class.ts
@@ -1,4 +1,3 @@
-import type { QContainerElement } from '../container/container';
 import { assertDefined } from '../error/assert';
 import { qError, QError_qrlIsNotFunction } from '../error/error';
 import { getPlatform, isServerPlatform } from '../platform/platform';
@@ -12,6 +11,7 @@ import {
   type InvokeContext,
   type InvokeTuple,
 } from '../use/use-core';
+import { getQFuncs, QManifestHash } from '../util/markers';
 import { maybeThen } from '../util/promises';
 import { qDev, qSerialize, qTest, seal } from '../util/qdev';
 import { isArray, isFunction, type ValueOrPromise } from '../util/types';
@@ -55,7 +55,7 @@ export type QRLInternalMethods<TYPE> = {
       unknown;
 
   $setContainer$(containerEl: Element | undefined): Element | undefined;
-  $resolveLazy$(containerEl?: Element): ValueOrPromise<TYPE>;
+  $resolveLazy$(containerEl: Element): ValueOrPromise<TYPE>;
 };
 
 export type QRLInternal<TYPE = unknown> = QRL<TYPE> & QRLInternalMethods<TYPE>;
@@ -103,7 +103,9 @@ export const createQRL = <TYPE>(
     if (chunk === '') {
       // Sync QRL
       assertDefined(_containerEl, 'Sync QRL must have container element');
-      const qFuncs = (_containerEl as QContainerElement).qFuncs || [];
+      const hash = _containerEl.getAttribute(QManifestHash)!;
+      const doc = _containerEl.ownerDocument!;
+      const qFuncs = getQFuncs(doc, hash);
       return (qrl.resolved = symbolRef = qFuncs[Number(symbol)] as TYPE);
     }
     if (symbolFn !== null) {

--- a/packages/qwik/src/core/qrl/qrl-class.ts
+++ b/packages/qwik/src/core/qrl/qrl-class.ts
@@ -11,7 +11,7 @@ import {
   type InvokeContext,
   type InvokeTuple,
 } from '../use/use-core';
-import { getQFuncs, QManifestHash } from '../util/markers';
+import { getQFuncs, QInstance } from '../util/markers';
 import { maybeThen } from '../util/promises';
 import { qDev, qSerialize, qTest, seal } from '../util/qdev';
 import { isArray, isFunction, type ValueOrPromise } from '../util/types';
@@ -103,7 +103,7 @@ export const createQRL = <TYPE>(
     if (chunk === '') {
       // Sync QRL
       assertDefined(_containerEl, 'Sync QRL must have container element');
-      const hash = _containerEl.getAttribute(QManifestHash)!;
+      const hash = _containerEl.getAttribute(QInstance)!;
       const doc = _containerEl.ownerDocument!;
       const qFuncs = getQFuncs(doc, hash);
       return (qrl.resolved = symbolRef = qFuncs[Number(symbol)] as TYPE);

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -157,6 +157,7 @@ export const _renderSSR = async (node: JSXOutput, opts: RenderSSROptions) => {
   containerAttributes['q:base'] = opts.base || '';
   containerAttributes['q:locale'] = locale;
   containerAttributes['q:manifest-hash'] = opts.manifestHash;
+  containerAttributes['q:instance'] = hash();
 
   const children = root === 'html' ? [node] : [headNodes, node];
   if (root !== 'html') {
@@ -188,6 +189,8 @@ export const _renderSSR = async (node: JSXOutput, opts: RenderSSROptions) => {
     renderRoot(rootNode, rCtx, ssrCtx, opts.stream, containerState, opts)
   );
 };
+
+const hash = () => Math.random().toString(36).slice(2);
 
 const renderRoot = async (
   node: JSXNode,

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -148,27 +148,32 @@ export const _renderSSR = async (node: JSXOutput, opts: RenderSSROptions) => {
   };
   seal(ssrCtx);
 
-  let qRender = qDev ? 'ssr-dev' : 'ssr';
-  if (opts.containerAttributes['q:render']) {
-    qRender = `${opts.containerAttributes['q:render']}-${qRender}`;
-  }
-  const containerAttributes: Record<string, any> = {
-    ...opts.containerAttributes,
-    'q:container': 'paused',
-    'q:version': version ?? 'dev',
-    'q:render': qRender,
-    'q:base': opts.base,
-    'q:locale': opts.serverData?.locale,
-    'q:manifest-hash': opts.manifestHash,
-  };
+  const locale = opts.serverData?.locale;
+  const containerAttributes = opts.containerAttributes;
+  const qRender = containerAttributes['q:render'];
+  containerAttributes['q:container'] = 'paused';
+  containerAttributes['q:version'] = version ?? 'dev';
+  containerAttributes['q:render'] = (qRender ? qRender + '-' : '') + (qDev ? 'ssr-dev' : 'ssr');
+  containerAttributes['q:base'] = opts.base || '';
+  containerAttributes['q:locale'] = locale;
+  containerAttributes['q:manifest-hash'] = opts.manifestHash;
+
   const children = root === 'html' ? [node] : [headNodes, node];
   if (root !== 'html') {
     containerAttributes.class =
       'qc📦' + (containerAttributes.class ? ' ' + containerAttributes.class : '');
   }
-  if (opts.serverData) {
-    containerState.$serverData$ = opts.serverData;
-  }
+  const serverData = (containerState.$serverData$ = {
+    ...containerState.$serverData$,
+    ...opts.serverData,
+  });
+  serverData.containerAttributes = {
+    ...serverData['containerAttributes'],
+    ...containerAttributes,
+  };
+  const invokeCtx = (ssrCtx.$invocationContext$ = newInvokeContext(locale));
+  invokeCtx.$renderCtx$ = rCtx;
+  ssrCtx.$invocationContext$;
 
   const rootNode = _jsxQ(
     root,

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -1843,7 +1843,7 @@ async function testSSR(
   expected: string | string[],
   opts?: Partial<RenderSSROptions>
 ) {
-  const chunks: string[] = [];
+  let chunks: string[] = [];
   const stream: StreamWriter = {
     write(chunk) {
       chunks.push(chunk);
@@ -1856,6 +1856,7 @@ async function testSSR(
     manifestHash: 'test',
     ...opts,
   });
+  chunks = chunks.map((c) => c.replace(/ q:instance="[^"]+"/, ''));
   if (typeof expected === 'string') {
     const options = { parser: 'html', htmlWhitespaceSensitivity: 'ignore' } as const;
     expect(await format(chunks.join(''), options)).toBe(

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -22,7 +22,7 @@ import type { JSXOutput } from '../jsx/types/jsx-node';
 test('render attributes', async () => {
   await testSSR(
     <body id="stuff" aria-required="true" role=""></body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body id="stuff" aria-required="true" role=""></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body id="stuff" aria-required="true" role=""></body></html>'
   );
 });
 
@@ -37,7 +37,7 @@ test('render aria value', async () => {
       aria-hidden={undefined}
     ></body>,
     `
-        <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+        <html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
           <body id="stuff" aria-required="true" aria-busy="false" role="" preventdefault:click></body>
         </html>
         `
@@ -47,7 +47,7 @@ test('render aria value', async () => {
 test('render className', async () => {
   await testSSR(
     <body class="stuff"></body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body class="stuff"></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body class="stuff"></body></html>'
   );
 });
 
@@ -152,7 +152,7 @@ test('render class', async () => {
         'm-0 p-2': true,
       }}
     ></body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body class="stuff m-0 p-2"></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body class="stuff m-0 p-2"></body></html>'
   );
 
   const Test = component$(() => {
@@ -164,7 +164,7 @@ test('render class', async () => {
     <body>
       <Test />
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
         <!--qv q:id=0 q:key=sX:-->
         <div class="myClass" q:id="1"></div>
@@ -177,7 +177,7 @@ test('render class', async () => {
     <body
       class={['stuff', '', 'm-0 p-2', null, { active: 1 }, undefined, [{ container: 'yup' }]]}
     ></body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body class="stuff m-0 p-2 active container"></body>
     </html>`
   );
@@ -186,7 +186,7 @@ test('render class', async () => {
 test('render contentEditable', async () => {
   await testSSR(
     <body contentEditable="true"></body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body contentEditable="true"></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body contentEditable="true"></body></html>'
   );
 });
 
@@ -198,7 +198,7 @@ test('render draggable', async () => {
       <div draggable={undefined}></div>
     </body>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
         <div draggable="true"></div>
         <div draggable="false"></div>
@@ -215,7 +215,7 @@ test('render <textarea>', async () => {
       <textarea value="some text"></textarea>
     </body>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
         <textarea>some text</textarea>
       </body>
@@ -232,7 +232,7 @@ test('render spellcheck', async () => {
       <div spellcheck={undefined}></div>
     </body>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
         <div spellcheck="true"></div>
         <div spellcheck="false"></div>
@@ -256,7 +256,7 @@ test('render styles', async () => {
       }}
     ></body>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body style="
           padding-top: 10px;
           padding-bottom: 10px;
@@ -274,7 +274,7 @@ test('render fake click handler', async () => {
   const Div = 'body' as any;
   await testSSR(
     <Div on:click="true" onScroll="text"></Div>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body on:click="true" onScroll="text"></body>
     </html>`
   );
@@ -285,7 +285,7 @@ test('self closing elements', async () => {
     <body>
       <input></input>
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
         <input>
       </body>
@@ -296,27 +296,27 @@ test('self closing elements', async () => {
 test('single simple children', async () => {
   await testSSR(
     <body>hola</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body>hola</body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body>hola</body></html>'
   );
   await testSSR(
     <body>{0}</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body>0</body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body>0</body></html>'
   );
   await testSSR(
     <body>{true}</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body></body></html>'
   );
   await testSSR(
     <body>{false}</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body></body></html>'
   );
   await testSSR(
     <body>{null}</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body></body></html>'
   );
   await testSSR(
     <body>{undefined}</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body></body></html>'
   );
 });
 
@@ -327,7 +327,7 @@ test('valid phrasing content', async () => {
         <del>Del</del>
       </p>
     </body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body><p><del>Del</del></p></body>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body><p><del>Del</del></p></body>'
   );
   await testSSR(
     <body>
@@ -338,7 +338,7 @@ test('valid phrasing content', async () => {
         </select>
       </p>
     </body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body><p><select><option>A</option><option>B</option></select></p></body>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body><p><select><option>A</option><option>B</option></select></p></body>'
   );
   await testSSR(
     <body>
@@ -346,7 +346,7 @@ test('valid phrasing content', async () => {
         <link rel="example" />
       </p>
     </body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body><p><link rel="example"/></p></body>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body><p><link rel="example"/></p></body>'
   );
   await testSSR(
     <body>
@@ -357,7 +357,7 @@ test('valid phrasing content', async () => {
         <img useMap="#my-map" src="/example.png" alt="Example" />
       </p>
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
         <p>
           <map name="my-map">
@@ -381,7 +381,7 @@ test('valid phrasing content', async () => {
         </svg>
       </p>
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
         <p>
           <svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -406,7 +406,7 @@ test('valid phrasing content', async () => {
         </math>
       </p>
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
         <p>
           <math>
@@ -427,51 +427,51 @@ test('valid phrasing content', async () => {
 test('events', async () => {
   await testSSR(
     <body onClick$={() => console.warn('hol')}>hola</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body on:click="/runtimeQRL#_">hola</body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body on:click="/runtimeQRL#_">hola</body></html>'
   );
   await testSSR(
     <body onClick$={[undefined, $(() => console.warn('hol'))]}>hola</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body on:click="/runtimeQRL#_">hola</body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body on:click="/runtimeQRL#_">hola</body></html>'
   );
   await testSSR(
     <body onClick$={[undefined, [$(() => console.warn('hol'))]]}>hola</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body on:click="/runtimeQRL#_">hola</body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body on:click="/runtimeQRL#_">hola</body></html>'
   );
   await testSSR(
     <body document:onClick$={() => console.warn('hol')}>hola</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body on-document:click="/runtimeQRL#_">hola</body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body on-document:click="/runtimeQRL#_">hola</body></html>'
   );
   await testSSR(
     <body window:onClick$={() => console.warn('hol')}>hola</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body on-window:click="/runtimeQRL#_">hola</body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body on-window:click="/runtimeQRL#_">hola</body></html>'
   );
   await testSSR(
     <body>
       <input onInput$={() => console.warn('hol')} />
     </body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body><input on:input="/runtimeQRL#_"></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body><input on:input="/runtimeQRL#_"></body></html>'
   );
 });
 
 test('innerHTML', async () => {
   await testSSR(
     <body dangerouslySetInnerHTML="<p>hola</p>"></body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body><p>hola</p></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body><p>hola</p></body></html>'
   );
   await testSSR(
     <body dangerouslySetInnerHTML=""></body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body></body></html>'
   );
   const Div = 'body' as any;
   await testSSR(
     <Div dangerouslySetInnerHTML={0}></Div>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body>0</body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body>0</body></html>'
   );
   await testSSR(
     <body>
       <script dangerouslySetInnerHTML="() => null"></script>
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
         <script>
           () => null
@@ -486,7 +486,7 @@ test('single complex children', async () => {
     <div>
       <p>hola</p>
     </div>,
-    '<container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦"><div><p>hola</p></div></container>',
+    '<container q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test" class="qc📦"><div><p>hola</p></div></container>',
     {
       containerTagName: 'container',
     }
@@ -496,7 +496,7 @@ test('single complex children', async () => {
       hola {2}
       <p>hola</p>
     </div>,
-    '<container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦"><div>hola 2<p>hola</p></div></container>',
+    '<container q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test" class="qc📦"><div>hola 2<p>hola</p></div></container>',
     {
       containerTagName: 'container',
     }
@@ -515,7 +515,7 @@ test('single multiple children', async () => {
       <li>7</li>
       <li>8</li>
     </ul>,
-    '<container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦"><ul><li>1</li><li>2</li><li>3</li><li>4</li><li>5</li><li>6</li><li>7</li><li>8</li></ul></container>',
+    '<container q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test" class="qc📦"><ul><li>1</li><li>2</li><li>3</li><li>4</li><li>5</li><li>6</li><li>7</li><li>8</li></ul></container>',
     {
       containerTagName: 'container',
     }
@@ -527,7 +527,7 @@ test('sanity', async () => {
     <body>
       <div>{`.rule > thing{}`}</div>
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
         <div>.rule &gt; thing{}</div>
       </body>
@@ -557,7 +557,7 @@ test('using fragment', async () => {
       </>
       <li>8</li>
     </ul>,
-    '<container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦"><ul><li>1</li><li>2</li><li>3</li><li>4</li><li>5</li><li>6</li><li>7</li><li>8</li></ul></container>',
+    '<container q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test" class="qc📦"><ul><li>1</li><li>2</li><li>3</li><li>4</li><li>5</li><li>6</li><li>7</li><li>8</li></ul></container>',
     {
       containerTagName: 'container',
     }
@@ -567,11 +567,11 @@ test('using fragment', async () => {
 test('using promises', async () => {
   await testSSR(
     <body>{Promise.resolve('hola')}</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body><!--qkssr-f-->hola</body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body><!--qkssr-f-->hola</body></html>'
   );
   await testSSR(
     <body>{Promise.resolve(<p>hola</p>)}</body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body><!--qkssr-f--><p>hola</p></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body><!--qkssr-f--><p>hola</p></body></html>'
   );
 
   await testSSR(
@@ -586,7 +586,7 @@ test('using promises', async () => {
       ))}
     </ul>,
     [
-      '<container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦">',
+      '<container q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test" class="qc📦">',
       '<ul>',
       '<!--qkssr-f-->',
       '<li>',
@@ -628,7 +628,7 @@ test('mixed children', async () => {
       ))}
     </ul>,
     `
-        <container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦">
+        <container q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test" class="qc📦">
         <ul>
         <li>0</li>
         <li>1</li>
@@ -656,7 +656,7 @@ test('DelayResource', async () => {
         <DelayResource text="thing" delay={10} />
       </ul>
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
     <body>
       <ul>
         <!--qv q:id=0 q:key=sX:-->
@@ -682,7 +682,7 @@ test('using promises with DelayResource', async () => {
         <DelayResource text="thing" delay={500} />
       </ul>
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
       <ul>
         <!--qkssr-f-->
@@ -700,7 +700,7 @@ test('using promises with DelayResource', async () => {
 test('using component', async () => {
   await testSSR(
     <MyCmp />,
-    `<container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦">
+    `<container q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test" class="qc📦">
       <!--qv q:id=0 q:key=sX:-->
       <section><div>MyCmp{}</div></section>
       <!--/qv-->
@@ -716,7 +716,7 @@ test('using component with key', async () => {
     <body>
       <MyCmp key="hola" />
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
         <!--qv q:id=0 q:key=sX:hola-->
         <section><div>MyCmp{}</div></section>
@@ -731,7 +731,7 @@ test('using element with key', async () => {
     <body>
       <div key="hola" />
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
         <div q:key="hola"></div>
       </body>
@@ -744,7 +744,7 @@ test('using element with key containing double quotes', async () => {
     <body>
       <div key={'"hola"'} />
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
         <div q:key="&quot;hola&quot;"></div>
       </body>
@@ -766,7 +766,7 @@ test('using component props', async () => {
       stuff
     </MyCmp>,
     `
-    <container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦">
+    <container q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test" class="qc📦">
       <!--qv q:id=0 q:key=sX:-->
       <section>
         <div>MyCmp{"id":"12","host:prop":"attribute","innerHTML":"123","dangerouslySetInnerHTML":"432","onClick":"lazy.js","prop":"12"}</div>
@@ -787,7 +787,7 @@ test('using component project content', async () => {
       <div>slot</div>
     </MyCmp>,
     `
-  <container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦">
+  <container q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test" class="qc📦">
     <!--qv q:id=0 q:key=sX:-->
     <section><div>MyCmp{}</div></section>
     <q:template q:slot hidden aria-hidden="true"><div>slot</div></q:template>
@@ -805,7 +805,7 @@ test('using complex component', async () => {
     <body>
       <MyCmpComplex></MyCmpComplex>
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
         <!--qv q:id=0 q:key=sX:-->
         <div on:click="/runtimeQRL#_" q:id="1">
@@ -822,7 +822,7 @@ test('using complex component with slot', async () => {
   await testSSR(
     <MyCmpComplex>Hola</MyCmpComplex>,
     `
-    <container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦">
+    <container q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test" class="qc📦">
       <!--qv q:id=0 q:key=sX:-->
       <div on:click="/runtimeQRL#_" q:id="1">
         <button on:click="/runtimeQRL#_">Click</button>
@@ -847,7 +847,7 @@ test('<head>', async () => {
       </>
     </head>,
     `
-  <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+  <html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
     <head q:head>
       <title q:head>hola</title>
       <meta q:head>
@@ -870,7 +870,7 @@ test('named slots', async () => {
       default
     </NamedSlot>,
     `
-    <container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦">
+    <container q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test" class="qc📦">
       <!--qv q:id=0 q:key=sX:-->
       <div>
         <!--qv q:s q:sref=0 q:key=start-->
@@ -904,7 +904,7 @@ test('nested slots', async () => {
       </SimpleSlot>
     </SimpleSlot>,
     `
-    <container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦">
+    <container q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test" class="qc📦">
       <!--qv q:id=0 q:key=sX:-->
         <div id="root">
           Before root
@@ -943,7 +943,7 @@ test('mixes slots', async () => {
   await testSSR(
     <MixedSlot>Content</MixedSlot>,
     `
-    <container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦">
+    <container q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test" class="qc📦">
       <!--qv q:id=0 q:key=sX:-->
       <!--qv q:id=1 q:key=sX:-->
         <div id="1">Before 1
@@ -968,7 +968,7 @@ test('component RenderSignals()', async () => {
   await testSSR(
     <RenderSignals />,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <!--qv q:id=0 q:key=sX:-->
       <head q:head>
         <title q:head>value</title>
@@ -990,7 +990,7 @@ test('component useContextProvider()', async () => {
     <Context>
       <ContextConsumer />
     </Context>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <!--qv q:id=0 q:key=sX:-->
         <!--qv q:s q:sref=0 q:key=-->
           <!--qv q:id=1 q:key=sX:-->hello bye<!--/qv-->
@@ -1004,7 +1004,7 @@ test('component useContextProvider()', async () => {
 test('component useContextProvider() + useContext()', async () => {
   await testSSR(
     <ContextWithValueAndUse value="hello bye" />,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <!--qv q:id=0 q:key=sX:-->hello bye<!--/qv-->
     </html>`
   );
@@ -1020,7 +1020,7 @@ test('component slotted context', async () => {
       </VariadicContext>
     </body>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
         <!--qv q:id=0 q:key=sX:-->
         <!--qv q:id=1 q:key=sX:-->
@@ -1061,7 +1061,7 @@ test('component useOn()', async () => {
     <body>
       <Events />
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
       <!--qv q:id=0 q:key=sX:-->
       <div on:click="/runtimeQRL#_\n/runtimeQRL#_" on-window:click="/runtimeQRL#_" on-document:click="/runtimeQRL#_"></div>
@@ -1077,7 +1077,7 @@ test('component useOn([array])', async () => {
       <UseOnMultiple />
     </body>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
         <!--qv q:id=0 q:key=sX:-->
         <div on:click="/runtimeQRL#_\n/runtimeQRL#_"
@@ -1100,7 +1100,7 @@ test('component useStyles()', async () => {
         <Styles />
       </body>
     </>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
         <!--qv q:id=0 q:key=sX:-->
           <style q:style="17nc-0" hidden>.host {color: red}</style>
@@ -1123,7 +1123,7 @@ test('component useStylesScoped()', async () => {
       </body>
     </>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
         <!--qv q:sstyle=⭐️1d-0|⭐️1e-1 q:id=0 q:key=sX:-->
         <style q:style="1d-0" hidden>
@@ -1179,7 +1179,7 @@ test('component useStylesScoped() + slot', async () => {
       <RootStyles></RootStyles>
     </>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <!--qv q:sstyle=⭐️lkei4s-0 q:id=0 q:key=sX:-->
       <body class="⭐️lkei4s-0">
         <!--qv q:sstyle=⭐️tdblg1-0 q:id=1 q:key=sX:-->
@@ -1207,7 +1207,7 @@ test('component useStylesScoped() + slot', async () => {
 test('component useBrowserVisibleTask()', async () => {
   await testSSR(
     <UseClientEffect />,
-    `<container q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class="qc📦">
+    `<container q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test" class="qc📦">
       <!--qv q:id=0 q:key=sX:-->
         <div on:qvisible="/runtimeQRL#_[0]
 /runtimeQRL#_[1]" q:id="1"></div>
@@ -1225,7 +1225,7 @@ test('component useBrowserVisibleTask() without elements', async () => {
       <UseEmptyClientEffect />
     </body>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
         <!--qv q:id=0 q:key=sX:-->
         Hola
@@ -1244,7 +1244,7 @@ test('component useBrowserVisibleTask() inside <head>', async () => {
       <UseClientEffect as="style" />
     </head>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <head q:head>
         <!--qv q:id=0 q:key=sX:-->
         Hola
@@ -1263,7 +1263,7 @@ test('nested html', async () => {
     <>
       <body></body>
     </>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body></body></html>`
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body></body></html>`
   );
 });
 
@@ -1273,7 +1273,7 @@ test('root html component', async () => {
       <link></link>
     </HeadCmp>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <!--qv q:id=0 q:key=sX:-->
       <head on-document:qinit="/runtimeQRL#_[0]" q:id="1" q:head>
         <title q:head>hola</title>
@@ -1320,7 +1320,7 @@ test('containerAttributes', async () => {
       <body></body>
     </>,
     `
-    <html prefix="something" q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    <html prefix="something" q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
      <body></body>
     </html>
     `,
@@ -1335,7 +1335,7 @@ test('containerAttributes', async () => {
       <div></div>
     </>,
     `
-    <app prefix="something" q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test" class='qc📦 thing'>
+    <app prefix="something" q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test" class='qc📦 thing'>
      <div></div>
     </app>
     `,
@@ -1355,7 +1355,7 @@ test('custom q:render', async () => {
       <body></body>
     </>,
     `
-    <html q:render="static-ssr-dev" q:container="paused" q:version="dev" q:manifest-hash="test">
+    <html q:render="static-ssr-dev" q:container="paused" q:version="dev" q:base="" q:manifest-hash="test">
      <body></body>
     </html>
     `,
@@ -1370,7 +1370,7 @@ test('custom q:render', async () => {
       <body></body>
     </>,
     `
-    <html q:render="ssr-dev" q:container="paused" q:version="dev" q:manifest-hash="test">
+    <html q:render="ssr-dev" q:container="paused" q:version="dev" q:base="" q:manifest-hash="test">
      <body></body>
     </html>
     `,
@@ -1399,7 +1399,7 @@ test('ssr marks', async () => {
         <li>3</li>
       ))}
     </body>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
         <!--qkssr-f-->
         <li>1</li>
@@ -1422,7 +1422,7 @@ test('ssr raw', async () => {
       <SSRRaw data="<div>hello</div>" />
     </body>,
     `
-  <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+  <html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
     <body>
       <div>hello</div>
     </body>
@@ -1436,7 +1436,7 @@ test('html fragment', async () => {
       <HTMLFragment dangerouslySetInnerHTML="<div>hello</div>" />
     </body>,
     `
-  <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+  <html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
     <body>
       <!--qv-->
       <div>hello</div>
@@ -1489,7 +1489,7 @@ test('null component', async () => {
     <>
       <NullCmp />
     </>,
-    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><!--qv q:id=0 q:key=sX:--><!--/qv--></html>`
+    `<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><!--qv q:id=0 q:key=sX:--><!--/qv--></html>`
   );
 });
 
@@ -1499,7 +1499,7 @@ test('cleanse attribute name', async () => {
   };
   await testSSR(
     <body {...o}></body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body></body></html>'
   );
 });
 
@@ -1509,7 +1509,7 @@ test('cleanse class attribute', async () => {
   };
   await testSSR(
     <body {...o}></body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body class="&quot;><script>alert(&quot;ಠ~ಠ&quot;)</script>"></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body class="&quot;><script>alert(&quot;ಠ~ಠ&quot;)</script>"></body></html>'
   );
 });
 
@@ -1519,7 +1519,7 @@ test('class emoji valid', async () => {
   };
   await testSSR(
     <body {...o}></body>,
-    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test"><body class="package📦"></body></html>'
+    '<html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test"><body class="package📦"></body></html>'
   );
 });
 
@@ -1531,7 +1531,7 @@ test('issue 4283', async () => {
       </Issue4283>
     </body>,
     `
-    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:manifest-hash="test">
+    <html q:container="paused" q:version="dev" q:render="ssr-dev" q:base="" q:manifest-hash="test">
       <body>
         <!--qv q:id=0 q:key=sX:-->
         <!--qv q:id=1 q:key=sX:-->

--- a/packages/qwik/src/core/util/markers.ts
+++ b/packages/qwik/src/core/util/markers.ts
@@ -19,6 +19,12 @@ export const QSlotS = 'q:s';
 export const QStyle = 'q:style';
 export const QScopedStyle = 'q:sstyle';
 export const QCtxAttr = 'q:ctx';
+export const QManifestHash = 'q:manifest-hash';
+export const QFuncsSuffix = ':qFuncs';
+
+export const getQFuncs = (document: Document, hash: string): Function[] => {
+  return (document as any)[hash + QFuncsSuffix] || [];
+};
 
 export const QLocaleAttr = 'q:locale';
 export const QContainerAttr = 'q:container';

--- a/packages/qwik/src/core/util/markers.ts
+++ b/packages/qwik/src/core/util/markers.ts
@@ -20,10 +20,11 @@ export const QStyle = 'q:style';
 export const QScopedStyle = 'q:sstyle';
 export const QCtxAttr = 'q:ctx';
 export const QManifestHash = 'q:manifest-hash';
-export const QFuncsSuffix = ':qFuncs';
+export const QInstance = 'q:instance';
+export const QFuncsPrefix = 'qFuncs_';
 
 export const getQFuncs = (document: Document, hash: string): Function[] => {
-  return (document as any)[hash + QFuncsSuffix] || [];
+  return (document as any)[QFuncsPrefix + hash] || [];
 };
 
 export const QLocaleAttr = 'q:locale';

--- a/packages/qwik/src/qwikloader.ts
+++ b/packages/qwik/src/qwikloader.ts
@@ -110,7 +110,8 @@ export const qwikLoader = (
         const isSync = qrl.startsWith('#');
         const eventData = { qBase, qManifest, qVersion, href, symbol, element, reqTime };
         if (isSync) {
-          handler = (container.qFuncs || [])[Number.parseInt(symbol)];
+          const hash = container.getAttribute('q:manifest-hash')!;
+          handler = ((doc as any)[hash + ':funcs'] || [])[Number.parseInt(symbol)];
           if (!handler) {
             importError = 'sync';
             error = new Error('sync handler error for symbol: ' + symbol);

--- a/packages/qwik/src/qwikloader.ts
+++ b/packages/qwik/src/qwikloader.ts
@@ -110,8 +110,8 @@ export const qwikLoader = (
         const isSync = qrl.startsWith('#');
         const eventData = { qBase, qManifest, qVersion, href, symbol, element, reqTime };
         if (isSync) {
-          const hash = container.getAttribute('q:manifest-hash')!;
-          handler = ((doc as any)[hash + ':funcs'] || [])[Number.parseInt(symbol)];
+          const hash = container.getAttribute('q:instance')!;
+          handler = ((doc as any)['qFuncs_' + hash] || [])[Number.parseInt(symbol)];
           if (!handler) {
             importError = 'sync';
             error = new Error('sync handler error for symbol: ' + symbol);

--- a/packages/qwik/src/server/prefetch-implementation.ts
+++ b/packages/qwik/src/server/prefetch-implementation.ts
@@ -8,6 +8,7 @@ import {
 import type { PrefetchImplementation, PrefetchResource, PrefetchStrategy } from './types';
 
 export function applyPrefetchImplementation(
+  base: string,
   prefetchStrategy: PrefetchStrategy | undefined,
   prefetchResources: PrefetchResource[],
   nonce?: string
@@ -19,7 +20,7 @@ export function applyPrefetchImplementation(
   const prefetchNodes: JSXNode[] = [];
 
   if (prefetchImpl.prefetchEvent === 'always') {
-    prefetchUrlsEvent(prefetchNodes, prefetchResources, nonce);
+    prefetchUrlsEvent(base, prefetchNodes, prefetchResources, nonce);
   }
 
   if (prefetchImpl.linkInsert === 'html-append') {
@@ -40,6 +41,7 @@ export function applyPrefetchImplementation(
 }
 
 function prefetchUrlsEvent(
+  base: string,
   prefetchNodes: JSXNode[],
   prefetchResources: PrefetchResource[],
   nonce?: string
@@ -58,7 +60,7 @@ function prefetchUrlsEvent(
     jsx('script', {
       'q:type': 'prefetch-bundles',
       dangerouslySetInnerHTML:
-        prefetchUrlsEventScript(prefetchResources) +
+        prefetchUrlsEventScript(base, prefetchResources) +
         `document.dispatchEvent(new CustomEvent('qprefetch', {detail:{links: [location.pathname]}}))`,
       nonce,
     })

--- a/packages/qwik/src/server/prefetch-utils.ts
+++ b/packages/qwik/src/server/prefetch-utils.ts
@@ -19,24 +19,13 @@ export function workerFetchScript() {
   return s;
 }
 
-export function prefetchUrlsEventScript(prefetchResources: PrefetchResource[]) {
+export function prefetchUrlsEventScript(base: string, prefetchResources: PrefetchResource[]) {
   const data: QPrefetchData = {
     bundles: flattenPrefetchResources(prefetchResources).map((u) => u.split('/').pop()!),
   };
-  return `(${PREFETCH_BUNDLES_CODE})(
-    document.currentScript.closest('[q\\\\:container]'),
-    window.qwikPrefetchSW||(window.qwikPrefetchSW=[]),
-    ${JSON.stringify(data.bundles!)}
-  );`;
+  const args = ['prefetch', base, data.bundles!].map((x) => JSON.stringify(x)).join(',');
+  return `window.qwikPrefetchSW||(window.qwikPrefetchSW=[]).push(${args});`;
 }
-
-const PREFETCH_BUNDLES_CODE = /*#__PURE__*/ ((
-  qc: HTMLElement, // QwikContainer Element
-  q: Array<any[]>, // Queue of messages to send to the service worker.
-  bundles: string // Bundles to prefetch
-) => {
-  q.push(['prefetch', qc.getAttribute('q:base'), ...bundles]);
-}).toString();
 
 export function flattenPrefetchResources(prefetchResources: PrefetchResource[]) {
   const urls: string[] = [];

--- a/packages/qwik/src/server/render.ts
+++ b/packages/qwik/src/server/render.ts
@@ -17,6 +17,7 @@ import type { ResolvedManifest, SymbolMapper } from '../optimizer/src/types';
 import { getValidManifest } from '../optimizer/src/manifest';
 import { applyPrefetchImplementation } from './prefetch-implementation';
 import type { QContext } from '../core/state/context';
+import { QManifestHash } from '../core/util/markers';
 
 const DOCTYPE = '<!DOCTYPE html>';
 
@@ -181,8 +182,10 @@ export async function renderToStream(
       if (opts.prefetchStrategy !== null) {
         // skip prefetch implementation if prefetchStrategy === null
         const prefetchResources = getPrefetchResources(snapshotResult, opts, resolvedManifest);
+        const base = containerAttributes['q:base']!;
         if (prefetchResources.length > 0) {
           const prefetchImpl = applyPrefetchImplementation(
+            base,
             opts.prefetchStrategy,
             prefetchResources,
             opts.serverData?.nonce
@@ -201,10 +204,11 @@ export async function renderToStream(
         })
       );
       if (snapshotResult.funcs.length > 0) {
+        const hash = containerAttributes[QManifestHash];
         children.push(
           jsx('script', {
             'q:func': 'qwik/json',
-            dangerouslySetInnerHTML: serializeFunctions(snapshotResult.funcs),
+            dangerouslySetInnerHTML: serializeFunctions(hash, snapshotResult.funcs),
             nonce: opts.serverData?.nonce,
           })
         );
@@ -243,7 +247,7 @@ export async function renderToStream(
       snapshotTime = snapshotTimer();
       return jsx(Fragment, { children });
     },
-    manifestHash: resolvedManifest?.manifest.manifestHash || 'dev',
+    manifestHash: resolvedManifest?.manifest.manifestHash || 'dev' + hash(),
   });
 
   // End of container
@@ -270,6 +274,10 @@ export async function renderToStream(
     _symbols: renderSymbols,
   };
   return result;
+}
+
+function hash() {
+  return Math.random().toString(36).slice(2);
 }
 
 /**
@@ -349,8 +357,8 @@ function collectRenderSymbols(renderSymbols: string[], elements: QContext[]) {
   }
 }
 
-export const Q_FUNCS_PREFIX = 'document.currentScript.closest("[q\\\\:container]").qFuncs=';
+export const Q_FUNCS_PREFIX = 'document["HASH:qFuncs"]=';
 
-function serializeFunctions(funcs: string[]) {
-  return Q_FUNCS_PREFIX + `[${funcs.join(',\n')}]`;
+function serializeFunctions(hash: string, funcs: string[]) {
+  return Q_FUNCS_PREFIX.replace('HASH', hash) + `[${funcs.join(',\n')}]`;
 }

--- a/packages/qwik/src/server/render.ts
+++ b/packages/qwik/src/server/render.ts
@@ -17,7 +17,7 @@ import type { ResolvedManifest, SymbolMapper } from '../optimizer/src/types';
 import { getValidManifest } from '../optimizer/src/manifest';
 import { applyPrefetchImplementation } from './prefetch-implementation';
 import type { QContext } from '../core/state/context';
-import { QManifestHash } from '../core/util/markers';
+import { QInstance } from '../core/util/markers';
 
 const DOCTYPE = '<!DOCTYPE html>';
 
@@ -204,7 +204,7 @@ export async function renderToStream(
         })
       );
       if (snapshotResult.funcs.length > 0) {
-        const hash = containerAttributes[QManifestHash];
+        const hash = containerAttributes[QInstance];
         children.push(
           jsx('script', {
             'q:func': 'qwik/json',
@@ -357,7 +357,7 @@ function collectRenderSymbols(renderSymbols: string[], elements: QContext[]) {
   }
 }
 
-export const Q_FUNCS_PREFIX = 'document["HASH:qFuncs"]=';
+export const Q_FUNCS_PREFIX = 'document["qFuncs_HASH"]=';
 
 function serializeFunctions(hash: string, funcs: string[]) {
   return Q_FUNCS_PREFIX.replace('HASH', hash) + `[${funcs.join(',\n')}]`;

--- a/packages/qwik/src/testing/element-fixture.ts
+++ b/packages/qwik/src/testing/element-fixture.ts
@@ -42,8 +42,9 @@ export class ElementFixture {
       assertDefined(this.host, 'host element must be defined');
       this.host.querySelectorAll('script[q\\:func="qwik/json"]').forEach((script) => {
         const code = script.textContent;
-        if (code?.startsWith(Q_FUNCS_PREFIX)) {
-          const qFuncs = eval(code.substring(Q_FUNCS_PREFIX.length));
+        if (code?.match(Q_FUNCS_PREFIX)) {
+          const equal = code.indexOf('=');
+          const qFuncs = eval(code.substring(equal + 1));
           const container = this.host.closest(QContainerSelector);
           (container as any as { qFuncs?: Function[] }).qFuncs = qFuncs;
         }
@@ -98,7 +99,7 @@ export async function trigger(
 
 const PREVENT_DEFAULT = 'preventdefault:';
 const STOP_PROPAGATION = 'stoppropagation:';
-const Q_FUNCS_PREFIX = 'document.currentScript.closest("[q\\\\:container]").qFuncs=';
+const Q_FUNCS_PREFIX = /document.qdata\["(.+):qFuncs"\]=/;
 const QContainerSelector = '[q\\:container]';
 
 /**

--- a/packages/qwik/src/testing/element-fixture.ts
+++ b/packages/qwik/src/testing/element-fixture.ts
@@ -99,7 +99,7 @@ export async function trigger(
 
 const PREVENT_DEFAULT = 'preventdefault:';
 const STOP_PROPAGATION = 'stoppropagation:';
-const Q_FUNCS_PREFIX = /document.qdata\["(.+):qFuncs"\]=/;
+const Q_FUNCS_PREFIX = /document.qdata\["qFuncs_(.+)"\]=/;
 const QContainerSelector = '[q\\:container]';
 
 /**


### PR DESCRIPTION
`currentScript` is not available in shadow dom. For this reason we can't use it. This change removes all references to `currentScript`

The biggest change is that the `qFuncs` are no longer written to the container element but rather to the document. Because there is only one document the `qFuncs` property now includes the `container` `q:manifest-hash` to distinguish between different containers.

