### PR TITLE
fixed library starter wrong Qwik version

### DIFF
--- a/.changeset/silver-readers-appear.md
+++ b/.changeset/silver-readers-appear.md
@@ -1,0 +1,5 @@
+---
+'create-qwik': patch
+---
+
+FIX: wrong version when creating a library

--- a/scripts/create-qwik-cli.ts
+++ b/scripts/create-qwik-cli.ts
@@ -8,6 +8,7 @@ import {
   copyFile,
   emptyDir,
   getBanner,
+  getQwikVersion,
   mkdir,
   nodeTarget,
   readdir,
@@ -91,10 +92,9 @@ export async function publishCreateQwikCli(
 }
 
 async function syncBaseStarterVersionsFromQwik(config: BuildConfig) {
-  const qwikDir = join(config.packagesDir, 'qwik');
-  const distPkg = await readPackageJson(qwikDir);
+  const qwikVersion = await getQwikVersion(config);
 
-  await updateBaseVersions(config, distPkg.version);
+  await updateBaseVersions(config, qwikVersion);
 }
 
 async function updateBaseVersions(config: BuildConfig, version: string) {
@@ -190,6 +190,7 @@ async function copyDir(config: BuildConfig, srcDir: string, destDir: string) {
 async function updatePackageJson(config: BuildConfig, destDir: string) {
   const rootPkg = await readPackageJson(config.rootDir);
   const pkgJson = await readPackageJson(destDir);
+  const qwikVersion = await getQwikVersion(config);
 
   const setVersionFromRoot = (pkgName: string) => {
     if (pkgJson.devDependencies && pkgJson.devDependencies[pkgName]) {
@@ -205,12 +206,11 @@ async function updatePackageJson(config: BuildConfig, destDir: string) {
   };
 
   if (pkgJson.devDependencies && pkgJson.devDependencies['@builder.io/qwik']) {
-    if (
-      pkgJson.devDependencies['@builder.io/qwik'] !== 'next' &&
-      pkgJson.devDependencies['@builder.io/qwik'] !== 'dev'
-    ) {
-      pkgJson.devDependencies['@builder.io/qwik'] = rootPkg.version;
-    }
+    pkgJson.devDependencies['@builder.io/qwik'] = qwikVersion;
+  }
+
+  if (pkgJson.devDependencies && pkgJson.devDependencies['eslint-plugin-qwik']) {
+    pkgJson.devDependencies['eslint-plugin-qwik'] = qwikVersion;
   }
 
   setVersionFromRoot('@types/eslint');

--- a/scripts/util.ts
+++ b/scripts/util.ts
@@ -1,23 +1,24 @@
 import type { Plugin } from 'esbuild';
-import { join } from 'node:path';
+import { execa, type Options } from 'execa';
 import mri from 'mri';
 import {
   access as fsAccess,
   copyFile as fsCopyFile,
-  mkdirSync,
+  mkdir as fsMkdir,
   readdir as fsReaddir,
   readFile as fsReadFile,
-  rmSync,
   stat as fsStat,
   unlink as fsUnlink,
   writeFile as fsWriteFile,
-  mkdir as fsMkdir,
+  mkdirSync,
+  rmSync,
 } from 'node:fs';
-import { promisify } from 'util';
-import { minify, type MinifyOptions } from 'terser';
-import type { Plugin as RollupPlugin } from 'rollup';
-import { execa, type Options } from 'execa';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { Plugin as RollupPlugin } from 'rollup';
+import { minify, type MinifyOptions } from 'terser';
+import { promisify } from 'util';
+import { readPackageJson } from './package-json';
 
 const stringOptions = [
   'distBindingsDir',
@@ -358,3 +359,9 @@ export const recursiveChangePrefix = <T>(obj: T, prefix: string, replace: string
   }
   return obj;
 };
+
+export async function getQwikVersion(config: BuildConfig) {
+  const qwikDir = join(config.packagesDir, 'qwik');
+  const qwikPkgJson = await readPackageJson(qwikDir);
+  return qwikPkgJson.version;
+}


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos

# Description

When creating a library via the CLI, it creates the wrong Qwik version in `devDependencies`

This fixes it and adds a test to make sure this bug won't come back.

(In the future we are planning a more robust testing system for qwik starters tests)


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
