### PR TITLE
fix(partytown-starter): using type import

### DIFF
--- a/starters/features/partytown/src/components/partytown/partytown.tsx
+++ b/starters/features/partytown/src/components/partytown/partytown.tsx
@@ -1,7 +1,5 @@
-import {
-  partytownSnippet,
-  PartytownConfig,
-} from "@builder.io/partytown/integration";
+import type { PartytownConfig } from "@builder.io/partytown/integration";
+import { partytownSnippet } from "@builder.io/partytown/integration";
 
 /**
  * Props for `<QwikPartytown/>`, which extends the Partytown Config.


### PR DESCRIPTION
In a typescript project the partytown starter will lead to lint warnings.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
