### PR TITLE
add  the manual step in the  auth documentation

### DIFF
--- a/packages/docs/src/routes/docs/integrations/authjs/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/authjs/index.mdx
@@ -65,6 +65,11 @@ This command will add a new package:
 - `@auth/qwik`
 
 and create a new file named `plugin@auth.ts` with an example configuration.
+the command will also prompt you to add a code snippet into your `vite.config.ts`
+
+```
+optimizeDeps: { include: ['@auth/core'] }
+```
 
 > **Note on Manual Deployments with Node**
 


### PR DESCRIPTION
# Overview

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos

# Description
the documetation was missing the manual involved  with  `qwik add auth` 
![image](https://github.com/user-attachments/assets/6da13920-6927-4dad-948b-99d0ed071ca2)

# Checklist:

- [ x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ x] I have performed a self-review of my own code
- [ x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
