### PR TITLE
chore: make root CHANGELOG permanent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ test-results
 # Local Netlify folder
 .netlify
 sandbox
+
+# We need to ignore this because "changesets" will try to replace it
+/CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelogs Index
+
+Here is an index file of all the changelogs in this repo:
+
+Package | File
+--- | ---
+`qwik` | [Changelog](packages/qwik/CHANGELOG.md)
+`qwik-city` | [Changelog](packages/qwik-city/CHANGELOG.md)
+`eslint-plugin-qwik` | [Changelog](packages/eslint-plugin-qwik/CHANGELOG.md)
+`create-qwik` | [Changelog](packages/create-qwik/CHANGELOG.md)
+


### PR DESCRIPTION
# Overview

Changesets will run over the root CHANGELOG

So I created an index for all of the sub packages changelogs and added it to gitignore so it wouldn't get run over by changesets.

