### PR TITLE
fix(dev): docs.dev playground + small things

### DIFF
--- a/.changeset/two-tips-protect.md
+++ b/.changeset/two-tips-protect.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik-city': patch
+---
+
+Support entry.ts routes in dev mode now that dist/ is no longer served, and special-case `repl-sw.js` in the docs.

--- a/.eslintignore
+++ b/.eslintignore
@@ -18,7 +18,7 @@ scripts/**/*
 **/server/**/*.js
 *.tsbuildinfo
 packages/docs/api/**/*
-packages/docs/public/repl/bundled/**/*
+packages/docs/public/repl/repl-sw.js*
 packages/docs/src/routes/examples/apps/**/*
 packages/docs/src/routes/playground/app/**/*
 packages/docs/src/routes/tutorial/**/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -731,15 +731,18 @@ jobs:
       - lint-package
       - build-docs
       - build-insights
-    if: |
-      always() &&
-      (needs.lint-package.result == 'success' || needs.lint-package.result == 'skipped') &&
-      (needs.test-e2e.result == 'success' || needs.test-e2e.result == 'skipped') &&
-      (needs.validate-rust.result == 'success' || needs.validate-rust.result == 'skipped') &&
-      (needs.build-docs.result == 'success' || needs.build-docs.result == 'skipped') &&
-      (needs.build-insights.result == 'success' || needs.build-insights.result == 'skipped')
+    if: always()
     steps:
-      - run: echo "All good :-)"
+      - name: check status
+        if: |
+          !(
+            (needs.lint-package.result == 'success' || needs.lint-package.result == 'skipped') &&
+            (needs.test-e2e.result == 'success' || needs.test-e2e.result == 'skipped') &&
+            (needs.validate-rust.result == 'success' || needs.validate-rust.result == 'skipped') &&
+            (needs.build-docs.result == 'success' || needs.build-docs.result == 'skipped') &&
+            (needs.build-insights.result == 'success' || needs.build-insights.result == 'skipped')
+          )
+        run: exit 1
 
   ############ RELEASE ############
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,8 +503,32 @@ jobs:
             packages/docs/dist
             packages/docs/server
 
-      - name: Cloudflare Pages Deployment
-        # not the official version, so be careful when updating
+  deploy-docs:
+    name: Cloudflare Pages Deployment
+    if: always() && needs.changes.outputs.build-docs == 'true'
+    needs:
+      - build-docs
+      - changes
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check docs status
+        if: needs.build-docs.result != 'success'
+        run: exit 1
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Restore docs cache
+        uses: actions/cache/restore@v4
+        with:
+          key: ${{ needs.changes.outputs.hash-docs }}
+          path: |
+            packages/docs/dist
+            packages/docs/server
+
+      # not the official version, so be careful when updating
+      - name: Deploy to Cloudflare Pages
         uses: AdrianGonz97/refined-cf-pages-action@c7b767eef599f127d8ce2388d4ed2270d3b750af
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -24,6 +24,7 @@ build
 .rollup.cache
 tsconfig.tsbuildinfo
 packages/docs/api/**/*
+packages/docs/public/repl/repl-sw.js*
 packages/docs/src/routes/**/*.mdx
 **/server/**/*.js
 starters/**/*.js
@@ -33,7 +34,6 @@ packages/docs/server
 packages/docs/src/routes/api
 packages/docs/**/*.md
 packages/docs/**/*.mdx
-packages/docs/public/repl/bundled
 packages/insights/drizzle
 packages/insights/.netlify
 packages/insights/scripts

--- a/packages/docs/.gitignore
+++ b/packages/docs/.gitignore
@@ -3,10 +3,9 @@ build
 dist
 server
 functions/**/*.js
-
-# Bundled files for REPL
-# Managed by check-qwik-build.ts
-public/repl/bundled
+# This is used in dev mode because service
+# workers don't support imports
+public/repl/repl-sw.js*
 
 !src/routes/api/qwik/server/
 

--- a/packages/docs/check-qwik-build.ts
+++ b/packages/docs/check-qwik-build.ts
@@ -1,4 +1,5 @@
 // verify that ../qwik/dist/core.d.ts exists or run `pnpm run build.core` in the root directory
+// Also make sure that the repl-sw.js file is present, for dev mode
 // we need it for development and for the REPL
 import fs from 'fs';
 import path from 'path';
