### PR TITLE
fix(optimizer): let the bundler handle entries

### DIFF
--- a/.changeset/ninety-weeks-enjoy.md
+++ b/.changeset/ninety-weeks-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': minor
+---
+
+The optimizer plugin will now rely on Rollup to group QRL segments. It will only provide hints on which segments fit well together. The result of this change is that now code splitting happens during the transform phase only, and other Rollup/Vite plugins (such as css-in-js plugins) can transform the code before Qwik transforms it.

--- a/packages/qwik/src/optimizer/core/src/clean_side_effects.rs
+++ b/packages/qwik/src/optimizer/core/src/clean_side_effects.rs
@@ -1,5 +1,11 @@
-use swc_common::Mark;
-use swc_ecmascript::ast;
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::rc::Rc;
+
+use swc_common::Span;
+use swc_common::Spanned;
+use swc_ecmascript::ast::Module;
+use swc_ecmascript::ast::{Expr, ModuleItem, Stmt};
 use swc_ecmascript::visit::VisitMut;
 
 /// This is a simple treeshaker that removes anything with side effects from the module.
@@ -7,48 +13,51 @@ use swc_ecmascript::visit::VisitMut;
 /// - `new` expressions
 /// - `call` expressions
 ///
-/// but only when they are not assigned and used elsewhere.
+/// but only when they are not assigned and used elsewhere, or when they were already present before simplifying.
 ///
 /// - First it marks top-level expressions
 /// - Then the code needs to be simplified by you
 /// - Then it removes all top-level expressions that are not marked. Those will be expressions that were
 ///   assigned to unused variables etc.
+
 pub struct Treeshaker {
 	pub marker: CleanMarker,
 	pub cleaner: CleanSideEffects,
 }
 
