### PR TITLE
fix(vite): don't filter out qwik library files

### DIFF
--- a/.changeset/polite-feet-greet.md
+++ b/.changeset/polite-feet-greet.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': patch
+---
+
+The `fileFilter` option to `qwikVite()` now always allows `*.qwik.{m,c,}js` files so that QRLs in libraries can be processed.

--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -952,7 +952,13 @@ const RESOLVE_EXTS = {
   '.cjs': true,
 } as const;
 
-const TRANSFORM_REGEX = /\.qwik\.[mc]?js$/;
+/**
+ * Any file that matches this needs to be processed by Qwik to extract QRL segments etc. Used in
+ * libraries.
+ *
+ * @internal
+ */
+export const TRANSFORM_REGEX = /\.qwik\.[mc]?js$/;
 
 export const QWIK_CORE_ID = '@builder.io/qwik';
 

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -24,6 +24,7 @@ import {
   QWIK_JSX_RUNTIME_ID,
   Q_MANIFEST_FILENAME,
   SSR_OUT_DIR,
+  TRANSFORM_REGEX,
   createPlugin,
   parseId,
   type NormalizedQwikPluginOptions,
@@ -68,7 +69,9 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
   let rootDir: string | null = null;
 
   let ssrOutDir: string | null = null;
-  const fileFilter = qwikViteOpts.fileFilter || (() => true);
+  const fileFilter: QwikVitePluginOptions['fileFilter'] = qwikViteOpts.fileFilter
+    ? (id, type) => TRANSFORM_REGEX.test(id) || qwikViteOpts.fileFilter!(id, type)
+    : () => true;
   const injections: GlobalInjections[] = [];
   const qwikPlugin = createPlugin(qwikViteOpts.optimizerOptions);
 


### PR DESCRIPTION
The `fileFilter` option to `qwikVite()` now always allows `*.qwik.{m,c,}.js` files so that QRLs in libraries can be processed.