### PR TITLE
fix(docs): update valibot snippet

### DIFF
--- a/packages/docs/src/routes/demo/integration/modular-forms/index.tsx
+++ b/packages/docs/src/routes/demo/integration/modular-forms/index.tsx
@@ -9,12 +9,12 @@ import * as v from 'valibot';
 const LoginSchema = v.object({
   email: v.pipe(
     v.string(),
-    v.minLength(1, 'Please enter your email.'),
+    v.nonEmpty('Please enter your email.'),
     v.email('The email address is badly formatted.')
   ),
   password: v.pipe(
     v.string(),
-    v.minLength(1, 'Please enter your password.'),
+    v.nonEmpty('Please enter your password.'),
     v.minLength(8, 'Your password must have 8 characters or more.')
   ),
 });

--- a/packages/docs/src/routes/demo/integration/modular-forms/index.tsx
+++ b/packages/docs/src/routes/demo/integration/modular-forms/index.tsx
@@ -4,20 +4,22 @@ import { $, component$, type QRL } from '@builder.io/qwik';
 import { routeLoader$ } from '@builder.io/qwik-city';
 import type { InitialValues, SubmitHandler } from '@modular-forms/qwik';
 import { formAction$, useForm, valiForm$ } from '@modular-forms/qwik';
-import { email, type Input, minLength, object, string } from 'valibot';
+import * as v from 'valibot';
 
-const LoginSchema = object({
-  email: string([
-    minLength(1, 'Please enter your email.'),
-    email('The email address is badly formatted.'),
-  ]),
-  password: string([
-    minLength(1, 'Please enter your password.'),
-    minLength(8, 'Your password must have 8 characters or more.'),
-  ]),
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.minLength(1, 'Please enter your email.'),
+    v.email('The email address is badly formatted.'),
+  ),
+  password: v.pipe(
+    v.string(),
+    v.minLength(1, 'Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.'),
+  ),
 });
 
