### PR TITLE
fix(v2): do not use tag nesting for production build

### DIFF
--- a/packages/qwik/src/server/prefetch-implementation.ts
+++ b/packages/qwik/src/server/prefetch-implementation.ts
@@ -102,14 +102,14 @@ function prefetchUrlsEvent2(
     if (nonce) {
       attrs.push('nonce', nonce);
     }
-    container.openElement('link', attrs);
+    container.openElement('link', null, attrs);
     container.closeElement();
   }
   const scriptAttrs = ['q:type', 'prefetch-bundles'];
   if (nonce) {
     scriptAttrs.push('nonce', nonce);
   }
-  container.openElement('script', scriptAttrs);
+  container.openElement('script', null, scriptAttrs);
   container.writer.write(prefetchUrlsEventScript(prefetchResources));
   container.writer.write(
     `;document.dispatchEvent(new CustomEvent('qprefetch', {detail:{links: [location.pathname]}}))`
@@ -157,7 +157,7 @@ function linkHtmlImplementation2(
       }
     }
 
-    container.openElement('link', attributes);
+    container.openElement('link', null, attributes);
     container.closeElement();
   }
 }
@@ -228,7 +228,7 @@ function linkJsImplementation2(
   if (nonce) {
     scriptAttrs.push('nonce', nonce);
   }
-  container.openElement('script', scriptAttrs);
+  container.openElement('script', null, scriptAttrs);
 
   const rel = prefetchImpl.linkRel || 'prefetch';
 
@@ -294,7 +294,7 @@ function workerFetchImplementation2(
   if (nonce) {
     scriptAttrs.push(nonce, 'nonce');
   }
-  container.openElement('script', scriptAttrs);
+  container.openElement('script', null, scriptAttrs);
 
   container.writer.write(`const u=${JSON.stringify(flattenPrefetchResources(prefetchResources))};`);
   container.writer.write(workerFetchScript());

--- a/packages/qwik/src/server/v2-ssr-container.ts
+++ b/packages/qwik/src/server/v2-ssr-container.ts
@@ -359,8 +359,8 @@ class SSRContainer extends _SharedContainer implements ISSRContainer {
   closeElement(): ValueOrPromise<void> {
     const currentFrame = this.currentElementFrame!;
     if (
-      (currentFrame.parent === null && currentFrame.tagNesting !== TagNesting.HTML) ||
-      currentFrame.tagNesting === TagNesting.BODY
+      (currentFrame.parent === null && currentFrame.elementName !== 'html') ||
+      currentFrame.elementName === 'body'
     ) {
       this.drainCleanupQueue();
       this.timing.render = this.renderTimer();


### PR DESCRIPTION
This PR removes the use of tag nesting as it doesn't work for production. This fixes the "missing child" error in production build.