-pub struct CleanSideEffects {
-	pub did_drop: bool,
-	pub mark: Mark,
+pub struct CleanMarker {
+	set: Rc<RefCell<HashSet<Span>>>,
 }
 
-pub struct CleanMarker {
-	pub mark: Mark,
+pub struct CleanSideEffects {
+	pub did_drop: bool,
+	set: Rc<RefCell<HashSet<Span>>>,
 }
 
 impl Treeshaker {
 	pub fn new() -> Self {
-		let mark = Mark::new();
+		let set = Rc::new(RefCell::new(HashSet::new()));
 		Self {
-			marker: CleanMarker { mark },
+			marker: CleanMarker {
+				set: Rc::clone(&set),
+			},
 			cleaner: CleanSideEffects {
 				did_drop: false,
-				mark,
+				set: Rc::clone(&set),
 			},
 		}
 	}
 }
 
 impl VisitMut for CleanMarker {
-	fn visit_mut_module_item(&mut self, node: &mut ast::ModuleItem) {
-		if let ast::ModuleItem::Stmt(ast::Stmt::Expr(expr)) = node {
+	fn visit_mut_module_item(&mut self, node: &mut ModuleItem) {
+		if let ModuleItem::Stmt(Stmt::Expr(expr)) = node {
 			match &*expr.expr {
-				ast::Expr::New(e) => {
-					e.ctxt.apply_mark(self.mark);
+				Expr::New(e) => {
+					self.set.borrow_mut().insert(e.span());
 				}
-				ast::Expr::Call(e) => {
-					e.ctxt.apply_mark(self.mark);
+				Expr::Call(e) => {
+					self.set.borrow_mut().insert(e.span());
 				}
 				_ => {}
 			}
@@ -57,18 +66,18 @@ impl VisitMut for CleanMarker {
 }
 
 impl VisitMut for CleanSideEffects {
-	fn visit_mut_module(&mut self, node: &mut ast::Module) {
+	fn visit_mut_module(&mut self, node: &mut Module) {
 		node.body.retain(|item| match item {
-			ast::ModuleItem::Stmt(ast::Stmt::Expr(expr)) => match &*expr.expr {
-				ast::Expr::New(e) => {
-					if e.ctxt.has_mark(self.mark) {
+			ModuleItem::Stmt(Stmt::Expr(expr)) => match &*expr.expr {
+				Expr::New(e) => {
+					if self.set.borrow().contains(&e.span()) {
 						return true;
 					}
 					self.did_drop = true;
 					false
 				}
-				ast::Expr::Call(e) => {
-					if e.ctxt.has_mark(self.mark) {
+				Expr::Call(e) => {
+					if self.set.borrow().contains(&e.span()) {
 						return true;
 					}
 					self.did_drop = true;

--- a/packages/qwik/src/optimizer/core/src/code_move.rs
+++ b/packages/qwik/src/optimizer/core/src/code_move.rs
@@ -1,19 +1,12 @@
 use crate::collector::{new_ident_from_id, GlobalCollect, Id, ImportKind};
-use crate::parse::{
-	emit_source_code, might_need_handle_watch, HookAnalysis, PathData, TransformModule,
-	TransformOutput,
-};
+use crate::parse::PathData;
 use crate::transform::{add_handle_watch, create_synthetic_named_import};
 use crate::words::*;
 
-use std::collections::BTreeMap;
-use std::path::Path;
-
-use anyhow::{Context, Error};
-use path_slash::PathExt;
+use anyhow::Error;
 use swc_atoms::JsWord;
 use swc_common::comments::{SingleThreadedComments, SingleThreadedCommentsMap};
-use swc_common::{sync::Lrc, SourceMap, DUMMY_SP};
+use swc_common::DUMMY_SP;
 use swc_ecmascript::ast;
 use swc_ecmascript::utils::private_ident;
 
@@ -158,32 +151,6 @@ pub fn new_module(ctx: NewModuleCtx) -> Result<(ast::Module, SingleThreadedComme
 	Ok((module, comments))
 }
 
-pub fn fix_path<S: AsRef<Path>, D: AsRef<Path>>(
-	src: S,
-	dest: D,
-	ident: &str,
-) -> Result<JsWord, Error> {
-	let src = src.as_ref();
-	let dest = dest.as_ref();
-	if ident.starts_with('.') {
-		let diff = pathdiff::diff_paths(src, dest);
-
-		if let Some(diff) = diff {
-			let normalize = diff.to_slash_lossy();
-			let relative = relative_path::RelativePath::new(&normalize);
-			let final_path = relative.join(ident).normalize();
-			let final_str = final_path.as_str();
-			return Ok(if final_str.starts_with('.') {
-				JsWord::from(final_str)
-			} else {
-				JsWord::from(format!("./{}", final_str))
-			});
-		}
-	}
-
-	Ok(JsWord::from(ident))
-}
-
 fn create_named_export(expr: Box<ast::Expr>, name: &str) -> ast::ModuleItem {
 	ast::ModuleItem::ModuleDecl(ast::ModuleDecl::ExportDecl(ast::ExportDecl {
 		span: DUMMY_SP,
@@ -204,123 +171,6 @@ fn create_named_export(expr: Box<ast::Expr>, name: &str) -> ast::ModuleItem {
 			}],
 		})),
 	}))
-}
-
-#[test]
-fn test_fix_path() {
-	assert_eq!(
-		fix_path("src", "", "./state.qwik.mjs").unwrap(),
-		JsWord::from("./src/state.qwik.mjs")
-	);
-
-	assert_eq!(
-		fix_path("src/path", "", "./state").unwrap(),
-		JsWord::from("./src/path/state")
-	);
-
-	assert_eq!(
-		fix_path("src", "", "../state").unwrap(),
-		JsWord::from("./state")
-	);
-	assert_eq!(
-		fix_path("a", "a", "./state").unwrap(),
-		JsWord::from("./state")
-	);
-}
-
-pub fn generate_entries(
-	mut output: TransformOutput,
-	core_module: &JsWord,
-	explicit_extensions: bool,
-	root_dir: Option<&Path>,
-) -> Result<TransformOutput, anyhow::Error> {
-	let source_map = Lrc::new(SourceMap::default());
-	let mut entries_map: BTreeMap<&str, Vec<&HookAnalysis>> = BTreeMap::new();
-	let mut new_modules = Vec::with_capacity(output.modules.len());
-	{
-		let hooks: Vec<&HookAnalysis> = output.modules.iter().flat_map(|m| &m.hook).collect();
-		for hook in hooks {
-			if let Some(ref e) = hook.entry {
-				entries_map.entry(e.as_ref()).or_default().push(hook);
-			}
-		}
-
-		for (entry, hooks) in &entries_map {
-			let module = new_entry_module(entry, hooks, core_module, explicit_extensions);
-			let (code, map) =
-				emit_source_code(Lrc::clone(&source_map), None, &module, root_dir, false)
-					.context("Emitting source code")?;
-			new_modules.push(TransformModule {
-				path: [entry, ".js"].concat(),
-				code,
-				map,
-				is_entry: true,
-				hook: None,
-				order: 0,
-			});
-		}
-	}
-	output.modules.append(&mut new_modules);
-
-	Ok(output)
-}
-
-fn new_entry_module(
-	path: &str,
-	hooks: &[&HookAnalysis],
-	core_module: &JsWord,
-	explicit_extensions: bool,
-) -> ast::Module {
-	let mut module = ast::Module {
-		span: DUMMY_SP,
-		body: Vec::with_capacity(hooks.len()),
-		shebang: None,
-	};
-	let mut need_handle_watch = false;
-	for hook in hooks {
-		// TODO fix the path from the entry to the hook in case of mismatched location
-		let mut src = fix_path(
-			hook.path.to_string(),
-			Path::new(path).parent().unwrap().to_str().unwrap(),
-			&["./", &hook.canonical_filename].concat(),
-		)
-		.unwrap()
-		.to_string();
-		if explicit_extensions {
-			src = src + "." + hook.extension.as_ref();
-		}
-		if might_need_handle_watch(&hook.ctx_kind, &hook.ctx_name) {
-			need_handle_watch = true;
-		}
-		module
-			.body
-			.push(ast::ModuleItem::ModuleDecl(ast::ModuleDecl::ExportNamed(
-				ast::NamedExport {
-					span: DUMMY_SP,
-					type_only: false,
-					with: None,
-					src: Some(Box::new(ast::Str {
-						span: DUMMY_SP,
-						value: JsWord::from(src),
-						raw: None,
-					})),
-					specifiers: vec![ast::ExportSpecifier::Named(ast::ExportNamedSpecifier {
-						is_type_only: false,
-						span: DUMMY_SP,
-						orig: ast::ModuleExportName::Ident(ast::Ident::new(
-							hook.name.clone(),
-							DUMMY_SP,
-							Default::default(),
-						)),
-						exported: None,
-					})],
-				},
-			)));
-	}
-	if need_handle_watch {
-		add_handle_watch(&mut module.body, core_module);
-	}
-	module
 }
 
 pub fn transform_function_expr(

--- a/packages/qwik/src/optimizer/core/src/lib.rs
+++ b/packages/qwik/src/optimizer/core/src/lib.rs
@@ -43,7 +43,6 @@ use std::path::Path;
 use std::str;
 use swc_atoms::JsWord;
 
-use crate::code_move::generate_entries;
 use crate::entry_strategy::parse_entry_strategy;
 pub use crate::entry_strategy::EntryStrategy;
 pub use crate::parse::EmitMode;
@@ -160,23 +159,7 @@ pub fn transform_fs(config: TransformFsOptions) -> Result<TransformOutput, Error
 		.reduce(|| Ok(TransformOutput::new()), |x, y| Ok(x?.append(&mut y?)))?;
 
 	final_output.modules.sort_unstable_by_key(|key| key.order);
-	if !matches!(
-		config.entry_strategy,
-		EntryStrategy::Hook | EntryStrategy::Inline | EntryStrategy::Hoist
-	) {
-		final_output = generate_entries(
-			final_output,
-			&core_module,
-			config.explicit_extensions,
-			root_dir,
-		)?;
-	}
-	// final_output = generate_entries(
-	//     final_output,
-	//     &core_module,
-	//     config.explicit_extensions,
-	//     root_dir,
-	// )?;
+
 	Ok(final_output)
 }
 
@@ -231,23 +214,6 @@ pub fn transform_modules(config: TransformModulesOptions) -> Result<TransformOut
 
 	let mut final_output = final_output?;
 	final_output.modules.sort_unstable_by_key(|key| key.order);
-	if !matches!(
-		config.entry_strategy,
-		EntryStrategy::Hook | EntryStrategy::Inline | EntryStrategy::Hoist
-	) {
-		final_output = generate_entries(
-			final_output,
-			&core_module,
-			config.explicit_extensions,
-			root_dir,
-		)?;
-	}
-	// final_output = generate_entries(
-	//     final_output,
-	//     &core_module,
-	//     config.explicit_extensions,
-	//     root_dir,
-	// )?;
 
 	Ok(final_output)
 }

--- a/packages/qwik/src/optimizer/core/src/parse.rs
+++ b/packages/qwik/src/optimizer/core/src/parse.rs
@@ -379,7 +379,7 @@ pub fn transform_code(config: TransformCodeOptions) -> Result<TransformOutput, a
 						]
 						.concat();
 						let need_handle_watch =
-							might_need_handle_watch(&h.data.ctx_kind, &h.data.ctx_name) && is_entry;
+							might_need_handle_watch(&h.data.ctx_kind, &h.data.ctx_name);
 
 						let (mut hook_module, comments) = new_module(NewModuleCtx {
 							expr: h.expr,
@@ -676,7 +676,6 @@ fn handle_error(
 pub struct PathData {
 	pub abs_path: PathBuf,
 	pub rel_path: PathBuf,
-	pub base_dir: PathBuf,
 	pub abs_dir: PathBuf,
 	pub rel_dir: PathBuf,
 	pub file_stem: String,
@@ -706,7 +705,6 @@ pub fn parse_path(src: &str, base_dir: &Path) -> Result<PathData, Error> {
 
 	Ok(PathData {
 		abs_path,
-		base_dir: base_dir.to_path_buf(),
 		rel_path: path.into(),
 		abs_dir,
 		rel_dir,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_11.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_11.snap
@@ -29,6 +29,7 @@ export const App = component$(() => {
 
 import dep3 from "dep3/something";
 export const Header_component_Header_onClick_KjD9TCNkNxY = (ev)=>dep3(ev);
+export { _hW } from "@builder.io/qwik";
 
 
 Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\":[],\"mappings\":\";2DAQ2B,CAAC,KAAO,KAAK\"}")
@@ -59,13 +60,13 @@ import { bar as bbar } from "../state";
 import * as dep2 from "dep2";
 import { qrl } from "@builder.io/qwik";
 export const Header_component_UVBJuFYfvDo = ()=>{
-    return <Header onClick={/*#__PURE__*/ qrl(()=>import("../entry_hooks"), "Header_component_Header_onClick_KjD9TCNkNxY")}>
+    return <Header onClick={/*#__PURE__*/ qrl(()=>import("./header_component_header_onclick_kjd9tcnknxy"), "Header_component_Header_onClick_KjD9TCNkNxY")}>
             {dep2.stuff()}{bbar()}
         </Header>;
 };
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\":[],\"mappings\":\";;;;4CAMiC;IAC7B,QACK,OAAO,yGAA8B;YAClC,CAAC,KAAK,KAAK,IAAI,OAAO;QAC1B,EAAE;AAEV\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\":[],\"mappings\":\";;;;4CAMiC;IAC7B,QACK,OAAO,wIAA8B;YAClC,CAAC,KAAK,KAAK,IAAI,OAAO;QAC1B,EAAE;AAEV\"}")
 /*
 {
   "origin": "project/test.tsx",
@@ -120,20 +121,11 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\"
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("../entry_hooks"), "Header_component_UVBJuFYfvDo"));
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("../entry_hooks"), "App_component_wGkRHWXaqjs"));
+export const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./header_component_uvbjufyfvdo"), "Header_component_UVBJuFYfvDo"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_wgkrhwxaqjs"), "App_component_wGkRHWXaqjs"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\":[],\"mappings\":\";;AAMA,OAAO,MAAM,uBAAS,8FAMnB;AAEH,OAAO,MAAM,oBAAM,2FAIhB\"}")
-============================= entry_hooks.js (ENTRY POINT)==
-
-export { Header_component_Header_onClick_KjD9TCNkNxY } from "./project/header_component_header_onclick_kjd9tcnknxy";
-export { Header_component_UVBJuFYfvDo } from "./project/header_component_uvbjufyfvdo";
-export { App_component_wGkRHWXaqjs } from "./project/app_component_wgkrhwxaqjs";
-export { _hW } from "@builder.io/qwik";
-
-
-None
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\":[],\"mappings\":\";;AAMA,OAAO,MAAM,uBAAS,8GAMnB;AAEH,OAAO,MAAM,oBAAM,wGAIhB\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_default_export.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_default_export.snap
@@ -21,10 +21,10 @@ export default component$(() => {
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export default /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("../../../../src/routes/_repl/[id]/[[...slug]].tsx_entry_[[...slug]].js"), "slug_component_0AM8HPnkNs4"));
+export default /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./slug_component_0am8hpnkns4.js"), "slug_component_0AM8HPnkNs4"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/src/routes/_repl/[id]/[[...slug]].tsx\"],\"names\":[],\"mappings\":\";;AAIA,6BAAe,oJAKZ\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/src/routes/_repl/[id]/[[...slug]].tsx\"],\"names\":[],\"mappings\":\";;AAIA,6BAAe,6GAKZ\"}")
 ============================= src/routes/_repl/[id]/slug_component_div_onclick_xevvy0qc7pa.js (ENTRY POINT)==
 
 import { sibling } from "./sibling";
@@ -84,12 +84,6 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/src/routes/_repl/[id]/[[...sl
   ]
 }
 */
-============================= src/routes/_repl/[id]/[[...slug]].tsx_entry_[[...slug]].js (ENTRY POINT)==
-
-export { slug_component_0AM8HPnkNs4 } from "./slug_component_0am8hpnkns4.js";
-
-
-None
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_drop_side_effects.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_drop_side_effects.snap
@@ -41,6 +41,14 @@ import { serverQrl } from "@builder.io/qwik-city";
 import { _noopQrlDEV } from "@builder.io/qwik";
 import { componentQrl } from "@builder.io/qwik";
 import { qrlDEV } from "@builder.io/qwik";
+import { sideEffect } from './secret';
+(function() {
+    console.log('run');
+})();
+(()=>{
+    console.log('run');
+})();
+sideEffect();
 export const api = serverQrl(/*#__PURE__*/ _noopQrlDEV("api_server_JonPp043gH0", {
     file: "/user/qwik/src/test.tsx",
     lo: 0,
@@ -55,7 +63,7 @@ export default /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrlDEV(()=>import("./tes
 }));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;AAoBA,OAAO,MAAM,MAAM;;;;;IAEhB;AAEH,6BAAe;;;;;IAIV\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;AAMA,SAAS,UAAU,QAAQ,WAAW;AAKtC,CAAC;IACG,QAAQ,GAAG,CAAC;AACd,CAAC;AACD,CAAC;IACC,QAAQ,GAAG,CAAC;AACd,CAAC;AAEH;AAEA,OAAO,MAAM,MAAM;;;;;IAEhB;AAEH,6BAAe;;;;;IAIV\"}")
 ============================= test_component_button_onclick_dgk9xlyroka.js (ENTRY POINT)==
 
 import { api } from "./test";

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_explicit_ext_no_transpile.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_explicit_ext_no_transpile.snap
@@ -19,10 +19,10 @@ export const App = component$((props) => {
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./entry_hooks.tsx"), "App_component_ckEPmXZlub0"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_ckepmxzlub0.tsx"), "App_component_ckEPmXZlub0"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,8FAKhB\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,4GAKhB\"}")
 ============================= app_component_usestyles_t35nsa5uv7u.tsx ==
 
 export const App_component_useStyles_t35nSa5UV7U = 'hola';
@@ -54,8 +54,8 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 import { qrl } from "@builder.io/qwik";
 import { useStylesQrl } from "@builder.io/qwik";
 export const App_component_ckEPmXZlub0 = (props)=>{
-    useStylesQrl(/*#__PURE__*/ qrl(()=>import("./entry_hooks.tsx"), "App_component_useStyles_t35nSa5UV7U"));
-    return /*#__PURE__*/ qrl(()=>import("./entry_hooks.tsx"), "App_component_1_w0t0o3QMovU");
+    useStylesQrl(/*#__PURE__*/ qrl(()=>import("./app_component_usestyles_t35nsa5uv7u.tsx"), "App_component_useStyles_t35nSa5UV7U"));
+    return /*#__PURE__*/ qrl(()=>import("./app_component_1_w0t0o3qmovu.tsx"), "App_component_1_w0t0o3QMovU");
 };
 
 
@@ -83,6 +83,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 ============================= app_component_1_w0t0o3qmovu.tsx ==
 
 export const App_component_1_w0t0o3QMovU = ()=><div></div>;
+export { _hW } from "@builder.io/qwik";
 
 
 Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"2CAKa,KACJ,MAAM\"}")
@@ -106,15 +107,6 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= entry_hooks.js (ENTRY POINT)==
-
-export { App_component_useStyles_t35nSa5UV7U } from "./app_component_usestyles_t35nsa5uv7u.tsx";
-export { App_component_ckEPmXZlub0 } from "./app_component_ckepmxzlub0.tsx";
-export { App_component_1_w0t0o3QMovU } from "./app_component_1_w0t0o3qmovu.tsx";
-export { _hW } from "@builder.io/qwik";
-
-
-None
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_fix_dynamic_import.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_fix_dynamic_import.snap
@@ -61,16 +61,10 @@ import { qrl } from "@builder.io/qwik";
 export function foo() {
     return import("../foo/state2");
 }
-export const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("../../entry_hooks"), "Header_component_RGgm7Ks9QWI"));
+export const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./header_component_rggm7ks9qwi"), "Header_component_RGgm7Ks9QWI"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/folder/test.tsx\"],\"names\":[],\"mappings\":\";;AAIA,OAAO,SAAS;IACZ,OAAO,MAAM,CAAC;AAClB;AAEA,OAAO,MAAM,uBAAS,iGAOnB\"}")
-============================= entry_hooks.js (ENTRY POINT)==
-
-export { Header_component_RGgm7Ks9QWI } from "./project/folder/header_component_rggm7ks9qwi";
-
-
-None
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/folder/test.tsx\"],\"names\":[],\"mappings\":\";;AAIA,OAAO,SAAS;IACZ,OAAO,MAAM,CAAC;AAClB;AAEA,OAAO,MAAM,uBAAS,8GAOnB\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_manual_chunks.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_manual_chunks.snap
@@ -55,6 +55,7 @@ export const Parent_component_useTask_gDH1EtUWqBU = async ()=>{
     state.text = await mongo.users();
     redis.set(state.text);
 };
+export { _hW } from "@builder.io/qwik";
 
 
 Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;oDAWa;;IACL,MAAM,IAAI,GAAG,MAAM,MAAM,KAAK;IAC9B,MAAM,GAAG,CAAC,MAAM,IAAI\"}")
@@ -82,11 +83,11 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Parent = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_entry_Parent"), "Parent_component_0TaiDayHrlo"));
-export const Child = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_entry_Child"), "Child_component_9GyF01GDKqw"));
+export const Parent = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./parent_component_0taidayhrlo"), "Parent_component_0TaiDayHrlo"));
+export const Child = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./child_component_9gyf01gdkqw"), "Child_component_9GyF01GDKqw"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAKA,OAAO,MAAM,uBAAS,uGAgBnB;AAEH,OAAO,MAAM,sBAAQ,qGAelB\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAKA,OAAO,MAAM,uBAAS,8GAgBnB;AAEH,OAAO,MAAM,sBAAQ,4GAelB\"}")
 ============================= child_component_usetask_oh4n7zeqjku.js ==
 
 import { useLexicalScope } from "@builder.io/qwik";
@@ -95,6 +96,7 @@ export const Child_component_useTask_Oh4n7ZeqJkU = async ()=>{
     const [state] = useLexicalScope();
     state.text = await mongo.users();
 };
+export { _hW } from "@builder.io/qwik";
 
 
 Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;mDA6Ba;;IACL,MAAM,IAAI,GAAG,MAAM,MAAM,KAAK\"}")
@@ -130,7 +132,7 @@ export const Parent_component_0TaiDayHrlo = ()=>{
         text: ''
     });
     // Double count watch
-    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_entry_Parent"), "Parent_component_useTask_gDH1EtUWqBU", [
+    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./parent_component_usetask_gdh1etuwqbu"), "Parent_component_useTask_gDH1EtUWqBU", [
         state
     ]));
     return /*#__PURE__*/ _jsxQ("div", null, {
@@ -200,7 +202,7 @@ export const Child_component_9GyF01GDKqw = ()=>{
         text: ''
     });
     // Double count watch
-    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_entry_Child"), "Child_component_useTask_Oh4n7ZeqJkU", [
+    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./child_component_usetask_oh4n7zeqjku"), "Child_component_useTask_Oh4n7ZeqJkU", [
         state
     ]));
     return /*#__PURE__*/ _jsxQ("div", null, {
@@ -258,22 +260,6 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= test.tsx_entry_Child.js (ENTRY POINT)==
-
-export { Child_component_useTask_Oh4n7ZeqJkU } from "./child_component_usetask_oh4n7zeqjku";
-export { Child_component_9GyF01GDKqw } from "./child_component_9gyf01gdkqw";
-export { _hW } from "@builder.io/qwik";
-
-
-None
-============================= test.tsx_entry_Parent.js (ENTRY POINT)==
-
-export { Parent_component_useTask_gDH1EtUWqBU } from "./parent_component_usetask_gdh1etuwqbu";
-export { Parent_component_0TaiDayHrlo } from "./parent_component_0taidayhrlo";
-export { _hW } from "@builder.io/qwik";
-
-
-None
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_qwik_sdk_inline.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_qwik_sdk_inline.snap
@@ -1321,6 +1321,7 @@ export const QwikCityProvider_component_useTask_02wMImzEAbk = ({ track })=>{
     if (isServer) return promise;
     else return;
 };
+export { _hW } from "@builder.io/qwik";
 
 
 Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-city/index.qwik.mjs\"],\"names\":[],\"mappings\":\";;;;;;;;;;;;;;8DAycQ,CAAC,EAAE,KAAK,EAAE;IACR,MAAM,CACJ,cACA,UACA,kBACA,eACA,MACA,cACA,UACA,QACA,gBACA,KACD,GAAG;IACJ,eAAe;QACb,MAAM,CAAC,MAAM,OAAO,GAAG,MAAM,IAAM;gBAAC,SAAS,KAAK;gBAAE,aAAa,KAAK;aAAC;QACvE,MAAM,SAAS,UAAU;QACzB,IAAI;QACJ,IAAI;QACJ,IAAI,cAAc;QAClB,IAAI,UAAU;YACZ,WAAW,IAAI,IAAI,MAAM,eAAe,GAAG;YAC3C,cAAc,KAAK,WAAW;YAC9B,iBAAiB,KAAK,QAAQ;QAChC,OAAO;YACL,WAAW,IAAI,IAAI,MAAM;YACzB,IAAI,SAAS,QAAQ,CAAC,QAAQ,CAAC,MAC7B;gBAAA,IAAI,CAAC,SAAS,aAAa,EAAE,SAAS,QAAQ,GAAG,SAAS,QAAQ,CAAC,KAAK,CAAC,GAAG;YAAG,OAC1E,IAAI,SAAS,aAAa,EAAE,SAAS,QAAQ,IAAI;YACxD,IAAI,mBAAmB,UACrB,SAAS,MAAM,EACf,SAAS,KAAK,EACd,SAAS,YAAY,EACrB,SAAS,QAAQ;YAEnB,MAAM,UAAU;YAChB,MAAM,WAAY,iBAAiB,MAAM,eACvC,UACA,SACA,MACA;YAEF,IAAI,CAAC,UAAU;gBACb,SAAS,cAAc,GAAG,OAAO;gBACjC;YACF;YACA,MAAM,UAAU,SAAS,IAAI;YAC7B,MAAM,SAAS,IAAI,IAAI,SAAS,SAAS,IAAI;YAC7C,IAAI,OAAO,QAAQ,KAAK,SAAS,QAAQ,EAAE;gBACzC,WAAW;gBACX,mBAAmB,UACjB,SAAS,MAAM,EACf,SAAS,KAAK,EACd,SAAS,YAAY,EACrB,SAAS,QAAQ;YAErB;YACA,cAAc,MAAM;QACtB;QACA,IAAI,aAAa;YACf,MAAM,CAAC,QAAQ,MAAM,KAAK,GAAG;YAC7B,MAAM,iBAAiB;YACvB,MAAM,aAAa,cAAc,CAAC,eAAe,MAAM,GAAG,EAAE;YAC5D,eAAe,GAAG,GAAG;YACrB,eAAe,MAAM,GAAG;gBACtB,GAAG,MAAM;YACX;YACA,SAAS,cAAc,GAAG,OAAO;YACjC,MAAM,eAAe,YACnB,gBACA,gBACA,gBACA;YAEF,SAAS,QAAQ,GAAG,WAAW,QAAQ;YACvC,SAAS,IAAI,GAAG;YAChB,iBAAiB,KAAK,GAAG,YAAY;YACrC,cAAc,KAAK,GAAG,aAAa,KAAK;YACxC,cAAc,IAAI,GAAG,aAAa,IAAI;YACtC,cAAc,MAAM,GAAG,aAAa,MAAM;YAC1C,cAAc,KAAK,GAAG,aAAa,KAAK;YACxC,cAAc,WAAW,GAAG,aAAa,WAAW;YACpD,IAAI,WAAW;gBACb,IACE,CAAC,OAAO,cAAc,IAAI,IAAI,KAC9B,8BAA8B,OAAO,QAAQ,EAAE,OAE/C,SAAS,qBAAqB,GAAG;gBACnC,MAAM,UAAU,gBAAgB;gBAChC,IAAI,SAAS,OAAO,MAAM,CAAC,cAAc;gBACzC,kBAAkB,KAAK;gBACvB,eAAe,QAAQ,UAAU;gBACjC,eAAe,YAAY,GAAG;YAChC;QACF;IACF;IACA,MAAM,UAAU;IAChB,IAAI,UAAU,OAAO;SAChB;AACP\"}")
@@ -1368,7 +1369,7 @@ import { useStore } from "@builder.io/qwik";
 import { useStylesQrl } from "@builder.io/qwik";
 import { useTaskQrl } from "@builder.io/qwik";
 export const QwikCityProvider_component_TxCFOy819ag = (props)=>{
-    useStylesQrl(/*#__PURE__*/ qrl(()=>import("../../../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_QwikCityProvider.mjs"), "QwikCityProvider_component_useStyles_RPDJAz33WLA"));
+    useStylesQrl(/*#__PURE__*/ qrl(()=>import("./qwikcityprovider_component_usestyles_rpdjaz33wla.mjs"), "QwikCityProvider_component_useStyles_RPDJAz33WLA"));
     const env = useQwikCityEnv();
     if (!env?.params) throw new Error(`Missing Qwik City Env Data`);
     const urlEnv = useServerData('url');
@@ -1401,7 +1402,7 @@ export const QwikCityProvider_component_TxCFOy819ag = (props)=>{
             status: env.response.status
         }
     } : void 0);
-    const goto = eventQrl(/*#__PURE__*/ qrl(()=>import("../../../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_QwikCityProvider.mjs"), "QwikCityProvider_component_goto_event_cBcjROynRVg", [
+    const goto = eventQrl(/*#__PURE__*/ qrl(()=>import("./qwikcityprovider_component_goto_event_cbcjroynrvg.mjs"), "QwikCityProvider_component_goto_event_cBcjROynRVg", [
         actionState,
         navPath,
         routeLocation
@@ -1413,7 +1414,7 @@ export const QwikCityProvider_component_TxCFOy819ag = (props)=>{
     useContextProvider(RouteNavigateContext, goto);
     useContextProvider(RouteStateContext, loaderState);
     useContextProvider(RouteActionContext, actionState);
-    useTaskQrl(/*#__PURE__*/ qrl(()=>import("../../../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_QwikCityProvider.mjs"), "QwikCityProvider_component_useTask_02wMImzEAbk", [
+    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./qwikcityprovider_component_usetask_02wmimzeabk.mjs"), "QwikCityProvider_component_useTask_02wMImzEAbk", [
         actionState,
         content,
         contentInternal,
@@ -1504,7 +1505,7 @@ export const QwikCityMockProvider_component_WmYC5H00wtI = (props)=>{
         deep: false
     });
     const loaderState = useSignal({});
-    const goto = /*#__PURE__*/ qrl(()=>import("../../../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_QwikCityMockProvider.mjs"), "QwikCityMockProvider_component_goto_BUbtvTyvVRE");
+    const goto = /*#__PURE__*/ qrl(()=>import("./qwikcitymockprovider_component_goto_bubtvtyvvre.mjs"), "QwikCityMockProvider_component_goto_BUbtvTyvVRE");
     const documentHead = useStore(createDocumentHead, {
         deep: false
     });
@@ -1631,7 +1632,7 @@ export const Link_component_8gdLBszqbaM = (props)=>{
         ...linkProps,
         'data-prefetch': prefetchDataset,
         children: /* @__PURE__ */ _jsxC(Slot, null, 3, 'AD_0'),
-        onClick$: /*#__PURE__*/ qrl(()=>import("../../../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_Link.mjs"), "Link_component_a_onClick_kzjavhDI3L0", [
+        onClick$: /*#__PURE__*/ qrl(()=>import("./link_component_a_onclick_kzjavhdi3l0.mjs"), "Link_component_a_onClick_kzjavhDI3L0", [
             nav,
             reload
         ]),
@@ -1874,7 +1875,7 @@ export const GetForm_component_Nk9PlpjQm9Y = (props)=>{
     return /* @__PURE__ */ _jsxS('form', {
         ...rest,
         children: /* @__PURE__ */ _jsxC(Slot, null, 3, 'BC_0'),
-        onSubmit$: /*#__PURE__*/ qrl(()=>import("../../../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_GetForm.mjs"), "GetForm_component_form_onSubmit_p9MSze0ojs4", [
+        onSubmit$: /*#__PURE__*/ qrl(()=>import("./getform_component_form_onsubmit_p9msze0ojs4.mjs"), "GetForm_component_form_onSubmit_p9MSze0ojs4", [
             nav
         ])
     }, {
@@ -1925,7 +1926,7 @@ const DocumentHeadContext = /* @__PURE__ */ createContextId('qc-h');
 const RouteLocationContext = /* @__PURE__ */ createContextId('qc-l');
 const RouteNavigateContext = /* @__PURE__ */ createContextId('qc-n');
 const RouteActionContext = /* @__PURE__ */ createContextId('qc-a');
-const RouterOutlet = /* @__PURE__ */ componentQrl(/*#__PURE__*/ qrl(()=>import("../../../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_RouterOutlet.mjs"), "RouterOutlet_component_AKetNByE5TM"));
+const RouterOutlet = /* @__PURE__ */ componentQrl(/*#__PURE__*/ qrl(()=>import("./routeroutlet_component_aketnbye5tm.mjs"), "RouterOutlet_component_AKetNByE5TM"));
 const MODULE_CACHE = /* @__PURE__ */ new WeakMap();
 const CLIENT_DATA_CACHE = /* @__PURE__ */ new Map();
 const QACTION_KEY = 'qaction';
@@ -2192,9 +2193,9 @@ const useLocation = ()=>useContext(RouteLocationContext);
 const useNavigate = ()=>useContext(RouteNavigateContext);
 const useAction = ()=>useContext(RouteActionContext);
 const useQwikCityEnv = ()=>noSerialize(useServerData('qwikcity'));
-const QwikCityProvider = /* @__PURE__ */ componentQrl(/*#__PURE__*/ qrl(()=>import("../../../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_QwikCityProvider.mjs"), "QwikCityProvider_component_TxCFOy819ag"));
-const QwikCityMockProvider = /* @__PURE__ */ componentQrl(/*#__PURE__*/ qrl(()=>import("../../../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_QwikCityMockProvider.mjs"), "QwikCityMockProvider_component_WmYC5H00wtI"));
-const Link = /* @__PURE__ */ componentQrl(/*#__PURE__*/ qrl(()=>import("../../../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_Link.mjs"), "Link_component_8gdLBszqbaM"));
+const QwikCityProvider = /* @__PURE__ */ componentQrl(/*#__PURE__*/ qrl(()=>import("./qwikcityprovider_component_txcfoy819ag.mjs"), "QwikCityProvider_component_TxCFOy819ag"));
+const QwikCityMockProvider = /* @__PURE__ */ componentQrl(/*#__PURE__*/ qrl(()=>import("./qwikcitymockprovider_component_wmyc5h00wti.mjs"), "QwikCityMockProvider_component_WmYC5H00wtI"));
+const Link = /* @__PURE__ */ componentQrl(/*#__PURE__*/ qrl(()=>import("./link_component_8gdlbszqbam.mjs"), "Link_component_8gdLBszqbaM"));
 const prefetchLinkResources = (elm, isOnVisible)=>{
     if (elm && elm.href && elm.hasAttribute('data-prefetch')) {
         if (!windowInnerWidth) windowInnerWidth = innerWidth;
@@ -2232,7 +2233,7 @@ const routeActionQrl = (actionQrl, ...rest)=>{
             }
             return initialState;
         });
-        const submit = /*#__PURE__*/ qrl(()=>import("../../../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_routeActionQrl.mjs"), "routeActionQrl_action_submit_A5bZC7WO00A", [
+        const submit = /*#__PURE__*/ qrl(()=>import("./routeactionqrl_action_submit_a5bzc7wo00a.mjs"), "routeActionQrl_action_submit_A5bZC7WO00A", [
             currentAction,
             id,
             loc,
@@ -2315,7 +2316,7 @@ const serverQrl = (qrl1)=>{
         if (captured && captured.length > 0 && !_getContextElement()) throw new Error('For security reasons, we cannot serialize QRLs that capture lexical scope.');
     }
     function stuff() {
-        return /*#__PURE__*/ qrl(()=>import("../../../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_serverQrl.mjs"), "serverQrl_stuff_wOIPfiQ04l4", [
+        return /*#__PURE__*/ qrl(()=>import("./serverqrl_stuff_woipfiq04l4.mjs"), "serverQrl_stuff_wOIPfiQ04l4", [
             qrl1
         ]);
     }
@@ -2415,7 +2416,7 @@ const Form = ({ action, spaReset, reloadDocument, onSubmit$, ...rest }, key)=>{
         ...rest
     }, 0, key);
 };
-const GetForm = /* @__PURE__ */ componentQrl(/*#__PURE__*/ qrl(()=>import("../../../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_GetForm.mjs"), "GetForm_component_Nk9PlpjQm9Y"));
+const GetForm = /* @__PURE__ */ componentQrl(/*#__PURE__*/ qrl(()=>import("./getform_component_nk9plpjqm9y.mjs"), "GetForm_component_Nk9PlpjQm9Y"));
 export { Form, Link, QwikCityMockProvider, QwikCityProvider, RouterOutlet, ServiceWorkerRegister, globalAction$, globalActionQrl, routeAction$, routeActionQrl, routeLoader$, routeLoaderQrl, server$, serverQrl, useContent, useDocumentHead, useLocation, useNavigate, validator$, validatorQrl, z2 as z, zod$, zodQrl };
 export { CLIENT_DATA_CACHE as _auto_CLIENT_DATA_CACHE };
 export { ContentContext as _auto_ContentContext };
@@ -2441,55 +2442,6 @@ export { useQwikCityEnv as _auto_useQwikCityEnv };
 
 
 Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-city/index.qwik.mjs\"],\"names\":[],\"mappings\":\";AAAA,SACE,eAAe,EACf,YAAY,EAEZ,UAAU,EAGV,UAAU,EACV,KAAK,EAEL,UAAU,EACV,gBAAgB,EAChB,WAAW,EACX,aAAa,EAEb,QAAQ,EAIR,kBAAkB,EAMlB,KAAK,EACL,KAAK,EACL,WAAW,EACX,iBAAiB,QAIZ,mBAAmB;AAC1B,SAAoB,QAAQ,EAAE,KAAK,QAAQ,yBAAyB;AAEpE,OAAO,gBAAgB,yBAAyB;AAChD,SAAS,CAAC,QAAQ,MAAM;AACxB,SAAS,KAAK,EAAE,QAAQ,MAAM;AAC9B,MAAM,oBAAoB,aAAa,GAAG,gBAAgB;AAC1D,MAAM,iBAAiB,aAAa,GAAG,gBAAgB;AACvD,MAAM,yBAAyB,aAAa,GAAG,gBAAgB;AAC/D,MAAM,sBAAsB,aAAa,GAAG,gBAAgB;AAC5D,MAAM,uBAAuB,aAAa,GAAG,gBAAgB;AAC7D,MAAM,uBAAuB,aAAa,GAAG,gBAAgB;AAC7D,MAAM,qBAAqB,aAAa,GAAG,gBAAgB;AAC3D,MAAM,eAAe,aAAa,GAAG;AAsCrC,MAAM,eAAe,aAAa,GAAG,IAAI;AACzC,MAAM,oBAAoB,aAAa,GAAG,IAAI;AAC9C,MAAM,cAAc;AACpB,MAAM,SAAS,CAAC,MAAQ,IAAI,QAAQ,GAAG,IAAI,MAAM,GAAG,IAAI,IAAI;AAC5D,MAAM,QAAQ,CAAC,KAAK,UAAY,IAAI,IAAI,KAAK,QAAQ,IAAI;AACzD,MAAM,eAAe,CAAC,GAAG,IAAM,EAAE,MAAM,KAAK,EAAE,MAAM;AACpD,MAAM,aAAa,CAAC,GAAG,IAAM,EAAE,QAAQ,GAAG,EAAE,MAAM,KAAK,EAAE,QAAQ,GAAG,EAAE,MAAM;AAC5E,MAAM,iBAAiB,CAAC,GAAG,IAAM,EAAE,QAAQ,KAAK,EAAE,QAAQ;AAC1D,MAAM,gCAAgC,CAAC,GAAG,IAAM,aAAa,GAAG,MAAM,CAAC,WAAW,GAAG;AACrF,MAAM,oBAAoB,CAAC,UAAU,YAAY;IAC/C,IAAI,SAAS,cAAc;IAC3B,IAAI,QAAQ,UAAU,CAAC,SAAS,MAAM,GAAG,IAAI,cAAc,MAAM,mBAAmB,OAAO,EAAE;IAC7F,OAAO,WAAW,CAAC,SAAS,QAAQ,CAAC,OAAO,KAAK,GAAG,IAAI,gBAAgB;AAC1E;AACA,MAAM,mBAAmB,CAAC,OAAO;IAC/B,MAAM,OAAO,MAAM,IAAI;IACvB,IAAI,OAAO,SAAS,YAAY,KAAK,IAAI,OAAO,MAAM,OAAO,MAAM,MAAM,KAAK,UAC5E,IAAI;QACF,MAAM,UAAU,MAAM,MAAM,QAAQ,GAAG;QACvC,MAAM,aAAa,MAAM,IAAI,QAAQ,GAAG;QACxC,IAAI,aAAa,SAAS,aAAa,OAAO,OAAO;IACvD,EAAE,OAAO,GAAG;QACV,QAAQ,KAAK,CAAC;IAChB;SACG,IAAI,MAAM,MAAM,EAAE,OAAO,OAAO,MAAM,IAAI,QAAQ,GAAG;IAC1D,OAAO;AACT;AACA,MAAM,qBAAqB,CAAC,OAAO,eAAe;IAChD,IAAI,MAAM,QAAQ,KAAK,QAAQ,eAAe;QAC5C,MAAM,cAAc,MAAM,eAAe,WAAW,GAAG;QACvD,IAAI,CAAC,eAAe,aAAa,MAAM,IAAI,WAAW,GAAG,IAAI,OAAO;IACtE;IACA,OAAO;AACT;AACA,MAAM,iBAAiB,CAAC,KAAK,QAAQ;IACnC,MAAM,aAAa,IAAI,QAAQ;IAC/B,IAAI,8BAA8B,YAAY,SAAS;QACrD,aAAa,KAAK,YAAY;QAC9B,IAAI,OAAO,CAAC,SAAS,CAAC,IAAI,IAAI,OAAO;IACvC;IACA,IAAI,CAAC,IAAI,aAAa,EAAE;QACtB,IAAI,aAAa,GAAG;QACpB,IAAI,gBAAgB,CAAC,YAAY;YAC/B,MAAM,cAAc,IAAI,QAAQ;YAChC,MAAM,cAAc,MAAM,cAAc,KAAK,EAAE;YAC/C,IAAI,8BAA8B,aAAa,cAAc;gBAC3D,aAAa,KAAK,aAAa;gBAC/B,cAAc,KAAK,GAAG,OAAO,IAAI,IAAI,YAAY,IAAI;YACvD;QACF;QACA,IAAI,mBAAmB,CAAC,YAAY,IAAI,sBAAsB;IAChE;AACF;AACA,MAAM,eAAe,OAAO,KAAK,aAAa;IAC5C,MAAM,MAAM,IAAI,QAAQ;IACxB,MAAM,UAAU,OAAO,IAAI;IAC3B,IAAI,WAAW,aAAa,SAC1B;QAAA,IAAI,YAAY,IAAI,KAAK,SAAS;YAChC,MAAM;YACN,IAAI,SAAS,eAAe,KAAK;iBAC5B,IAAI,QAAQ,CAAC,GAAG;QACvB;IAAA,OACK;QACL,IAAI,SACF,IAAK,IAAI,IAAI,GAAG,IAAI,IAAI,IAAK;YAC3B,MAAM;YACN,IAAI,eAAe,KAAK,UAAU;QACpC;aACG;YACH,MAAM;YACN,IAAI,QAAQ,CAAC,GAAG;QAClB;IACF;AACF;AACA,MAAM,UAAU,IAAM,IAAI,QAAQ,CAAC,UAAY,WAAW,SAAS;AACnE,MAAM,iBAAiB,CAAC,KAAK;IAC3B,MAAM,QAAQ,KAAK,KAAK,CAAC;IACzB,MAAM,MAAM,IAAI,cAAc,CAAC;IAC/B,IAAI,KAAK,IAAI,cAAc;IAC3B,OAAO;AACT;AACA,MAAM,wBAAwB,CAAC;IAC7B,IAAI,OAAO,aAAa,aACtB,SAAS,aAAa,CACpB,IAAI,YAAY,aAAa;QAC3B,QAAQ;IACV;AAEN;AACA,MAAM,cAAc,CAAC,UAAU,eAAe,gBAAgB;IAC5D,MAAM,OAAO;IACb,MAAM,UAAU,CAAC;QACf,MAAM,KAAK,eAAe,IAAI;QAC9B,IAAI,eAAe,OAAO,KAAK,iBAAiB;YAC9C,IAAI,CAAC,CAAC,MAAM,SAAS,OAAO,GAC1B,MAAM,IAAI,MACR;QAEN;QACA,MAAM,OAAO,SAAS,OAAO,CAAC,GAAG;QACjC,IAAI,gBAAgB,SAClB,MAAM,IAAI,MAAM;QAClB,OAAO;IACT;IACA,MAAM,YAAY;QAChB;QACA,YAAY,CAAC,KAAO,WAAW,QAAQ;QACvC,cAAc;QACd,GAAG,aAAa;IAClB;IACA,IAAK,IAAI,IAAI,eAAe,MAAM,GAAG,GAAG,KAAK,GAAG,IAAK;QACnD,MAAM,oBAAoB,cAAc,CAAC,EAAE,IAAI,cAAc,CAAC,EAAE,CAAC,IAAI;QACrE,IAAI,mBAAmB;YACrB,IAAI,OAAO,sBAAsB,YAC/B,oBACE,MACA,WAAW,QAAQ,IAAM,kBAAkB;iBAE1C,IAAI,OAAO,sBAAsB,UAAU,oBAAoB,MAAM;QAC5E;IACF;IACA,OAAO,UAAU,IAAI;AACvB;AACA,MAAM,sBAAsB,CAAC,cAAc;IACzC,IAAI,OAAO,YAAY,KAAK,KAAK,UAAU,aAAa,KAAK,GAAG,YAAY,KAAK;IACjF,WAAW,aAAa,IAAI,EAAE,YAAY,IAAI;IAC9C,WAAW,aAAa,KAAK,EAAE,YAAY,KAAK;IAChD,WAAW,aAAa,MAAM,EAAE,YAAY,MAAM;IAClD,OAAO,MAAM,CAAC,aAAa,WAAW,EAAE,YAAY,WAAW;AACjE;AACA,MAAM,aAAa,CAAC,aAAa;IAC/B,IAAI,MAAM,OAAO,CAAC,SAChB,KAAK,MAAM,WAAW,OAAQ;QAC5B,IAAI,OAAO,QAAQ,GAAG,KAAK,UAAU;YACnC,MAAM,gBAAgB,YAAY,SAAS,CAAC,CAAC,IAAM,EAAE,GAAG,KAAK,QAAQ,GAAG;YACxE,IAAI,gBAAgB,IAAI;gBACtB,WAAW,CAAC,cAAc,GAAG;gBAC7B;YACF;QACF;QACA,YAAY,IAAI,CAAC;IACnB;AACJ;AACA,MAAM,qBAAqB,IAAM,CAAC;QAChC,OAAO;QACP,MAAM,EAAE;QACR,OAAO,EAAE;QACT,QAAQ,EAAE;QACV,aAAa,CAAC;IAChB,CAAC;AACD,MAAM,YAAY,OAAO,QAAQ,OAAO,cAAc;IACpD,IAAI,MAAM,OAAO,CAAC,SAChB,KAAK,MAAM,SAAS,OAAQ;QAC1B,MAAM,QAAQ,KAAK,CAAC,EAAE,CAAC,IAAI,CAAC;QAC5B,IAAI,OAAO;YACT,MAAM,UAAU,KAAK,CAAC,EAAE;YACxB,MAAM,SAAS,cAAc,KAAK,CAAC,EAAE,EAAE;YACvC,MAAM,mBAAmB,KAAK,CAAC,EAAE;YACjC,MAAM,OAAO,IAAI,MAAM,QAAQ,MAAM;YACrC,MAAM,eAAe,EAAE;YACvB,MAAM,aAAa,cAAc,OAAO;YACxC,IAAI,OAAO,KAAK;YAChB,QAAQ,OAAO,CAAC,CAAC,cAAc;gBAC7B,WACE,cACA,cACA,CAAC,cAAiB,IAAI,CAAC,EAAE,GAAG,aAC5B;YAEJ;YACA,WACE,YACA,cACA,CAAC,aAAgB,OAAO,YAAY,SACpC;YAEF,IAAI,aAAa,MAAM,GAAG,GAAG,MAAM,QAAQ,GAAG,CAAC;YAC/C,OAAO;gBAAC;gBAAQ;gBAAM;gBAAM;aAAiB;QAC/C;IACF;IACF,OAAO;AACT;AACA,MAAM,aAAa,CAAC,cAAc,cAAc,cAAc;IAC5D,IAAI,OAAO,iBAAiB,YAAY;QACtC,MAAM,eAAe,aAAa,GAAG,CAAC;QACtC,IAAI,cAAc,aAAa;aAC1B;YACH,MAAM,IAAI;YACV,IAAI,OAAO,EAAE,IAAI,KAAK,YACpB,aAAa,IAAI,CACf,EAAE,IAAI,CAAC,CAAC;gBACN,IAAI,iBAAiB,OAAO,aAAa,GAAG,CAAC,cAAc;gBAC3D,aAAa;YACf;iBAEC,IAAI,GAAG,aAAa;QAC3B;IACF;AACF;AACA,MAAM,gBAAgB,CAAC,OAAO;IAC5B,IAAI,OAAO;QACT,WAAW,SAAS,QAAQ,CAAC,OAAO,WAAW,WAAW;QAC1D,MAAM,OAAO,MAAM,IAAI,CACrB,CAAC,IAAM,CAAC,CAAC,EAAE,KAAK,YAAY,SAAS,UAAU,CAAC,CAAC,CAAC,EAAE,GAAG,CAAC,SAAS,QAAQ,CAAC,OAAO,KAAK,GAAG;QAE3F,IAAI,MAAM,OAAO,IAAI,CAAC,EAAE;IAC1B;AACF;AACA,MAAM,gBAAgB,CAAC,YAAY;IACjC,MAAM,SAAS,CAAC;IAChB,IAAI,YACF,IAAK,IAAI,IAAI,GAAG,IAAI,WAAW,MAAM,EAAE,IAAK;QAC1C,MAAM,QAAQ,OAAO,CAAC,IAAI,EAAE,IAAI;QAChC,MAAM,IAAI,MAAM,QAAQ,CAAC,OAAO,MAAM,KAAK,CAAC,GAAG,MAAM;QACrD,MAAM,CAAC,UAAU,CAAC,EAAE,CAAC,GAAG,mBAAmB;IAC7C;IACF,OAAO;AACT;AACA,MAAM,iBAAiB,OAAO,KAAK,SAAS,YAAY;IACtD,MAAM,eAAe,IAAI,QAAQ;IACjC,MAAM,aAAa,IAAI,MAAM;IAC7B,MAAM,iBAAiB,kBAAkB,cAAc,YAAY;IACnE,IAAI,QAAQ,KAAK;IACjB,IAAI,CAAC,QAAQ,QAAQ,kBAAkB,GAAG,CAAC;IAC3C,sBAAsB;QACpB,OAAO;YAAC;SAAa;IACvB;IACA,IAAI,CAAC,OAAO;QACV,MAAM,UAAU,gBAAgB;QAChC,IAAI,QAAQ,OAAO,IAAI,GAAG,KAAK;QAC/B,QAAQ,MAAM,gBAAgB,SAAS,IAAI,CAAC,CAAC;YAC3C,MAAM,gBAAgB,IAAI,IAAI,IAAI,GAAG;YACrC,IAAI,cAAc,MAAM,KAAK,SAAS,MAAM,IAAI,CAAC,YAAY,cAAc,QAAQ,GAAG;gBACpF,SAAS,IAAI,GAAG,cAAc,IAAI;gBAClC;YACF;YACA,IAAI,CAAC,IAAI,OAAO,CAAC,GAAG,CAAC,mBAAmB,EAAE,EAAE,QAAQ,CAAC,SACnD,OAAO,IAAI,IAAI,GAAG,IAAI,CAAC,CAAC;gBACtB,MAAM,aAAa,iBAAiB,MAAM;gBAC1C,IAAI,CAAC,YAAY;oBACf,SAAS,IAAI,GAAG,IAAI,IAAI;oBACxB;gBACF;gBACA,IAAI,YAAY,kBAAkB,MAAM,CAAC;gBACzC,IAAI,WAAW,QAAQ,EAAE,SAAS,IAAI,GAAG,WAAW,QAAQ;qBACvD,IAAI,QAAQ;oBACf,MAAM,aAAa,WAAW,OAAO,CAAC,OAAO,EAAE,CAAC;oBAChD,OAAO,OAAO,CAAC;wBACb,QAAQ,IAAI,MAAM;wBAClB,QAAQ;oBACV;gBACF;gBACA,OAAO;YACT;iBACG;gBACH,SAAS,IAAI,GAAG,IAAI,IAAI;gBACxB,OAAO,KAAK;YACd;QACF;QACA,IAAI,CAAC,QAAQ,kBAAkB,GAAG,CAAC,gBAAgB;IACrD;IACA,OAAO,MAAM,IAAI,CAAC,CAAC;QACjB,IAAI,CAAC,GAAG,kBAAkB,MAAM,CAAC;QACjC,OAAO;IACT;AACF;AACA,MAAM,kBAAkB,CAAC;IACvB,MAAM,aAAa,QAAQ;IAC3B,IAAI,CAAC,YAAY,OAAO,KAAK;IAC7B,IAAI,sBAAsB,UACxB,OAAO;QACL,QAAQ;QACR,MAAM;IACR;SAEA,OAAO;QACL,QAAQ;QACR,MAAM,KAAK,SAAS,CAAC;QACrB,SAAS;YACP,gBAAgB;QAClB;IACF;AACJ;AACA,MAAM,cAAc,CAAC;IACnB,OAAO,SAAS,QAAQ,CAAC;AAC3B;AACA,MAAM,aAAa;AACnB,MAAM,aAAa,IAAM,WAAW;AACpC,MAAM,kBAAkB,IAAM,WAAW;AACzC,MAAM,cAAc,IAAM,WAAW;AACrC,MAAM,cAAc,IAAM,WAAW;AACrC,MAAM,YAAY,IAAM,WAAW;AACnC,MAAM,iBAAiB,IAAM,YAAY,cAAc;AACvD,MAAM,mBAAmB,aAAa,GAAG;AAsMzC,MAAM,uBAAuB,aAAa,GAAG;AAwC7C,MAAM,OAAO,aAAa,GAAG;AA0C7B,MAAM,wBAAwB,CAAC,KAAK;IAClC,IAAI,OAAO,IAAI,IAAI,IAAI,IAAI,YAAY,CAAC,kBAAkB;QACxD,IAAI,CAAC,kBAAkB,mBAAmB;QAC1C,IAAI,CAAC,eAAgB,eAAe,mBAAmB,KACrD,eAAe,IAAI,IAAI,IAAI,IAAI,GAAG;IACtC;AACF;AACA,IAAI,mBAAmB;AACvB,MAAM,wBAAwB,CAAC,QAC7B,MACE,UACA;QACE,OAAO,YAAY,OAAO;IAC5B,GACA;QACE,yBAAyB;IAC3B,GACA,MACA,GACA;AAEJ,MAAM,iBAAiB,CAAC,WAAW,GAAG;IACpC,MAAM,EAAE,EAAE,EAAE,UAAU,EAAE,GAAG,cAAc,MAAM;IAC/C,SAAS;QACP,MAAM,MAAM;QACZ,MAAM,gBAAgB;QACtB,MAAM,eAAe;YACnB,YAAY,CAAC,CAAC,EAAE,YAAY,CAAC,EAAE,GAAG,CAAC;YACnC,WAAW;YACX,QAAQ,KAAK;YACb,OAAO,KAAK;YACZ,UAAU,KAAK;QACjB;QACA,MAAM,QAAQ,SAAS;YACrB,MAAM,QAAQ,cAAc,KAAK;YACjC,IAAI,SAAS,OAAO,OAAO,IAAI;gBAC7B,MAAM,OAAO,MAAM,IAAI;gBACvB,IAAI,gBAAgB,UAAU,aAAa,QAAQ,GAAG;gBACtD,IAAI,MAAM,MAAM,EAAE;oBAChB,MAAM,EAAE,MAAM,EAAE,MAAM,EAAE,GAAG,MAAM,MAAM;oBACvC,aAAa,MAAM,GAAG;oBACtB,aAAa,KAAK,GAAG;gBACvB;YACF;YACA,OAAO;QACT;QACA,MAAM;;;;;;QAwDN,aAAa,MAAM,GAAG;QACtB,OAAO;IACT;IACA,OAAO,OAAO,GAAG;IACjB,OAAO,YAAY,GAAG;IACtB,OAAO,KAAK,GAAG;IACf,OAAO,IAAI,GAAG;IACd,OAAO,MAAM,CAAC;IACd,OAAO;AACT;AACA,MAAM,kBAAkB,CAAC,WAAW,GAAG;IACrC,MAAM,SAAS,eAAe,cAAc;IAC5C,IAAI,UAAU;QACZ,IAAI,OAAO,WAAW,eAAe,KAAK,aACxC,WAAW,eAAe,GAAG,aAAa,GAAG,IAAI;QACnD,WAAW,eAAe,CAAC,GAAG,CAAC,OAAO,IAAI,EAAE;IAC9C;IACA,OAAO;AACT;AACA,MAAM,eAAe,aAAa,GAAG,kBAAkB;AACvD,MAAM,gBAAgB,aAAa,GAAG,kBAAkB;AACxD,MAAM,iBAAiB,CAAC,WAAW,GAAG;IACpC,MAAM,EAAE,EAAE,EAAE,UAAU,EAAE,GAAG,cAAc,MAAM;IAC/C,SAAS;QACP,OAAO,WAAW,mBAAmB,CAAC;YACpC,IAAI,CAAC,CAAC,MAAM,KAAK,GACf,MAAM,IAAI,MAAM,CAAC,QAAQ,EAAE,GAAG;;uEAEiC,CAAC;YAClE,OAAO,YAAY,OAAO;QAC5B;IACF;IACA,OAAO,OAAO,GAAG;IACjB,OAAO,KAAK,GAAG;IACf,OAAO,YAAY,GAAG;IACtB,OAAO,IAAI,GAAG;IACd,OAAO,MAAM,CAAC;IACd,OAAO;AACT;AACA,MAAM,eAAe,aAAa,GAAG,kBAAkB;AACvD,MAAM,eAAe,CAAC;IACpB,IAAI,UACF,OAAO;QACL,UAAU;IACZ;IACF,OAAO,KAAK;AACd;AACA,MAAM,aAAa,aAAa,GAAG,kBAAkB;AACrD,MAAM,SAAS,CAAC;IACd,IAAI,UAAU;QACZ,MAAM,SAAS,IAAI,OAAO,GAAG,IAAI,CAAC,CAAC;YACjC,IAAI,OAAO,QAAQ,YAAY,MAAM,IAAI;YACzC,IAAI,eAAe,EAAE,MAAM,EAAE,OAAO;iBAC/B,OAAO,EAAE,MAAM,CAAC;QACvB;QACA,OAAO;YACL,MAAM,UAAS,EAAE,EAAE,SAAS;gBAC1B,MAAM,OAAO,aAAc,MAAM,GAAG,SAAS;gBAC7C,MAAM,SAAS,MAAM,CAAC,MAAM,MAAM,EAAE,cAAc,CAAC;gBACnD,IAAI,OAAO,OAAO,EAAE,OAAO;qBACtB;oBACH,IAAI,OACF,QAAQ,KAAK,CACX,sDACA,iBACA,OAAO,KAAK,CAAC,MAAM;oBAEvB,OAAO;wBACL,SAAS;wBACT,QAAQ;wBACR,OAAO,OAAO,KAAK,CAAC,OAAO;oBAC7B;gBACF;YACF;QACF;IACF;IACA,OAAO,KAAK;AACd;AACA,MAAM,OAAO,aAAa,GAAG,kBAAkB;AAC/C,MAAM,YAAY,CAAC;IACjB,IAAI,UAAU;QACZ,MAAM,WAAW,KAAI,WAAW;QAChC,IAAI,YAAY,SAAS,MAAM,GAAG,KAAK,CAAC,sBACtC,MAAM,IAAI,MAAM;IACpB;IACA,SAAS;QACP;;;IA0CF;IACA,OAAO;AACT;AACA,MAAM,UAAU,aAAa,GAAG,kBAAkB;AAClD,MAAM,gBAAgB,CAAC,MAAM;IAC3B,IAAI;IACJ,MAAM,aAAa,EAAE;IACrB,IAAI,KAAK,MAAM,KAAK,GAAG;QACrB,MAAM,UAAU,IAAI,CAAC,EAAE;QACvB,IAAI,WAAW,OAAO,YAAY;YAChC,IAAI,cAAc,SAAS,WAAW,IAAI,CAAC;iBACtC;gBACH,KAAK,QAAQ,EAAE;gBACf,IAAI,QAAQ,UAAU,EAAE,WAAW,IAAI,IAAI,QAAQ,UAAU;YAC/D;;IAEJ,OAAO,IAAI,KAAK,MAAM,GAAG,GAAG,WAAW,IAAI,IAAI,KAAK,MAAM,CAAC,CAAC,IAAM,CAAC,CAAC;IACpE,IAAI,OAAO,OAAO,UAAU;QAC1B,IAAI,OAAO;YACT,IAAI,CAAC,aAAa,IAAI,CAAC,KACrB,MAAM,IAAI,MAAM,CAAC,YAAY,EAAE,GAAG,oCAAoC,CAAC;QAC3E;QACA,KAAK,CAAC,GAAG,EAAE,GAAG,CAAC;IACjB,OAAO,KAAK,IAAI,OAAO;IACvB,OAAO;QACL,YAAY,WAAW,OAAO;QAC9B;IACF;AACF;AACA,MAAM,oBAAoB;IACxB,IAAI,cAAc;IAClB,MAAM,UAAU,IAAI;IACpB,MAAM,cAAc,IAAI,gBAAgB;QACtC,WAAU,KAAK,EAAE,UAAU;YACzB,MAAM,QAAQ,QAAQ,MAAM,CAAC,OAAO,KAAK,CAAC;YAC1C,IAAK,IAAI,IAAI,GAAG,IAAI,MAAM,MAAM,GAAG,GAAG,IAAK;gBACzC,MAAM,OAAO,cAAc,KAAK,CAAC,EAAE;gBACnC,IAAI,KAAK,MAAM,KAAK,GAAG;oBACrB,WAAW,SAAS;oBACpB;gBACF,OAAO;oBACL,WAAW,OAAO,CAAC,WAAW;oBAC9B,cAAc;gBAChB;YACF;YACA,eAAe,KAAK,CAAC,MAAM,MAAM,GAAG,EAAE;QACxC;IACF;IACA,OAAO;AACT;AACA,MAAM,aAAa,CAAC;IAClB,MAAM,QAAQ,QAAQ,KAAK,CAAC;IAC5B,MAAM,QAAQ;QACZ,MAAM;IACR;IACA,IAAI,OAAO;IACX,KAAK,MAAM,QAAQ,MACjB,IAAI,KAAK,UAAU,CAAC,WAAW,QAAQ,KAAK,KAAK,CAAC,KAAK;SAClD;QACH,MAAM,CAAC,KAAK,MAAM,GAAG,KAAK,KAAK,CAAC;QAChC,IAAI,OAAO,QAAQ,YAAY,OAAO,UAAU,UAAU,KAAK,CAAC,IAAI,GAAG,MAAM,IAAI;IACnF;IACF,MAAM,IAAI,GAAG;IACb,OAAO;AACT;AACA,gBAAgB,oBAAoB,MAAM,EAAE,MAAM;IAChD,MAAM,SAAS,OAAO,SAAS;IAC/B,IAAI;QACF,MAAO,KAAM;YACX,MAAM,EAAE,IAAI,EAAE,KAAK,EAAE,GAAG,MAAM,OAAO,IAAI;YACzC,IAAI,MAAM;YACV,MAAM,MAAM,MAAM,iBAAiB,MAAM,IAAI,EAAE;YAC/C,MAAM;QACR;IACF,SAAU;QACR,OAAO,WAAW;IACpB;AACF;AACA,MAAM,OAAO,CAAC,EAAE,MAAM,EAAE,QAAQ,EAAE,cAAc,EAAE,SAAS,EAAE,GAAG,MAAM,EAAE;IACtE;IACA,IAAI,QACF,OAAO,MACL,QACA;QACE,GAAG,IAAI;QACP,QAAQ,YAAY,QAAQ;QAC5B,yBAAyB,CAAC;QAC1B,CAAC,iBAAiB,EAAE,WAAW,SAAS,KAAK;QAC7C,WAAW;YAAC,CAAC,iBAAiB,OAAO,MAAM,GAAG,KAAK;YAAG;SAAU;IAClE,GACA;QACE,QAAQ;IACV,GACA,GACA;SAGF,OAAO,aAAa,GAAG,MACrB,SACA;QACE;QACA;QACA;QACA,GAAG,IAAI;IACT,GACA,GACA;AAEN;AACA,MAAM,UAAU,aAAa,GAAG;AAqDhC,SACE,IAAI,EACJ,IAAI,EACJ,oBAAoB,EACpB,gBAAgB,EAChB,YAAY,EACZ,qBAAqB,EACrB,aAAa,EACb,eAAe,EACf,YAAY,EACZ,cAAc,EACd,YAAY,EACZ,cAAc,EACd,OAAO,EACP,SAAS,EACT,UAAU,EACV,eAAe,EACf,WAAW,EACX,WAAW,EACX,UAAU,EACV,YAAY,EACZ,MAAM,CAAC,EACP,IAAI,EACJ,MAAM,GACN\"}")
-============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_GetForm.js (ENTRY POINT)==
-
-export { GetForm_component_form_onSubmit_p9MSze0ojs4 } from "./getform_component_form_onsubmit_p9msze0ojs4.mjs";
-export { GetForm_component_Nk9PlpjQm9Y } from "./getform_component_nk9plpjqm9y.mjs";
-
-
-None
-============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_Link.js (ENTRY POINT)==
-
-export { Link_component_a_onClick_kzjavhDI3L0 } from "./link_component_a_onclick_kzjavhdi3l0.mjs";
-export { Link_component_8gdLBszqbaM } from "./link_component_8gdlbszqbam.mjs";
-
-
-None
-============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_QwikCityMockProvider.js (ENTRY POINT)==
-
-export { QwikCityMockProvider_component_goto_BUbtvTyvVRE } from "./qwikcitymockprovider_component_goto_bubtvtyvvre.mjs";
-export { QwikCityMockProvider_component_WmYC5H00wtI } from "./qwikcitymockprovider_component_wmyc5h00wti.mjs";
-
-
-None
-============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_QwikCityProvider.js (ENTRY POINT)==
-
-export { QwikCityProvider_component_useStyles_RPDJAz33WLA } from "./qwikcityprovider_component_usestyles_rpdjaz33wla.mjs";
-export { QwikCityProvider_component_goto_event_cBcjROynRVg } from "./qwikcityprovider_component_goto_event_cbcjroynrvg.mjs";
-export { QwikCityProvider_component_useTask_02wMImzEAbk } from "./qwikcityprovider_component_usetask_02wmimzeabk.mjs";
-export { QwikCityProvider_component_TxCFOy819ag } from "./qwikcityprovider_component_txcfoy819ag.mjs";
-export { _hW } from "@builder.io/qwik";
-
-
-None
-============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_RouterOutlet.js (ENTRY POINT)==
-
-export { RouterOutlet_component_AKetNByE5TM } from "./routeroutlet_component_aketnbye5tm.mjs";
-
-
-None
-============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_routeActionQrl.js (ENTRY POINT)==
-
-export { routeActionQrl_action_submit_A5bZC7WO00A } from "./routeactionqrl_action_submit_a5bzc7wo00a.mjs";
-
-
-None
-============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_serverQrl.js (ENTRY POINT)==
-
-export { serverQrl_stuff_wOIPfiQ04l4 } from "./serverqrl_stuff_woipfiq04l4.mjs";
-
-
-None
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_use_server_mount.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_use_server_mount.snap
@@ -55,6 +55,7 @@ export const Parent_component_useTask_gDH1EtUWqBU = async ()=>{
     state.text = await mongo.users();
     redis.set(state.text);
 };
+export { _hW } from "@builder.io/qwik";
 
 
 Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;oDAWa;;IACL,MAAM,IAAI,GAAG,MAAM,MAAM,KAAK;IAC9B,MAAM,GAAG,CAAC,MAAM,IAAI\"}")
@@ -82,11 +83,11 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Parent = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_entry_Parent"), "Parent_component_0TaiDayHrlo"));
-export const Child = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_entry_Child"), "Child_component_9GyF01GDKqw"));
+export const Parent = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./parent_component_0taidayhrlo"), "Parent_component_0TaiDayHrlo"));
+export const Child = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./child_component_9gyf01gdkqw"), "Child_component_9GyF01GDKqw"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAKA,OAAO,MAAM,uBAAS,uGAgBnB;AAEH,OAAO,MAAM,sBAAQ,qGAelB\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAKA,OAAO,MAAM,uBAAS,8GAgBnB;AAEH,OAAO,MAAM,sBAAQ,4GAelB\"}")
 ============================= child_component_usetask_oh4n7zeqjku.js ==
 
 import { useLexicalScope } from "@builder.io/qwik";
@@ -95,6 +96,7 @@ export const Child_component_useTask_Oh4n7ZeqJkU = async ()=>{
     const [state] = useLexicalScope();
     state.text = await mongo.users();
 };
+export { _hW } from "@builder.io/qwik";
 
 
 Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;mDA6Ba;;IACL,MAAM,IAAI,GAAG,MAAM,MAAM,KAAK\"}")
@@ -130,7 +132,7 @@ export const Parent_component_0TaiDayHrlo = ()=>{
         text: ''
     });
     // Double count watch
-    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_entry_Parent"), "Parent_component_useTask_gDH1EtUWqBU", [
+    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./parent_component_usetask_gdh1etuwqbu"), "Parent_component_useTask_gDH1EtUWqBU", [
         state
     ]));
     return /*#__PURE__*/ _jsxQ("div", null, {
@@ -200,7 +202,7 @@ export const Child_component_9GyF01GDKqw = ()=>{
         text: ''
     });
     // Double count watch
-    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_entry_Child"), "Child_component_useTask_Oh4n7ZeqJkU", [
+    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./child_component_usetask_oh4n7zeqjku"), "Child_component_useTask_Oh4n7ZeqJkU", [
         state
     ]));
     return /*#__PURE__*/ _jsxQ("div", null, {
@@ -258,22 +260,6 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= test.tsx_entry_Child.js (ENTRY POINT)==
-
-export { Child_component_useTask_Oh4n7ZeqJkU } from "./child_component_usetask_oh4n7zeqjku";
-export { Child_component_9GyF01GDKqw } from "./child_component_9gyf01gdkqw";
-export { _hW } from "@builder.io/qwik";
-
-
-None
-============================= test.tsx_entry_Parent.js (ENTRY POINT)==
-
-export { Parent_component_useTask_gDH1EtUWqBU } from "./parent_component_usetask_gdh1etuwqbu";
-export { Parent_component_0TaiDayHrlo } from "./parent_component_0taidayhrlo";
-export { _hW } from "@builder.io/qwik";
-
-
-None
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/transform.rs
+++ b/packages/qwik/src/optimizer/core/src/transform.rs
@@ -1,4 +1,4 @@
-use crate::code_move::{fix_path, transform_function_expr};
+use crate::code_move::transform_function_expr;
 use crate::collector::{
 	collect_from_pat, new_ident_from_id, GlobalCollect, Id, IdentCollector, ImportKind,
 };
@@ -732,7 +732,8 @@ impl<'a> QwikTransform<'a> {
 	}
 
 	/// Removes `expr` from the AST and moves it to a separate import.
-	/// These import are then grouped into entry files depending on strategy.
+	/// These import are then grouped into entry files depending on strategy, which is used to
+	/// determine the chunks for bundling.
 	fn create_hook(
 		&mut self,
 		hook_data: HookData,
@@ -743,31 +744,19 @@ impl<'a> QwikTransform<'a> {
 	) -> ast::CallExpr {
 		let canonical_filename = get_canonical_filename(&symbol_name);
 
+		// We import from the hook file directly but store the entry for later chunking by the bundler
 		let entry = self.options.entry_policy.get_entry_for_sym(
 			&hook_data.hash,
 			&self.stack_ctxt,
 			&hook_data,
 		);
 
-		// We import from the given entry, or from the hook file directly
-		let mut url = entry
-			.as_ref()
-			.map(|e| {
-				fix_path(
-					&self.options.path_data.base_dir,
-					&self.options.path_data.abs_dir,
-					&["./", e.as_ref()].concat(),
-				)
-				.map(|f| f.to_string())
-			})
-			.unwrap_or_else(|| Ok(["./", &canonical_filename].concat()))
-			.unwrap();
+		let mut import_path = ["./", &canonical_filename].concat();
 		if self.options.explicit_extensions {
-			url.push('.');
-			url.push_str(&self.options.extension);
+			import_path.push('.');
+			import_path.push_str(&self.options.extension);
 		}
-
-		let import_expr = self.create_qrl(url.into(), &symbol_name, &hook_data, &span);
+		let import_expr = self.create_qrl(import_path.into(), &symbol_name, &hook_data, &span);
 		self.hooks.push(Hook {
 			entry,
 			span,
@@ -920,7 +909,7 @@ impl<'a> QwikTransform<'a> {
 
 	fn create_qrl(
 		&mut self,
-		url: JsWord,
+		path: JsWord,
 		symbol: &str,
 		hook_data: &HookData,
 		span: &Span,
@@ -938,7 +927,7 @@ impl<'a> QwikTransform<'a> {
 							spread: None,
 							expr: Box::new(ast::Expr::Lit(ast::Lit::Str(ast::Str {
 								span: DUMMY_SP,
-								value: url,
+								value: path,
 								raw: None,
 							}))),
 						}],

--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -12,7 +12,6 @@ import type {
   OptimizerOptions,
   OptimizerSystem,
   QwikManifest,
-  TransformFsOptions,
   TransformModule,
   TransformModuleInput,
   TransformModulesOptions,
@@ -354,89 +353,23 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
       }
     }
 
-    // Problematic part of the plugin: parse the entire source tree in the hopes of
-    // having all code combined into the entry hooks. This is a problem because it
-    // prevents other plugins from having a look at the untouched code.
-    // TODO work out a way to combine entries in a more incremental way
-    // Note: During dev mode, entry strategy is hook, so this doesn't run
-    const generatePreManifest = !['hoist', 'hook', 'inline'].includes(opts.entryStrategy.type);
-    if (generatePreManifest) {
-      const path = getPath();
+    const path = getPath();
 
-      let srcDir = '/';
-      if (typeof opts.srcDir === 'string') {
-        srcDir = normalizePath(opts.srcDir);
-        debug(`buildStart() srcDir`, opts.srcDir);
-      } else if (Array.isArray(opts.srcInputs)) {
-        optimizer.sys.getInputFiles = async (rootDir) =>
-          opts.srcInputs!.map((i) => {
-            const relInput: TransformModuleInput = {
-              path: normalizePath(path.relative(rootDir, i.path)),
-              code: i.code,
-            };
-            return relInput;
-          });
-        debug(`buildStart() opts.srcInputs (${opts.srcInputs.length})`);
-      }
-      const vendorRoots = opts.vendorRoots;
-      if (vendorRoots.length > 0) {
-        debug(`vendorRoots`, vendorRoots);
-      }
-
-      debug(`transformedOutput.clear()`);
-      clientTransformedOutputs.clear();
-
-      const mode =
-        opts.target === 'lib' ? 'lib' : opts.buildMode === 'development' ? 'dev' : 'prod';
-      const transformOpts: TransformFsOptions = {
-        srcDir,
-        rootDir: opts.rootDir,
-        vendorRoots,
-        entryStrategy: opts.entryStrategy,
-        minify: 'simplify',
-        transpileTs: true,
-        transpileJsx: true,
-        explicitExtensions: true,
-        preserveFilenames: true,
-        mode,
-        scope: opts.scope ? opts.scope : undefined,
-        sourceMaps: opts.sourcemap,
-      };
-
-      let outputs = clientTransformedOutputs;
-      if (opts.target === 'client') {
-        // Building for client only
-        transformOpts.stripCtxName = SERVER_STRIP_CTX_NAME;
-        transformOpts.stripExports = SERVER_STRIP_EXPORTS;
-        transformOpts.isServer = false;
-      } else if (opts.target === 'ssr' && !devServer) {
-        // Building for server, not in dev mode
-        transformOpts.stripCtxName = CLIENT_STRIP_CTX_NAME;
-        transformOpts.stripEventHandlers = true;
-        transformOpts.isServer = true;
-        transformOpts.regCtxName = REG_CTX_NAME;
-        outputs = serverTransformedOutputs;
-      }
-
-      const result = await optimizer.transformFs(transformOpts);
-      for (const output of result.modules) {
-        const key = normalizePath(path.join(srcDir, output.path)!);
-        debug(`buildStart() add transformedOutput`, key, output.hook?.displayName);
-        outputs.set(key, [output, key]);
-        if (opts.target === 'client' && output.isEntry) {
-          ctx.emitFile({
-            id: key,
-            type: 'chunk',
-            preserveSignature: 'allow-extension',
-          });
-        }
-      }
-
-      diagnosticsCallback(result.diagnostics, optimizer, srcDir);
-
-      clientResults.set('@buildStart', result);
-      serverResults.set('@buildStart', result);
+    if (Array.isArray(opts.srcInputs)) {
+      optimizer.sys.getInputFiles = async (rootDir) =>
+        opts.srcInputs!.map((i) => {
+          const relInput: TransformModuleInput = {
+            path: normalizePath(path.relative(rootDir, i.path)),
+            code: i.code,
+          };
+          return relInput;
+        });
+      debug(`buildStart() opts.srcInputs (${opts.srcInputs.length})`);
     }
+
+    debug(`transformedOutputs.clear()`);
+    clientTransformedOutputs.clear();
+    serverTransformedOutputs.clear();
   };
 
   const getIsServer = (viteOpts?: { ssr?: boolean }) => {
@@ -751,7 +684,7 @@ export function createPlugin(optimizerOptions: OptimizerOptions = {}) {
 
       if (isServer) {
         if (newOutput.diagnostics.length === 0 && linter) {
-          await linter.lint(ctx, code, id);
+          linter.lint(ctx, code, id);
         }
         serverResults.set(normalizedID, newOutput);
       } else {
@@ -908,6 +841,15 @@ export const manifest = ${JSON.stringify(manifest)};\n`;
     }
   }
 
+  // This groups all QRL segments into their respective entry points
+  // optimization opportunity: group small segments that don't import anything into smallish chunks
+  // order by discovery time, so that related segments are more likely to group together
+  function manualChunks(id: string, { getModuleInfo }: Rollup.ManualChunkMeta) {
+    const module = getModuleInfo(id)!;
+    const hook = module.meta.hook as HookAnalysis | undefined;
+    return hook?.entry;
+  }
+
   return {
     buildStart,
     createOutputAnalyzer,
@@ -931,6 +873,7 @@ export const manifest = ${JSON.stringify(manifest)};\n`;
     foundQrls,
     configureServer,
     handleHotUpdate,
+    manualChunks,
   };
 }
 

--- a/packages/qwik/src/optimizer/src/plugins/vite-dev-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-dev-server.ts
@@ -39,7 +39,6 @@ const encode = (url: string) =>
 function createSymbolMapper(
   base: string,
   opts: NormalizedQwikPluginOptions,
-  foundQrls: Map<string, string>,
   path: Path,
   sys: OptimizerSystem
 ): SymbolMapperFn {
@@ -55,13 +54,7 @@ function createSymbolMapper(
     const hash = getSymbolHash(symbolName);
     if (!parent) {
       console.warn(
-        `qwik vite-dev-server symbolMapper: parent not provided for ${symbolName}, falling back to foundQrls.`
-      );
-      parent = foundQrls.get(hash);
-    }
-    if (!parent) {
-      console.warn(
-        `qwik vite-dev-server symbolMapper: ${symbolName} not in foundQrls, falling back to mapper.`
+        `qwik vite-dev-server symbolMapper: parent not provided for ${symbolName}, falling back to mapper.`
       );
       const chunk = mapper && mapper[hash];
       if (chunk) {
@@ -110,10 +103,9 @@ export async function configureDevServer(
   path: Path,
   isClientDevOnly: boolean,
   clientDevInput: string | undefined,
-  foundQrls: Map<string, string>,
   devSsrServer: boolean
 ) {
-  symbolMapper = lazySymbolMapper = createSymbolMapper(base, opts, foundQrls, path, sys);
+  symbolMapper = lazySymbolMapper = createSymbolMapper(base, opts, path, sys);
   if (!devSsrServer) {
     // we just needed the symbolMapper
     return;

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -694,7 +694,6 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
             path,
             isClientDevOnly,
             clientDevInput,
-            qwikPlugin.foundQrls,
             devSsrServer
           );
         };

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -330,6 +330,11 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
           dynamicImportVarsOptions: {
             exclude: [/./],
           },
+          rollupOptions: {
+            output: {
+              manualChunks: qwikPlugin.manualChunks,
+            },
+          },
         },
         define: {
           [qDevKey]: qDev,
@@ -353,6 +358,7 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
             opts,
             viteConfig.build?.rollupOptions?.output,
             useAssetsDir,
+            qwikPlugin.manualChunks,
             buildOutputDir
           ),
           preserveEntrySignatures: 'exports-only',


### PR DESCRIPTION
This makes the Qwik rollup plugin behave like a normal plugin, and speeds up dev startup.

- removes entry creating from optimizer
- adds manualChunks option that tells Rollup which chunks to put together
- removes building at buildStart so other plugins can transform before the segment splitting
