### PR TITLE
fix: moved express to dependencies section

### DIFF
--- a/starters/adapters/express/package.json
+++ b/starters/adapters/express/package.json
@@ -4,12 +4,14 @@
     "build.server": "vite build -c adapters/express/vite.config.ts",
     "serve": "node server/entry.express"
   },
+  "dependencies": {
+    "express": "4.19.2"
+  },
   "devDependencies": {
     "@types/compression": "^1.7.2",
     "@types/express": "^4.17.19",
     "compression": "^1.7.4",
-    "dotenv": "^16.3.2",
-    "express": "4.19.2"
+    "dotenv": "^16.3.2"
   },
   "__qwik__": {
     "priority": 20,


### PR DESCRIPTION
# Overview

Moved express to dependencies section

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Express should be under dependencies

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
