### PR TITLE
fix(repl): code display in repl output

### DIFF
--- a/packages/docs/src/repl/repl-options.tsx
+++ b/packages/docs/src/repl/repl-options.tsx
@@ -70,7 +70,8 @@ const StoreOption = (props: StoreOptionProps) => {
 
 export const BUILD_MODE_OPTIONS = ['development', 'production'];
 
-export const ENTRY_STRATEGY_OPTIONS = ['component', 'hook', 'single', 'smart', 'inline', 'hoist'];
+// We don't support `inline` and `hoist` for client bundles
+export const ENTRY_STRATEGY_OPTIONS = ['component', 'hook', 'single', 'smart'];
 
 interface StoreOptionProps {
   label: string;

--- a/packages/docs/src/repl/repl-output-modules.tsx
+++ b/packages/docs/src/repl/repl-output-modules.tsx
@@ -1,14 +1,12 @@
-import { $, useStore, component$ } from '@builder.io/qwik';
+import { $, component$, useSignal } from '@builder.io/qwik';
 import { CodeBlock } from '../components/code-block/code-block';
-import type { PathInView, ReplModuleOutput } from './types';
-const FILE_MODULE_DIV_ID = 'file-modules-client-buisness';
+import type { ReplModuleOutput } from './types';
+const FILE_MODULE_DIV_ID = 'file-modules-client-modules';
 
 export const ReplOutputModules = component$(({ outputs, headerText }: ReplOutputModulesProps) => {
-  const store = useStore<PathInView>({
-    selectedPath: outputs.length ? outputs[0].path : '',
-  });
+  const selectedPath = useSignal(outputs.length ? outputs[0].path : '');
   const pathInView$ = $((path: string) => {
-    store.selectedPath = path;
+    selectedPath.value = path;
   });
   return (
     <div class="output-result output-modules">
@@ -20,44 +18,24 @@ export const ReplOutputModules = component$(({ outputs, headerText }: ReplOutput
               <a
                 href="#"
                 onClick$={() => {
-                  const fileItem = document.querySelector(`[data-file-item="${i}"]`);
+                  const fileItem = document.querySelector(`[data-output-item="${i}"]`);
                   if (fileItem) {
-                    fileItem.scrollIntoView();
+                    fileItem.scrollIntoView({ behavior: 'smooth' });
                   }
                 }}
-                class={{
-                  'in-view': store.selectedPath && store.selectedPath === o.path,
-                  '!hidden': true,
-                  'md:!block': true,
-                }}
+                class={{ 'in-view': selectedPath.value === o.path }}
                 preventdefault:click
                 key={o.path}
               >
                 {o.path}
               </a>
-              <div class="block md:hidden">
-                <div class="file-item" data-file-item={i} key={o.path}>
-                  <div class="file-info">
-                    <span>{o.path}</span>
-                    {o.size ? <span class="file-size">({o.size})</span> : null}
-                  </div>
-                  <div class="file-text">
-                    <CodeBlock
-                      pathInView$={pathInView$}
-                      path={o.path}
-                      code={o.code}
-                      observerRootId={FILE_MODULE_DIV_ID}
-                    />
-                  </div>
-                </div>
-              </div>
             </div>
           ))}
         </div>
       </div>
       <div class="file-modules" id={FILE_MODULE_DIV_ID}>
         {outputs.map((o, i) => (
-          <div class="file-item" data-file-item={i} key={o.path}>
+          <div class="file-item" data-output-item={i} key={o.path}>
             <div class="file-info">
               <span>{o.path}</span>
               {o.size ? <span class="file-size">({o.size})</span> : null}

--- a/packages/docs/src/repl/repl-output-symbols.tsx
+++ b/packages/docs/src/repl/repl-output-symbols.tsx
@@ -1,15 +1,12 @@
 import type { TransformModule } from '@builder.io/qwik/optimizer';
 import { CodeBlock } from '../components/code-block/code-block';
-import { $, useStore, component$ } from '@builder.io/qwik';
-import type { PathInView } from './types';
+import { $, component$, useSignal } from '@builder.io/qwik';
 const FILE_MODULE_DIV_ID = 'file-modules-symbol';
 
 export const ReplOutputSymbols = component$(({ outputs }: ReplOutputSymbolsProps) => {
-  const store = useStore<PathInView>({
-    selectedPath: outputs.length ? outputs[0].path : '',
-  });
+  const selectedPath = useSignal(outputs.length ? outputs[0].path : '');
   const pathInView$ = $((path: string) => {
-    store.selectedPath = path;
+    selectedPath.value = path;
   });
 
   return (
@@ -22,45 +19,26 @@ export const ReplOutputSymbols = component$(({ outputs }: ReplOutputSymbolsProps
               <a
                 href="#"
                 onClick$={() => {
-                  const fileItem = document.querySelector(`[data-file-item="${i}"]`);
+                  const fileItem = document.querySelector(`[data-symbol-item="${i}"]`);
                   if (fileItem) {
-                    store.selectedPath = o.path;
-                    fileItem.scrollIntoView();
+                    selectedPath.value = o.path;
+                    fileItem.scrollIntoView({ behavior: 'smooth' });
                   }
                 }}
-                class={{
-                  'in-view': store.selectedPath && store.selectedPath === o.path,
-                  '!hidden': true,
-                  'md:!block': true,
-                }}
+                class={{ 'in-view': selectedPath.value === o.path }}
                 preventdefault:click
               >
                 {o.hook?.canonicalFilename}
               </a>
-              <div class="block md:hidden">
-                <div class="file-item" data-file-item={i} key={o.path}>
-                  <div class="file-info">
-                    <span>{o.hook?.canonicalFilename}</span>
-                  </div>
-                  <div class="file-text">
-                    <CodeBlock
-                      pathInView$={pathInView$}
-                      path={o.path}
-                      code={o.code}
-                      observerRootId={FILE_MODULE_DIV_ID}
-                    />
-                  </div>
-                </div>
-              </div>
             </div>
           ))}
         </div>
       </div>
-      <div class="file-modules hidden md:block" id={FILE_MODULE_DIV_ID}>
+      <div class="file-modules" id={FILE_MODULE_DIV_ID}>
         {outputs
           .filter((o) => !!o.hook)
           .map((o, i) => (
-            <div class="file-item" data-file-item={i} key={o.path}>
+            <div class="file-item" data-symbol-item={i} key={o.path}>
               <div class="file-info">
                 <span>{o.hook?.canonicalFilename}</span>
               </div>

--- a/packages/docs/src/repl/repl-output-update.ts
+++ b/packages/docs/src/repl/repl-output-update.ts
@@ -1,14 +1,30 @@
 import type { ReplResult, ReplStore } from './types';
 
+// TODO fix useStore to recursively notify subscribers
+const deepUpdate = (prev: any, next: any) => {
+  for (const key in next) {
+    if (prev[key] && typeof next[key] === 'object' && typeof prev[key] === 'object') {
+      deepUpdate(prev[key], next[key]);
+    } else {
+      prev[key] = next[key];
+    }
+  }
+  for (const key in prev) {
+    if (!(key in next)) {
+      delete prev[key];
+    }
+  }
+};
+
 export const updateReplOutput = async (store: ReplStore, result: ReplResult) => {
   store.diagnostics = result.diagnostics;
 
   if (store.diagnostics.length === 0) {
     store.html = result.html;
-    store.transformedModules = result.transformedModules;
-    store.clientBundles = result.clientBundles;
-    store.ssrModules = result.ssrModules;
-    store.events = result.events;
+    deepUpdate(store.transformedModules, result.transformedModules);
+    deepUpdate(store.clientBundles, result.clientBundles);
+    deepUpdate(store.ssrModules, result.ssrModules);
+    deepUpdate(store.events, result.events);
 
     if (store.selectedOutputPanel === 'diagnostics' && store.monacoDiagnostics.length === 0) {
       store.selectedOutputPanel = 'app';

--- a/packages/docs/src/repl/repl.css
+++ b/packages/docs/src/repl/repl.css
@@ -219,6 +219,10 @@
 .output-modules {
   display: grid;
   grid-template-areas: 'repl-file-tree repl-file-text';
+  @media screen and (max-width: 768px) {
+    grid-template-areas: 'repl-file-tree' 'repl-file-text';
+  }
+
   height: 100%;
   overflow: hidden;
   @apply sm-grid-column;

--- a/packages/docs/src/repl/types.ts
+++ b/packages/docs/src/repl/types.ts
@@ -129,7 +129,3 @@ export type OutputPanel =
   | 'diagnostics';
 
 export type OutputDetail = 'options' | 'console';
-
-export interface PathInView {
-  selectedPath: string;
-}

--- a/packages/docs/src/repl/worker/repl-server.ts
+++ b/packages/docs/src/repl/worker/repl-server.ts
@@ -1,6 +1,6 @@
 /**
  * - Source for url: "/repl/~repl-server-host.js"
- * - Created from the route: "src/routes/repl/~repl-server.js/entry.ts"
+ * - Created from the route: "src/routes/repl/~repl-server-host.js/entry.ts"
  * - Script executed from url: "/repl/~repl-server-host.html"
  * - Public static html source file: "public/repl/~repl-server-host.html"
  */


### PR DESCRIPTION
- click to file works again
- don't duplicate code DOM elements
- in mobile, put file paths at the top

And most notably:
- store now deeply updates so that code changes update the output
