### PR TITLE
fix: moved Fastify packages to dependencies section

### DIFF
--- a/starters/adapters/fastify/package.json
+++ b/starters/adapters/fastify/package.json
@@ -4,12 +4,14 @@
     "build.server": "vite build -c adapters/fastify/vite.config.ts",
     "serve": "node server/entry.fastify"
   },
-  "devDependencies": {
-    "dotenv": "^16.3.2",
+  "dependencies": {
     "@fastify/compress": "^6.2.1",
     "@fastify/static": "^6.10.1",
     "fastify": "^4.17.0",
     "fastify-plugin": "^4.5.0"
+  },
+  "devDependencies": {
+    "dotenv": "^16.3.2"
   },
   "__qwik__": {
     "priority": 20,


### PR DESCRIPTION
# Overview

Moved fastify to dependencies section

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

Fastify should be under dependencies. Here the issue:

https://github.com/QwikDev/qwik/issues/5795

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
