### PR TITLE
fix(dev): vite base and qrl segment fixes

### DIFF
--- a/packages/docs/src/repl/worker/app-bundle-client.ts
+++ b/packages/docs/src/repl/worker/app-bundle-client.ts
@@ -76,7 +76,7 @@ export const appBundleClient = async (
     });
 
     result.clientBundles = generated.output.map(getOutput).filter((f) => {
-      return !f.path.endsWith('app.js') && !f.path.endsWith('q-manifest.json');
+      return !f.path.endsWith('q-manifest.json');
     });
 
     await Promise.all(

--- a/packages/docs/src/routes/api/qwik-optimizer/api.json
+++ b/packages/docs/src/routes/api/qwik-optimizer/api.json
@@ -621,6 +621,20 @@
       "mdFile": "qwik.sourcemapsoption.md"
     },
     {
+      "name": "symbolMapper",
+      "id": "symbolmapper",
+      "hierarchy": [
+        {
+          "name": "symbolMapper",
+          "id": "symbolmapper"
+        }
+      ],
+      "kind": "Variable",
+      "content": "> This API is provided as an alpha preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.\n> \n\nFor a given symbol (QRL such as `onKeydown$`<!-- -->) the server needs to know which bundle the symbol is in.\n\nNormally this is provided by Qwik's `q-manifest` . But `q-manifest` only exists after a full client build.\n\nThis would be a problem in dev mode. So in dev mode the symbol is mapped to the expected URL using the symbolMapper function below. For Vite the given path is fixed for a given symbol.\n\n\n```typescript\nsymbolMapper: ReturnType<typeof createSymbolMapper>\n```",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/optimizer/src/plugins/vite-dev-server.ts",
+      "mdFile": "qwik.symbolmapper.md"
+    },
+    {
       "name": "SymbolMapper",
       "id": "symbolmapper",
       "hierarchy": [
@@ -630,7 +644,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "```typescript\nexport type SymbolMapper = Record<string, readonly [symbol: string, chunk: string]>;\n```",
+      "content": "> This API is provided as an alpha preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.\n> \n\nFor a given symbol (QRL such as `onKeydown$`<!-- -->) the server needs to know which bundle the symbol is in.\n\nNormally this is provided by Qwik's `q-manifest` . But `q-manifest` only exists after a full client build.\n\nThis would be a problem in dev mode. So in dev mode the symbol is mapped to the expected URL using the symbolMapper function below. For Vite the given path is fixed for a given symbol.\n\n\n```typescript\nsymbolMapper: ReturnType<typeof createSymbolMapper>\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/optimizer/src/types.ts",
       "mdFile": "qwik.symbolmapper.md"
     },

--- a/packages/docs/src/routes/api/qwik-optimizer/index.md
+++ b/packages/docs/src/routes/api/qwik-optimizer/index.md
@@ -2764,13 +2764,34 @@ export type SourceMapsOption = "external" | "inline" | undefined | null;
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/optimizer/src/types.ts)
 
-## SymbolMapper
+## symbolMapper
+
+> This API is provided as an alpha preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+
+For a given symbol (QRL such as `onKeydown$`) the server needs to know which bundle the symbol is in.
+
+Normally this is provided by Qwik's `q-manifest` . But `q-manifest` only exists after a full client build.
+
+This would be a problem in dev mode. So in dev mode the symbol is mapped to the expected URL using the symbolMapper function below. For Vite the given path is fixed for a given symbol.
 
 ```typescript
-export type SymbolMapper = Record<
-  string,
-  readonly [symbol: string, chunk: string]
->;
+symbolMapper: ReturnType<typeof createSymbolMapper>;
+```
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/optimizer/src/plugins/vite-dev-server.ts)
+
+## SymbolMapper
+
+> This API is provided as an alpha preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+
+For a given symbol (QRL such as `onKeydown$`) the server needs to know which bundle the symbol is in.
+
+Normally this is provided by Qwik's `q-manifest` . But `q-manifest` only exists after a full client build.
+
+This would be a problem in dev mode. So in dev mode the symbol is mapped to the expected URL using the symbolMapper function below. For Vite the given path is fixed for a given symbol.
+
+```typescript
+symbolMapper: ReturnType<typeof createSymbolMapper>;
 ```
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/optimizer/src/types.ts)

