### PR TITLE
feat: add preserve modules to lib starter

### DIFF
--- a/.changeset/wicked-foxes-behave.md
+++ b/.changeset/wicked-foxes-behave.md
@@ -2,4 +2,4 @@
 'create-qwik': patch
 ---
 
-feat: improves library bundling / tree-shaking
+feat: added `preserveModules` to library starters to improve library bundling / tree-shaking

--- a/.changeset/wicked-foxes-behave.md
+++ b/.changeset/wicked-foxes-behave.md
@@ -1,0 +1,5 @@
+---
+'create-qwik': patch
+---
+
+feat: improves library bundling / tree-shaking

--- a/starters/apps/library/vite.config.ts
+++ b/starters/apps/library/vite.config.ts
@@ -14,9 +14,14 @@ export default defineConfig(() => {
       lib: {
         entry: "./src/index.ts",
         formats: ["es", "cjs"],
-        fileName: (format) => `index.qwik.${format === "es" ? "mjs" : "cjs"}`,
+        fileName: (format, entryName) =>
+          `${entryName}.qwik.${format === "es" ? "mjs" : "cjs"}`,
       },
       rollupOptions: {
+        output: {
+          preserveModules: true,
+          preserveModulesRoot: "src",
+        },
         // externalize deps that shouldn't be bundled into the library
         external: [
           /^node:.*/,


### PR DESCRIPTION
# Overview

Adds preserve modules to the library starters. It also makes the entryname apparent in the build, otherwise you would have:
`index.qwik2.mjs` and so forth.

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
