### PR TITLE
feat: add ability to set cli commands

### DIFF
--- a/.changeset/beige-pigs-joke.md
+++ b/.changeset/beige-pigs-joke.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': minor
+---
+
+Add ability to set CLI commands.

--- a/packages/qwik/src/cli/utils/run-build-command.ts
+++ b/packages/qwik/src/cli/utils/run-build-command.ts
@@ -24,12 +24,17 @@ export async function runBuildCommand(app: AppCommand) {
   const isPreviewBuild = app.args.includes('preview');
   const buildLibScript = getScript('build.lib');
   const isLibraryBuild = !!buildLibScript;
-  const buildClientScript = getScript('build.client');
-  const buildPreviewScript = isPreviewBuild ? getScript('build.preview') : undefined;
-  const buildServerScript = !isPreviewBuild ? getScript('build.server') : undefined;
-  const buildStaticScript = getScript('build.static');
+  const buildClientCommand = app.getArg("client-script") || "build.client"
+  const buildTypesCommand = app.getArg("types-script") || "build.types"
+  const buildPreviewCommand = app.getArg("preview-script") || "build.preview"
+  const buildServerCommand = app.getArg("server-script") || "build.server"
+  const buildStaticCommand = app.getArg("static-script") || "build.static"
+  const buildClientScript = getScript(buildClientCommand);
+  const buildPreviewScript = isPreviewBuild ? getScript(buildPreviewCommand) : undefined;
+  const buildServerScript = !isPreviewBuild ? getScript(buildServerCommand) : undefined;
+  const buildStaticScript = getScript(buildStaticCommand);
   const runSsgScript = getScript('ssg');
-  const buildTypes = getScript('build.types');
+  const buildTypes = getScript(buildTypesCommand);
   const lint = getScript('lint');
   const mode = app.getArg('mode');
 
@@ -55,12 +60,12 @@ export async function runBuildCommand(app: AppCommand) {
 
   if (!isLibraryBuild && !buildClientScript) {
     console.log(pkgJsonScripts);
-    throw new Error(`"build.client" script not found in package.json`);
+    throw new Error(`"${buildClientCommand}" script not found in package.json`);
   }
 
   if (isPreviewBuild && !buildPreviewScript && !buildStaticScript) {
     throw new Error(
-      `Neither "build.preview" or "build.static" script found in package.json for preview`
+      `Neither "${buildPreviewCommand}" or "${buildStaticCommand}" script found in package.json for preview`
     );
   }
 


### PR DESCRIPTION
# Overview

#6756

# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Add the ability to specify a command name for the Qwik application build.

# Use cases and why

This can be useful if the repository contains code for more than just the site.

For example, library code and site code with documentation. It would be convenient to separate commands by name.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