@@ -21,11 +22,11 @@ if (!fs.existsSync(path.join(qwikPkgDir, 'core.d.ts'))) {
   }
 }
 
-if (!fs.existsSync(path.join(__dirname, 'dist', 'repl', '~repl-server-host.js'))) {
+if (!fs.existsSync(path.join(__dirname, 'public', 'repl', 'repl-sw.js'))) {
   console.warn(
-    `\n\n=== Running 'pnpm run build.client' to generate missing REPL service worker dist/repl/~repl-server-host.js ===\n`
+    `\n\n=== Running 'pnpm run build.repl-sw' to generate missing REPL service worker public/repl/repl-sw.js ===\n`
   );
-  const out = spawnSync('pnpm', ['run', 'build.client'], {
+  const out = spawnSync('pnpm', ['run', 'build.repl-sw'], {
     stdio: 'inherit',
   });
   if (out.status !== 0) {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -67,6 +67,7 @@
   "scripts": {
     "build": "qwik build",
     "build.client": "vite build",
+    "build.repl-sw": "vite --config vite.config-repl-sw.mts build",
     "build.preview": "vite build --ssr src/entry.preview.tsx",
     "build.server": "vite build -c adapters/cloudflare-pages/vite.config.mts",
     "build.showcase": "pnpm node scripts/showcase.js",

--- a/packages/docs/src/components/docsearch/result.tsx
+++ b/packages/docs/src/components/docsearch/result.tsx
@@ -4,6 +4,7 @@ import { SearchContext } from './context';
 import { AiResultOpenContext, type DocSearchState } from './doc-search';
 import { Snippet } from './snippet';
 import type { InternalDocSearchHit } from './types';
+import { Link } from '@builder.io/qwik-city';
 
 export const Result = component$(
   ({ state, item }: { state: DocSearchState; item: InternalDocSearchHit }) => {
@@ -49,7 +50,9 @@ export const Result = component$(
           .filter(Boolean)
           .join(' ')}
       >
-        <a href={item.url}>
+        <Link
+          href={item.url.replace('https://qwik.dev/', '/').replace('https://qwik.builder.io/', '/')}
+        >
           <div class="DocSearch-Hit-Container">
             <Slot name="start-action"></Slot>
             {/* @ts-ignore */}
@@ -98,7 +101,7 @@ export const Result = component$(
             )}
             <Slot name="end-action"></Slot>
           </div>
-        </a>
+        </Link>
       </li>
     );
   }

--- a/packages/docs/src/routes/docs/(qwikcity)/routing/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/routing/index.mdx
@@ -416,7 +416,7 @@ Qwik City also supports:
 - [Request Handling](/docs/(qwikcity)/advanced/request-handling/index.mdx)
 
 ## Typesafe Routing
-- [Typed Routes](/docs/(qwikcity)/labs/typed-routes/index.mdx#-typed-routes)
-- [Declarative Routing](/docs/(qwikcity)/labs/typed-routes/index.mdx#declarative-routing)
+- [Typed Routes](/docs/labs/typed-routes/index.mdx#-typed-routes)
+- [Declarative Routing](/docs/labs/typed-routes/index.mdx#declarative-routing)
 
 These are discussed later.

--- a/packages/docs/vite.config-repl-sw.mts
+++ b/packages/docs/vite.config-repl-sw.mts
@@ -1,0 +1,32 @@
+import { copyFileSync } from 'fs';
+import { join } from 'path';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    sourcemap: true,
+    lib: {
+      entry: 'src/routes/repl/repl-sw.js/entry.ts',
+      formats: ['cjs'],
+      fileName: 'repl/repl-sw',
+    },
+  },
+  clearScreen: false,
+  plugins: [
+    {
+      name: 'copy-repl-sw',
+      writeBundle() {
+        // Copy the service worker to the public directory
+        // This is necessary for the REPL to work
+        // The service worker is generated in the build directory
+        // but we need it in the public directory
+        // so that the REPL can access it
+        copyFileSync(join('dist', 'repl', 'repl-sw.js'), join('public', 'repl', 'repl-sw.js'));
+        copyFileSync(
+          join('dist', 'repl', 'repl-sw.js.map'),
+          join('public', 'repl', 'repl-sw.js.map')
+        );
+      },
+    },
+  ],
+});


### PR DESCRIPTION
- allow HMR for `entry.ts` routes in dev
- speed up dev docs build by only building `repl-sw.js`, and only when needed
- speed up search results by doing SPA navigation
