### PR TITLE
fix(qrl): correct qrl loading in vite dev mode

### DIFF
--- a/packages/qwik-city/runtime/src/spa-init.ts
+++ b/packages/qwik-city/runtime/src/spa-init.ts
@@ -3,7 +3,7 @@ import type { ScrollHistoryState } from './scroll-restoration';
 import type { ScrollState } from './types';
 
 import { isDev } from '@builder.io/qwik/build';
-import { $ } from '@builder.io/qwik';
+import { event$ } from '@builder.io/qwik';
 
 // TODO Dedupe handler code from here and QwikCityProvider?
 // TODO Navigation API; check for support & simplify.
@@ -14,7 +14,7 @@ import { $ } from '@builder.io/qwik';
 // - Robust, fully relies only on history. (scrollRestoration = 'manual')
 
 // ! DO NOT IMPORT OR USE ANY EXTERNAL REFERENCES IN THIS SCRIPT.
-export default $((container: HTMLElement) => {
+export default event$((container: HTMLElement) => {
   const win: ClientSPAWindow = window;
 
   const currentPath = location.pathname + location.search;

--- a/packages/qwik-city/runtime/src/spa-shim.ts
+++ b/packages/qwik-city/runtime/src/spa-shim.ts
@@ -8,7 +8,7 @@ import init from './spa-init';
 
 export default (base: string) => {
   if (isServer) {
-    const [symbol, bundle] = getPlatform().chunkForSymbol(init.getSymbol(), null)!;
+    const [symbol, bundle] = getPlatform().chunkForSymbol(init.getSymbol(), null, init.dev?.file)!;
     const args = [base, bundle, symbol].map((x) => JSON.stringify(x)).join(',');
     return `(${shim.toString()})(${args});`;
   }

--- a/packages/qwik/src/core/qrl/qrl.ts
+++ b/packages/qwik/src/core/qrl/qrl.ts
@@ -210,7 +210,7 @@ export const serializeQRL = (qrl: QRLInternal, opts: QRLSerializeOptions = {}) =
       throwErrorAndStop('Sync QRL without containerState');
     }
   }
-  let output = `${encodeURI(chunk)}#${symbol}`;
+  let output = `${chunk}#${symbol}`;
   const capture = qrl.$capture$;
   const captureRef = qrl.$captureRef$;
   if (captureRef && captureRef.length) {

--- a/packages/qwik/src/core/qrl/qrl.unit.ts
+++ b/packages/qwik/src/core/qrl/qrl.unit.ts
@@ -101,9 +101,9 @@ describe('serialization', () => {
     );
     assert.equal(
       serializeQRL(
-        createQRL('src/routes/[...index]/c', 's1', null, null, [1 as any, '2'], null, null)
+        createQRL('src/routes/[...index]/a+b/c?foo', 's1', null, null, [1 as any, '2'], null, null)
       ),
-      'src/routes/%5B...index%5D/c#s1[1 2]'
+      'src/routes/[...index]/a+b/c?foo#s1[1 2]'
     );
   });
 

--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -476,6 +476,7 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
           // building here via ctx.load doesn't seem to work (target is always ssr?)
           // eslint-disable-next-line prefer-const
           let [, qrlId, parentId] = match;
+          parentId = decodeURIComponent(parentId);
           // If the parent is not in root (e.g. pnpm symlink), the qrl also isn't
           if (parentId.startsWith(opts.rootDir)) {
             qrlId = `${opts.rootDir}${qrlId}`;

--- a/packages/qwik/src/optimizer/src/plugins/vite-dev-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-dev-server.ts
@@ -133,6 +133,8 @@ export async function configureDevServer(
             });
           });
 
+          // We must encode the chunk so that e.g. + doesn't get converted to space etc
+          const encode = (url: string) => encodeURIComponent(url).replaceAll('%2F', '/');
           const renderOpts: RenderToStreamOptions = {
             debug: true,
             locale: serverData.locale,
@@ -147,7 +149,7 @@ export async function configureDevServer(
                   }
                   const chunk = mapper && mapper[getSymbolHash(symbolName)];
                   if (chunk) {
-                    return chunk;
+                    return [chunk[0], encode(chunk[1])];
                   }
                   parent ||= foundQrls.get(symbolName);
                   if (!parent) {
@@ -162,7 +164,7 @@ export async function configureDevServer(
                   const qrlPath = parentPath.startsWith(opts.rootDir)
                     ? path.relative(opts.rootDir, parentPath)
                     : parentPath;
-                  const qrlFile = `${qrlPath}/${symbolName.toLowerCase()}.js?_qrl_parent=${parent}`;
+                  const qrlFile = `${encode(qrlPath)}/${symbolName.toLowerCase()}.js?_qrl_parent=${encode(parent)}`;
                   return [symbolName, `${base}${qrlFile}`];
                 },
             prefetchStrategy: null,


### PR DESCRIPTION
Qwik city preloaded spa-init.ts but that didn't include the parent info so it gave a harmless error.
Also, qrl paths with + turned into spaces, which broke loading 