### PR TITLE
ci: made changesets work with dist tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,12 @@ jobs:
       build-insights: ${{ steps.cache-insights.outputs.cache-hit != 'true' }}
       build-unit: ${{ steps.cache-unit.outputs.cache-hit != 'true' }}
       build-e2e: ${{ steps.cache-e2e.outputs.cache-hit != 'true' }}
-      disttag: ${{ steps.check_changesets.outputs.disttag }}
+      disttag: ${{ steps.set_dist_tag.outputs.disttag }}
 
     steps:
       - name: Branch
         run: echo "${{ github.ref }}"
-      - name: NPM Dist Tag
+      - name: NPM Dist Tag from input
         run: echo "${{ github.event.inputs.disttag }}"
       - name: Github event
         run: echo event_name=${{ github.event_name }}
@@ -73,8 +73,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Check for removed .mock_changesets files and directory contents
-        id: check_changesets
+      - name: Set Dist Tag
+        id: set_dist_tag
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: |
           is_release=false
@@ -89,14 +89,14 @@ jobs:
 
           md_file_removed=false
           for file in $removed_files; do
-            if [[ $file == .mock_changesets/*.md ]]; then
+            if [[ $file == .changesets/*.md ]]; then
               md_file_removed=true
               break
             fi
           done
 
-          if [ -d ".mock_changesets" ]; then
-            md_files=$(find .mock_changesets -name '*.md')
+          if [ -d ".changesets" ]; then
+            md_files=$(find .changesets -name '*.md')
             if [ -z "$md_files" ] && [ "$md_file_removed" = true ]; then
               is_release=true
             fi
@@ -216,7 +216,7 @@ jobs:
           pnpm install --frozen-lockfile
 
       - name: 'build: qwik'
-        run: pnpm build --qwik --set-dist-tag="${{ github.event.inputs.disttag }}"
+        run: pnpm build --qwik --set-dist-tag="${{ needs.changes.outputs.disttag }}"
 
       - name: Print Qwik Dist Build
         continue-on-error: true
@@ -400,7 +400,7 @@ jobs:
 
       - name: 'build: qwik-city & others'
         if: needs.changes.outputs.build-others == 'true'
-        run: pnpm build --tsc --api --qwikcity --cli --qwiklabs --qwikreact --eslint --set-dist-tag="${{ github.event.inputs.disttag }}"
+        run: pnpm build --tsc --api --qwikcity --cli --qwiklabs --qwikreact --eslint --set-dist-tag="${{ needs.changes.outputs.disttag }}"
       - name: Save others cache
         if: needs.changes.outputs.build-others == 'true'
         uses: actions/cache/save@v4
@@ -874,7 +874,7 @@ jobs:
 
       - name: Publish manually
         if: github.event_name == 'workflow_dispatch'
-        run: pnpm build --set-dist-tag="${{ github.event.inputs.disttag }}" --validate --release
+        run: pnpm build --set-dist-tag="${{ needs.changes.outputs.disttag }}" --validate --release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -18,7 +18,7 @@ export async function getVersion(distTag?: string, rootDir?: string) {
     rootDir ||= resolve(__dirname, '..');
     const rootPkg = await readPackageJson(rootDir);
     let v = rootPkg.version;
-    if (distTag === 'dev') {
+    if (!distTag || distTag === 'dev') {
       const d = new Date();
       v += '-dev';
       v += String(d.getUTCFullYear());


### PR DESCRIPTION
This PR reverts the default "version setting" behavior to add the `dev-timestamp` suffix to the packages' version number.

But, if the CI identifies that the latest "push" (merge) removed the md files from the `.changesets` folder, and there are no other .md files there, it'll set the `disttag` to `latest`.

This will make sure Qwik doesn't add the `dev-timestamp` suffix but instead leave it intact
