### PR TITLE
docs: change superDefine to superRefine

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/action/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/action/index.mdx
@@ -258,7 +258,7 @@ Please refer to the [Zod documentation](https://zod.dev/) for more information o
 
 The constructor of ```zod$``` can also take a function, as the first argument is zod itself, so you can use this directly to build the schema. 
 The second parameter is the RequestEvent to construct an event-based zod schema.
-Especially in combination with ```refine``` and ```superDefine``` in zod, the only limit is your imagination.
+Especially in combination with ```refine``` and ```superRefine``` in zod, the only limit is your imagination.
 
 
 ```tsx {5-5} /ev/#a  title="Advanced event based validation"


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description

The documentation says `superDefine` but no such function exists. The author probably meant to say `superRefine`.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- Idk, typos are bad.
# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
