### PR TITLE
fix(dev): path to outside-project files

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/vite-dev-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-dev-server.ts
@@ -165,7 +165,7 @@ export async function configureDevServer(
                   // use the full path, otherwise relative to the source
                   const qrlPath = parentPath.startsWith(opts.rootDir)
                     ? path.relative(opts.rootDir, parentPath)
-                    : `/@fs/${parentPath}`;
+                    : `@fs${parentPath}`;
                   const qrlFile = `${encode(qrlPath)}/${symbolName.toLowerCase()}.js?_qrl_parent=${encode(parent)}`;
                   return [symbolName, `${base}${qrlFile}`];
                 },


### PR DESCRIPTION
`/` gets prepended due to the request and parentPath already has `/`
