### PR TITLE
fix(qwik-city): redirect route loads when sane

### DIFF
--- a/.changeset/nasty-files-fail.md
+++ b/.changeset/nasty-files-fail.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik-city': patch
+---
+
+qwik-city is now more careful about redirects after requesting routeLoader data


### PR DESCRIPTION
When using capacitor, the "browser" is on capacitor://localhost or http://localhost, and
when route loading is proxied, the return URL origin is not the same as the current
origin. This prompted qwik-city to reload the page.

Now, this is only done when the request was actually redirected.