--- a/packages/docs/src/routes/docs/(qwikcity)/advanced/content-security-policy/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/advanced/content-security-policy/index.mdx
@@ -77,6 +77,7 @@ import {
   ServiceWorkerRegister,
 } from "@builder.io/qwik-city";
 import { RouterHead } from "./components/router-head/router-head";
+import { isDev } from "@builder.io/qwik/build";
 
 import "./global.css";
 
@@ -86,12 +87,13 @@ export default component$(() => {
     <QwikCityProvider>
       <head>
         <meta charSet="utf-8" />
-        <link rel="manifest" href="/manifest.json" />
+        {!isDev && <link rel="manifest" href={`${import.meta.env.BASE_URL}manifest.json`} />}
+
         <RouterHead />
       </head>
       <body lang="en">
         <RouterOutlet />
-        <ServiceWorkerRegister nonce={nonce} />
+        {!isDev && <ServiceWorkerRegister nonce={nonce} />}
       </body>
     </QwikCityProvider>
   );

--- a/packages/qwik-city/buildtime/vite/dev-server.ts
+++ b/packages/qwik-city/buildtime/vite/dev-server.ts
@@ -498,7 +498,11 @@ function skipRequest(pathname: string) {
   if (pathname.includes('favicon')) {
     return true;
   }
-  if (pathname.startsWith('/src/')) {
+  if (
+    pathname.startsWith('/src/') ||
+    pathname.startsWith('/@fs/') ||
+    pathname.startsWith('/%40fs/')
+  ) {
     const ext = getExtension(pathname);
     if (SKIP_SRC_EXTS[ext]) {
       return true;

--- a/packages/qwik-city/buildtime/vite/dev-server.ts
+++ b/packages/qwik-city/buildtime/vite/dev-server.ts
@@ -498,11 +498,7 @@ function skipRequest(pathname: string) {
   if (pathname.includes('favicon')) {
     return true;
   }
-  if (
-    pathname.startsWith('/src/') ||
-    pathname.startsWith('/@fs/') ||
-    pathname.startsWith('/%40fs/')
-  ) {
+  if (pathname.startsWith('/src/') || pathname.startsWith('/@fs/')) {
     const ext = getExtension(pathname);
     if (SKIP_SRC_EXTS[ext]) {
       return true;

--- a/packages/qwik-react/package.json
+++ b/packages/qwik-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@builder.io/qwik-react",
   "description": "QwikReact allows adding React components into existing Qwik application",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "bugs": "https://github.com/QwikDev/qwik/issues",
   "devDependencies": {
     "@builder.io/qwik": "workspace:^",

--- a/packages/qwik-react/src/vite.ts
+++ b/packages/qwik-react/src/vite.ts
@@ -3,6 +3,7 @@ export function qwikReact(): any {
     'react',
     'react-dom',
     'react-dom/client',
+    'react-dom/server',
     'react/jsx-runtime',
     'react/jsx-dev-runtime',
   ];

--- a/packages/qwik/src/optimizer/src/api.md
+++ b/packages/qwik/src/optimizer/src/api.md
@@ -378,6 +378,11 @@ export type SourceMapsOption = 'external' | 'inline' | undefined | null;
 // @public (undocumented)
 export type SymbolMapper = Record<string, readonly [symbol: string, chunk: string]>;
 
+// Warning: (ae-forgotten-export) The symbol "createSymbolMapper" needs to be exported by the entry point index.d.ts
+//
+// @alpha
+export let symbolMapper: ReturnType<typeof createSymbolMapper>;
+
 // @public (undocumented)
 export type SymbolMapperFn = (symbolName: string, mapper: SymbolMapper | undefined, parent?: string) => readonly [symbol: string, chunk: string] | undefined;
 

--- a/packages/qwik/src/optimizer/src/index.ts
+++ b/packages/qwik/src/optimizer/src/index.ts
@@ -47,3 +47,4 @@ export type {
 
 export { qwikRollup } from './plugins/rollup';
 export { qwikVite } from './plugins/vite';
+export { symbolMapper } from './plugins/vite-dev-server';

--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -460,7 +460,6 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
       from: importerId,
       for: isSSR ? 'server' : 'client',
     });
-    // note that qrl segments request /%40fs instead of /@fs
     if (id.startsWith('\0')) {
       return;
     }

--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -1,4 +1,4 @@
-import type { Rollup, Plugin, ViteDevServer } from 'vite';
+import type { Rollup, Plugin, ViteDevServer, HmrContext } from 'vite';
 import { hashCode } from '../../../core/util/hash_code';
 import { generateManifestFromBundles, getValidManifest } from '../manifest';
 import { createOptimizer } from '../optimizer';
@@ -433,18 +433,37 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
     }
   };
 
+  const getParentId = (id: string, isSSR: boolean) => {
+    const transformedOutputs = isSSR ? serverTransformedOutputs : clientTransformedOutputs;
+    const segment = transformedOutputs.get(id);
+    if (segment) {
+      return segment[1];
+    }
+    const hash = getSymbolHash(id);
+    return foundQrls.get(hash);
+  };
+
+  let resolveIdCount = 0;
+  /** This resolves special names and QRL segments/entries. All the rest falls through */
   const resolveId = async (
     ctx: Rollup.PluginContext,
     id: string,
     importerId: string | undefined,
     resolveOpts?: Parameters<Extract<Plugin['resolveId'], Function>>[2]
   ) => {
-    debug(`resolveId()`, 'Start', id, importerId, resolveOpts, opts.target);
-    if (id.startsWith('\0') || id.startsWith('/@fs')) {
+    const count = resolveIdCount++;
+    const isSSR = !!resolveOpts?.ssr;
+    debug(`resolveId(${count})`, 'Start', id, {
+      from: importerId,
+      for: isSSR ? 'server' : 'client',
+    });
+    // note that qrl segments request /%40fs instead of /@fs
+    if (id.startsWith('\0')) {
       return;
     }
 
     if (opts.target === 'lib' && id.startsWith(QWIK_CORE_ID)) {
+      // For library code, we must retain the qwik imports as-is. They all start with /qwik.
       return {
         external: true,
         id,
@@ -452,7 +471,7 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
     }
 
     if (opts.resolveQwikBuild && id.endsWith(QWIK_BUILD_ID)) {
-      debug(`resolveId()`, 'Resolved', QWIK_BUILD_ID);
+      debug(`resolveId(${count})`, 'Resolved', QWIK_BUILD_ID);
       return {
         id: normalizePath(getPath().resolve(opts.rootDir, QWIK_BUILD_ID)),
         moduleSideEffects: false,
@@ -460,7 +479,7 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
     }
 
     if (id.endsWith(QWIK_CLIENT_MANIFEST_ID)) {
-      debug(`resolveId()`, 'Resolved', QWIK_CLIENT_MANIFEST_ID);
+      debug(`resolveId(${count})`, 'Resolved', QWIK_CLIENT_MANIFEST_ID);
       if (opts.target === 'lib') {
         return {
           id: id,
@@ -477,19 +496,17 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
     }
 
     const path = getPath();
-    const isSSR = !!resolveOpts?.ssr;
-    const transformedOutputs = isSSR ? serverTransformedOutputs : clientTransformedOutputs;
 
     // Requests originating from another file, or the browser
     if (importerId) {
       const looksLikePath = id.startsWith('.') || id.startsWith('/');
       if (!looksLikePath) {
         // Rollup can ask us to resolve imports from QRL segments
-        // It seems like files need to exist on disk for this to work automatically,
-        // so for segments we provide the parent instead
-        const segment = transformedOutputs.get(importerId);
-        if (segment) {
-          const parentId = segment[1];
+        // It seems like importers need to exist on disk for this to work automatically,
+        // so for segments we resolve via the parent instead
+        debug(`resolveId(${count})`, 'falling back to default resolver');
+        const parentId = getParentId(importerId, isSSR);
+        if (parentId) {
           return ctx.resolve(id, parentId, { skipSelf: true });
         }
         return;
@@ -497,44 +514,45 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
       importerId = normalizePath(importerId);
       const parsedImporterId = parseId(importerId);
       const dir = path.dirname(parsedImporterId.pathId);
-      if (opts.target === 'ssr' && !isSSR && importerId.endsWith('.html') && server) {
+      if (
+        opts.target === 'ssr' &&
+        !isSSR &&
+        importerId.endsWith('.html') &&
+        server &&
+        id.startsWith('/')
+      ) {
         // This is a request from a dev-mode browser
         // we uri-encode chunk paths in dev mode, and other imported files don't have % in their paths (hopefully)
         // These will be individual source files and their QRL segments
         id = decodeURIComponent(id);
         // Support absolute paths for qrl segments, due to e.g. pnpm linking
-        const isAbsoluteFile = id.startsWith('/@fs/');
-        if (isAbsoluteFile) {
+        if (id.startsWith('/@fs/')) {
           id = id.slice(4);
+        } else {
+          // We know for sure that the path is relative to the html importer even though it starts with /
+          id = path.join(dir, id);
         }
+        id = normalizePath(id);
         // Check for parent passed via QRL
         const match = /^([^?]*)\?_qrl_parent=(.*)/.exec(id);
         if (match) {
           id = match[1];
+          // The parent is in the same directory as the requested segment
           const parentId = id.slice(0, id.lastIndexOf('/') + 1) + match[2];
-          if (!isAbsoluteFile) {
-            // We know for sure that the path is relative to the html importer even though it starts with /
-            id = normalizePath(path.join(dir, id));
-          }
-          // building here via ctx.load doesn't seem to work (target is always ssr?)
-          // instead we use the devserver directly
-          if (!clientResults.has(parentId)) {
-            debug(`resolveId()`, 'transforming QRL parent', parentId);
-            await server.transformRequest(parentId);
-            // The QRL segment should exist now
-          }
+          const hash = getSymbolHash(id);
+          // Register the parent in case we don't have it (restart etc)
+          foundQrls.set(hash, parentId);
         }
       }
       const parsedId = parseId(id);
       let importeePathId = normalizePath(parsedId.pathId);
       const ext = path.extname(importeePathId).toLowerCase();
       if (ext in RESOLVE_EXTS) {
-        debug(`resolveId("${importeePathId}", "${importerId}")`);
         // resolve relative paths
         importeePathId = normalizePath(path.resolve(dir, importeePathId));
-
-        if (transformedOutputs.has(importeePathId)) {
-          debug(`resolveId() Resolved ${importeePathId} from transformedOutputs`);
+        const parentId = getParentId(importeePathId, isSSR);
+        if (parentId) {
+          debug(`resolveId(${count}) Resolved ${importeePathId} from transformedOutputs`);
           return {
             id: importeePathId + parsedId.query,
           };
@@ -544,19 +562,17 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
       const parsedId = parseId(id);
       const importeePathId = normalizePath(parsedId.pathId);
       const ext = path.extname(importeePathId).toLowerCase();
-      if (ext in RESOLVE_EXTS) {
-        debug(`resolveId("${importeePathId}", "${importerId}")`);
-
-        if (transformedOutputs.has(importeePathId)) {
-          debug(`resolveId() Resolved ${importeePathId} from transformedOutputs`);
-          return {
-            id: importeePathId + parsedId.query,
-          };
-        }
+      if (ext in RESOLVE_EXTS && getParentId(importeePathId, isSSR)) {
+        debug(
+          `resolveId(${count}) Resolved ${importeePathId} from transformedOutputs (no importer)`
+        );
+        return {
+          id: importeePathId + parsedId.query,
+        };
       }
     }
     // We don't (yet) know this id
-    debug(`resolveId()`, 'Not resolved', id, importerId, resolveOpts);
+    debug(`resolveId(${count})`, 'Not resolved', id, importerId);
     return null;
   };
 
@@ -588,9 +604,19 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
     const path = getPath();
     id = normalizePath(parsedId.pathId);
 
-    const transformedModule = isSSR
-      ? serverTransformedOutputs.get(id)
-      : clientTransformedOutputs.get(id);
+    const outputs = isSSR ? serverTransformedOutputs : clientTransformedOutputs;
+    if (server && !outputs.has(id)) {
+      // in dev mode, it could be that the id is a QRL segment that wasn't transformed yet
+      const parentId = getParentId(id, isSSR);
+      if (parentId) {
+        // building here via ctx.load doesn't seem to work (no transform), instead we use the devserver directly
+        debug(`load()`, 'transforming QRL parent', parentId);
+        await server.transformRequest(parentId);
+        // The QRL segment should exist now
+      }
+    }
+
+    const transformedModule = outputs.get(id);
 
     if (transformedModule) {
       debug(`load()`, 'Found', id);
@@ -609,7 +635,7 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
       return { code, map, meta: { hook } };
     }
 
-    debug('load()', 'Not found', id, parsedId);
+    debug('load()', 'Not found', id);
     return null;
   };
 
@@ -623,11 +649,12 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
       return;
     }
     const isSSR = !!transformOpts.ssr;
-    // TODO does this clear in dev mode ???
     const currentOutputs = isSSR ? serverTransformedOutputs : clientTransformedOutputs;
     if (currentOutputs.has(id)) {
+      // This is a QRL segment, and we don't need to process it any further
       return;
     }
+
     const optimizer = getOptimizer();
     const path = getPath();
 
@@ -644,14 +671,10 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
       /** Strip client|server code from server|client */
       const strip = opts.target === 'client' || opts.target === 'ssr';
       const normalizedID = normalizePath(pathId);
-      debug(`transform()`, 'Transforming', {
-        pathId,
-        id,
-        parsedPathId,
-        strip,
-        isSSR,
-        target: opts.target,
-      });
+      debug(
+        `transform()`,
+        `Transforming ${id} (for: ${isSSR ? 'server' : 'client'}${strip ? ', strip' : ''})`
+      );
 
       let filePath = base;
       if (opts.srcDir) {
@@ -720,6 +743,7 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
       for (const mod of newOutput.modules) {
         if (mod !== module) {
           const key = normalizePath(path.join(srcDir, mod.path));
+          debug(`transform()`, `segment ${key}`, mod.hook?.displayName);
           currentOutputs.set(key, [mod, id]);
           deps.add(key);
           // rollup must be told about entry points
@@ -730,7 +754,6 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
               preserveSignature: 'allow-extension',
             });
           }
-          ctx.addWatchFile(key);
         }
       }
 
@@ -741,6 +764,8 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
       for (const id of deps.values()) {
         await ctx.load({ id });
       }
+
+      ctx.addWatchFile(id);
 
       return {
         code: module.code,
@@ -821,6 +846,7 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
     diagnosticsCallback = cb;
   };
 
+  /** Convert windows backslashes to forward slashes */
   const normalizePath = (id: string) => {
     if (typeof id === 'string') {
       const sys = getSys();
@@ -863,6 +889,29 @@ export const manifest = ${JSON.stringify(manifest)};\n`;
     opts.sourcemap = sourcemap;
   }
 
+  // Only used in Vite dev mode
+  function handleHotUpdate(ctx: HmrContext) {
+    debug('handleHotUpdate()', ctx.file);
+
+    for (const mod of ctx.modules) {
+      const { id } = mod;
+      if (id) {
+        debug('handleHotUpdate()', `invalidate ${id}`);
+        serverResults.delete(id);
+        clientResults.delete(id);
+      }
+      for (const dep of mod.info?.meta?.qwikdeps || []) {
+        debug('handleHotUpdate()', `invalidate segment ${dep}`);
+        serverTransformedOutputs.delete(dep);
+        clientTransformedOutputs.delete(dep);
+        const mod = ctx.server.moduleGraph.getModuleById(dep);
+        if (mod) {
+          ctx.server.moduleGraph.invalidateModule(mod);
+        }
+      }
+    }
+  }
+
   return {
     buildStart,
     createOutputAnalyzer,
@@ -885,6 +934,7 @@ export const manifest = ${JSON.stringify(manifest)};\n`;
     setSourceMapSupport,
     foundQrls,
     configureServer,
+    handleHotUpdate,
   };
 }
 
@@ -916,6 +966,14 @@ export function parseId(originalId: string) {
     query: queryStr ? `?${query}` : '',
     params: new URLSearchParams(queryStr),
   };
+}
+
+export function getSymbolHash(symbolName: string) {
+  const index = symbolName.lastIndexOf('_');
+  if (index > -1) {
+    return symbolName.slice(index + 1);
+  }
+  return symbolName;
 }
 
 const TRANSFORM_EXTS = {

--- a/packages/qwik/src/optimizer/src/plugins/vite-dev-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-dev-server.ts
@@ -126,7 +126,7 @@ export async function configureDevServer(
                   location: 'head',
                   attributes: {
                     rel: 'stylesheet',
-                    href: url,
+                    href: `${base}${url.slice(1)}`,
                   },
                 });
               }
@@ -161,12 +161,13 @@ export async function configureDevServer(
                     return [symbolName, `${base}${symbolName.toLowerCase()}.js`];
                   }
                   const parentPath = path.dirname(parent);
+                  const parentFile = path.basename(parent);
                   // DX: if the file isn't under the source dir (e.g. a symlink from node_modules)
                   // use the full path, otherwise relative to the source
                   const qrlPath = parentPath.startsWith(opts.rootDir)
-                    ? path.relative(opts.rootDir, parentPath)
-                    : `@fs${parentPath}`;
-                  const qrlFile = `${encode(qrlPath)}/${symbolName.toLowerCase()}.js?_qrl_parent=${encode(parent)}`;
+                    ? path.posix.normalize(path.relative(opts.rootDir, parentPath))
+                    : `@fs${path.posix.normalize(parentPath)}`;
+                  const qrlFile = `${encode(qrlPath)}/${symbolName.toLowerCase()}.js?_qrl_parent=${encode(parentFile)}`;
                   return [symbolName, `${base}${qrlFile}`];
                 },
             prefetchStrategy: null,
@@ -193,7 +194,7 @@ export async function configureDevServer(
                   pathId.endsWith(ext)
                 )
               ) {
-                res.write(`<link rel="stylesheet" href="${v.url}">`);
+                res.write(`<link rel="stylesheet" href="${base}${v.url.slice(1)}">`);
               }
             });
           });

--- a/packages/qwik/src/optimizer/src/plugins/vite-dev-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-dev-server.ts
@@ -33,7 +33,8 @@ function getOrigin(req: IncomingMessage) {
 }
 
 // We must encode the chunk so that e.g. + doesn't get converted to space etc
-const encode = (url: string) => encodeURIComponent(url).replaceAll('%2F', '/');
+const encode = (url: string) =>
+  encodeURIComponent(url).replaceAll('%2F', '/').replaceAll('%40', '@');
 
 function createSymbolMapper(
   base: string,

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -692,18 +692,14 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
     },
 
     handleHotUpdate(ctx) {
-      qwikPlugin.debug('handleHotUpdate()', ctx);
+      qwikPlugin.handleHotUpdate(ctx);
 
-      for (const mod of ctx.modules) {
-        const deps = mod.info?.meta?.qwikdeps;
-        if (deps && deps.length > 0) {
-          for (const dep of deps) {
-            const mod = ctx.server.moduleGraph.getModuleById(dep);
-            if (mod) {
-              ctx.server.moduleGraph.invalidateModule(mod);
-            }
-          }
-        }
+      // Tell the client to reload the page if any modules were used in ssr or client
+      // this needs to be refined
+      if (ctx.modules.length) {
+        ctx.server.hot.send({
+          type: 'full-reload',
+        });
       }
     },
 

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -143,9 +143,7 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
 
       const shouldFindVendors =
         !qwikViteOpts.disableVendorScan && (target !== 'lib' || viteCommand === 'serve');
-      const vendorRoots = shouldFindVendors
-        ? await findQwikRoots(sys, path.join(sys.cwd(), 'package.json'))
-        : [];
+      const vendorRoots = shouldFindVendors ? await findQwikRoots(sys, sys.cwd()) : [];
       viteAssetsDir = viteConfig.build?.assetsDir;
       const useAssetsDir = target === 'client' && !!viteAssetsDir && viteAssetsDir !== '_astro';
       const pluginOpts: QwikPluginOptions = {
@@ -811,53 +809,64 @@ async function findDepPkgJsonPath(sys: OptimizerSystem, dep: string, parent: str
 
 const findQwikRoots = async (
   sys: OptimizerSystem,
-  packageJsonPath: string
+  packageJsonDir: string
 ): Promise<QwikPackages[]> => {
+  const paths = new Map<string, string>();
   if (sys.env === 'node') {
     const fs: typeof import('fs') = await sys.dynamicImport('node:fs');
-
-    try {
-      const data = await fs.promises.readFile(packageJsonPath, { encoding: 'utf-8' });
-
+    let prevPackageJsonDir: string | undefined;
+    do {
       try {
-        const packageJson = JSON.parse(data);
-        const dependencies = packageJson['dependencies'];
-        const devDependencies = packageJson['devDependencies'];
+        const data = await fs.promises.readFile(sys.path.join(packageJsonDir, 'package.json'), {
+          encoding: 'utf-8',
+        });
 
-        const packages: string[] = [];
-        if (typeof dependencies === 'object') {
-          packages.push(...Object.keys(dependencies));
-        }
-        if (typeof devDependencies === 'object') {
-          packages.push(...Object.keys(devDependencies));
-        }
+        try {
+          const packageJson = JSON.parse(data);
+          const dependencies = packageJson['dependencies'];
+          const devDependencies = packageJson['devDependencies'];
 
-        const basedir = sys.cwd();
-        const qwikDirs = await Promise.all(
-          packages.map(async (id) => {
-            const pkgJsonPath = await findDepPkgJsonPath(sys, id, basedir);
-            if (pkgJsonPath) {
-              const pkgJsonContent = await fs.promises.readFile(pkgJsonPath, 'utf-8');
-              const pkgJson = JSON.parse(pkgJsonContent);
-              const qwikPath = pkgJson['qwik'];
-              if (qwikPath) {
-                return {
-                  id,
-                  path: sys.path.resolve(sys.path.dirname(pkgJsonPath), qwikPath),
-                };
+          const packages: string[] = [];
+          if (typeof dependencies === 'object') {
+            packages.push(...Object.keys(dependencies));
+          }
+          if (typeof devDependencies === 'object') {
+            packages.push(...Object.keys(devDependencies));
+          }
+
+          const basedir = sys.cwd();
+          await Promise.all(
+            packages.map(async (id) => {
+              const pkgJsonPath = await findDepPkgJsonPath(sys, id, basedir);
+              if (pkgJsonPath) {
+                const pkgJsonContent = await fs.promises.readFile(pkgJsonPath, 'utf-8');
+                const pkgJson = JSON.parse(pkgJsonContent);
+                const qwikPath = pkgJson['qwik'];
+                if (!qwikPath) {
+                  return;
+                }
+                // Support multiple paths
+                const allPaths = Array.isArray(qwikPath) ? qwikPath : [qwikPath];
+                for (const p of allPaths) {
+                  paths.set(
+                    await fs.promises.realpath(sys.path.resolve(sys.path.dirname(pkgJsonPath), p)),
+                    id
+                  );
+                }
               }
-            }
-          })
-        );
-        return qwikDirs.filter(isNotNullable);
+            })
+          );
+        } catch (e) {
+          console.error(e);
+        }
       } catch (e) {
-        console.error(e);
+        // ignore errors if package.json not found
       }
-    } catch (e) {
-      // ignore errors if root package.json not found
-    }
+      prevPackageJsonDir = packageJsonDir;
+      packageJsonDir = sys.path.dirname(packageJsonDir);
+    } while (packageJsonDir !== prevPackageJsonDir);
   }
-  return [];
+  return Array.from(paths).map(([path, id]) => ({ path, id }));
 };
 
 export const isNotNullable = <T>(v: T): v is NonNullable<T> => {

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -648,7 +648,7 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
 
     configureServer(server: ViteDevServer) {
       qwikPlugin.configureServer(server);
-      const devSsrServer = 'devSsrServer' in qwikViteOpts ? qwikViteOpts.devSsrServer : true;
+      const devSsrServer = 'devSsrServer' in qwikViteOpts ? !!qwikViteOpts.devSsrServer : true;
       const imageDevTools =
         qwikViteOpts.devTools && 'imageDevTools' in qwikViteOpts.devTools
           ? qwikViteOpts.devTools.imageDevTools
@@ -658,7 +658,7 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
         server.middlewares.use(getImageSizeServer(qwikPlugin.getSys(), rootDir!, srcDir!));
       }
 
-      if (!qwikViteOpts.csr && devSsrServer) {
+      if (!qwikViteOpts.csr) {
         const plugin = async () => {
           const opts = qwikPlugin.getOptions();
           const sys = qwikPlugin.getSys();
@@ -671,7 +671,8 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
             path,
             isClientDevOnly,
             clientDevInput,
-            qwikPlugin.foundQrls
+            qwikPlugin.foundQrls,
+            devSsrServer
           );
         };
         const isNEW = (globalThis as any).__qwikCityNew === true;

--- a/starters/apps/empty/src/root.tsx
+++ b/starters/apps/empty/src/root.tsx
@@ -5,6 +5,7 @@ import {
   ServiceWorkerRegister,
 } from "@builder.io/qwik-city";
 import { RouterHead } from "./components/router-head/router-head";
+import { isDev } from "@builder.io/qwik/build";
 
 import "./global.css";
 
@@ -20,12 +21,17 @@ export default component$(() => {
     <QwikCityProvider>
       <head>
         <meta charset="utf-8" />
-        <link rel="manifest" href="/manifest.json" />
+        {!isDev && (
+          <link
+            rel="manifest"
+            href={`${import.meta.env.BASE_URL}manifest.json`}
+          />
+        )}
         <RouterHead />
       </head>
       <body lang="en">
         <RouterOutlet />
-        <ServiceWorkerRegister />
+        {!isDev && <ServiceWorkerRegister />}
       </body>
     </QwikCityProvider>
   );

--- a/starters/apps/playground/src/root.tsx
+++ b/starters/apps/playground/src/root.tsx
@@ -1,4 +1,5 @@
 import { component$ } from "@builder.io/qwik";
+import { isDev } from "@builder.io/qwik/build";
 import {
   QwikCityProvider,
   RouterOutlet,
@@ -20,9 +21,14 @@ export default component$(() => {
     <QwikCityProvider>
       <head>
         <meta charset="utf-8" />
-        <link rel="manifest" href="/manifest.json" />
+        {!isDev && (
+          <link
+            rel="manifest"
+            href={`${import.meta.env.BASE_URL}manifest.json`}
+          />
+        )}
         <RouterHead />
-        <ServiceWorkerRegister />
+        {!isDev && <ServiceWorkerRegister />}
       </head>
       <body lang="en">
         <RouterOutlet />


### PR DESCRIPTION
- fixes nx monorepo path lookup in dev mode
- fix vite prefix for css etc
- fix qrl segment path encoding for windows in dev mode
- only pass parent filename since path is always the same
- simplify resolveId path handling
- change starter to only add service worker in production
- add base url to manifest