-type LoginForm = Input<typeof LoginSchema>;
+type LoginForm = v.InferInput<typeof LoginSchema>;
 
 export const useFormLoader = routeLoader$<InitialValues<LoginForm>>(() => ({
   email: '',

--- a/packages/docs/src/routes/demo/integration/modular-forms/index.tsx
+++ b/packages/docs/src/routes/demo/integration/modular-forms/index.tsx
@@ -10,12 +10,12 @@ const LoginSchema = v.object({
   email: v.pipe(
     v.string(),
     v.minLength(1, 'Please enter your email.'),
-    v.email('The email address is badly formatted.'),
+    v.email('The email address is badly formatted.')
   ),
   password: v.pipe(
     v.string(),
     v.minLength(1, 'Please enter your password.'),
-    v.minLength(8, 'Your password must have 8 characters or more.'),
+    v.minLength(8, 'Your password must have 8 characters or more.')
   ),
 });
 

--- a/packages/docs/src/routes/docs/integrations/modular-forms/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/modular-forms/index.mdx
@@ -38,20 +38,22 @@ type LoginForm = {
 Since Modular Forms supports [Valibot](https://valibot.dev/) and [Zod](https://zod.dev/) for input validation, you can optionally derive the type definition from a schema.
 
 ```ts
-import { email, type InferOutput, minLength, object, string } from 'valibot';
+import * as v from 'valibot';
 
-const LoginSchema = object({
-  email: string([
-    minLength(1, 'Please enter your email.'),
-    email('The email address is badly formatted.'),
-  ]),
-  password: string([
-    minLength(1, 'Please enter your password.'),
-    minLength(8, 'Your password must have 8 characters or more.'),
-  ]),
+const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.minLength(1, 'Please enter your email'),
+    v.email('he email address is badly formatted'),
+  ),
+  password: v.pipe(
+    v.string(),
+    v.minLength(1, 'Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.'),
+  ),
 });
 
-type LoginForm = InferOutput<typeof LoginSchema>;
+type LoginForm = v.InferInput<typeof LoginSchema>;
 ```
 
 If you're wondering why this guide favors Valibot over Zod, I recommend reading this [announcement post](https://www.builder.io/blog/introducing-valibot).
@@ -183,20 +185,22 @@ import { $, component$, type QRL } from '@builder.io/qwik';
 import { routeLoader$ } from '@builder.io/qwik-city';
 import type { InitialValues, SubmitHandler } from '@modular-forms/qwik';
 import { formAction$, useForm, valiForm$ } from '@modular-forms/qwik';
-import { email, type InferOutput, minLength, object, string } from 'valibot';
+import * as v from 'valibot';
 
-const LoginSchema = object({
-  email: string([
-    minLength(1, 'Please enter your email.'),
-    email('The email address is badly formatted.'),
-  ]),
-  password: string([
-    minLength(1, 'Please enter your password.'),
-    minLength(8, 'Your password must have 8 characters or more.'),
-  ]),
+export const LoginSchema = v.object({
+  email: v.pipe(
+    v.string(),
+    v.minLength(1, 'Please enter your email'),
+    v.email('The email address is badly formatted'),
+  ),
+  password: v.pipe(
+    v.string(),
+    v.minLength(1, 'Please enter your password.'),
+    v.minLength(8, 'Your password must have 8 characters or more.'),
+  ),
 });
 
-type LoginForm = InferOutput<typeof LoginSchema>;
+type LoginForm = v.InferInput<typeof LoginSchema>;
 
 export const useFormLoader = routeLoader$<InitialValues<LoginForm>>(() => ({
   email: '',

--- a/packages/docs/src/routes/docs/integrations/modular-forms/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/modular-forms/index.mdx
@@ -43,8 +43,8 @@ import * as v from 'valibot';
 const LoginSchema = v.object({
   email: v.pipe(
     v.string(),
-    v.minLength(1, 'Please enter your email'),
-    v.email('he email address is badly formatted'),
+    v.minLength(1, 'Please enter your email.'),
+    v.email('he email address is badly formatted.'),
   ),
   password: v.pipe(
     v.string(),
@@ -187,11 +187,11 @@ import type { InitialValues, SubmitHandler } from '@modular-forms/qwik';
 import { formAction$, useForm, valiForm$ } from '@modular-forms/qwik';
 import * as v from 'valibot';
 
-export const LoginSchema = v.object({
+const LoginSchema = v.object({
   email: v.pipe(
     v.string(),
-    v.minLength(1, 'Please enter your email'),
-    v.email('The email address is badly formatted'),
+    v.minLength(1, 'Please enter your email.'),
+    v.email('The email address is badly formatted.'),
   ),
   password: v.pipe(
     v.string(),

--- a/packages/docs/src/routes/docs/integrations/modular-forms/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/modular-forms/index.mdx
@@ -43,12 +43,12 @@ import * as v from 'valibot';
 const LoginSchema = v.object({
   email: v.pipe(
     v.string(),
-    v.minLength(1, 'Please enter your email.'),
+    v.nonEmpty('Please enter your email.'),
     v.email('he email address is badly formatted.'),
   ),
   password: v.pipe(
     v.string(),
-    v.minLength(1, 'Please enter your password.'),
+    v.nonEmpty('Please enter your password.'),
     v.minLength(8, 'Your password must have 8 characters or more.'),
   ),
 });
@@ -190,12 +190,12 @@ import * as v from 'valibot';
 const LoginSchema = v.object({
   email: v.pipe(
     v.string(),
-    v.minLength(1, 'Please enter your email.'),
+    v.nonEmpty('Please enter your email.'),
     v.email('The email address is badly formatted.'),
   ),
   password: v.pipe(
     v.string(),
-    v.minLength(1, 'Please enter your password.'),
+    v.nonEmpty('Please enter your password.'),
     v.minLength(8, 'Your password must have 8 characters or more.'),
   ),
 });

--- a/packages/docs/src/routes/docs/integrations/modular-forms/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/modular-forms/index.mdx
@@ -38,7 +38,7 @@ type LoginForm = {
 Since Modular Forms supports [Valibot](https://valibot.dev/) and [Zod](https://zod.dev/) for input validation, you can optionally derive the type definition from a schema.
 
 ```ts
-import { email, type Input, minLength, object, string } from 'valibot';
+import { email, type InferOutput, minLength, object, string } from 'valibot';
 
 const LoginSchema = object({
   email: string([
@@ -51,7 +51,7 @@ const LoginSchema = object({
   ]),
 });
 
-type LoginForm = Input<typeof LoginSchema>;
+type LoginForm = InferOutput<typeof LoginSchema>;
 ```
 
 If you're wondering why this guide favors Valibot over Zod, I recommend reading this [announcement post](https://www.builder.io/blog/introducing-valibot).
@@ -183,7 +183,7 @@ import { $, component$, type QRL } from '@builder.io/qwik';
 import { routeLoader$ } from '@builder.io/qwik-city';
 import type { InitialValues, SubmitHandler } from '@modular-forms/qwik';
 import { formAction$, useForm, valiForm$ } from '@modular-forms/qwik';
-import { email, type Input, minLength, object, string } from 'valibot';
+import { email, type InferOutput, minLength, object, string } from 'valibot';
 
 const LoginSchema = object({
   email: string([
@@ -196,7 +196,7 @@ const LoginSchema = object({
   ]),
 });
 
-type LoginForm = Input<typeof LoginSchema>;
+type LoginForm = InferOutput<typeof LoginSchema>;
 
 export const useFormLoader = routeLoader$<InitialValues<LoginForm>>(() => ({
   email: '',


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description
I was trying to implement modular forms like on [docs](https://qwik.dev/docs/integrations/modular-forms/#modular-forms) but when I installed `valibot` ^0.32.0 found there is no exported type `Input` (I think it's outdated).
When I looked in `valibot` docs they use `InferOutput` instead.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
