### PR TITLE
docs(contributing): fix Qwik React indicated instead of Qwik Labs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,7 +183,7 @@ Run without arguments for all supported flags. Notable:
 - `--build`: Qwik (you'll probably also need `--api`)
 - `--qwikcity`: Qwik City (you'll probably also need `--api`)
 - `--qwikreact`: Qwik React
-- `--qwiklabs`: Qwik React
+- `--qwiklabs`: Qwik Labs
 - `--eslint`: Eslint plugin
 
 ### Full build without Rust


### PR DESCRIPTION
# Overview

Just fixing a contributing docs issue (I believe it to be just a copy-paste mistake)

<!--
The Qwik Team and Qwik Community are grateful for all PRs that improve Qwik. Thank you for your time and effort! Please be aware that not all PRs can be merged, but PRs that meet the following criteria will receive the highest priority:

a) Fixes to the core, and

b) Framework functionality that can only be achieved by the core.

If your functionality can be delivered as a 3rd-Party Community Add-On, we encourage that route as it will likely provide a faster path to adoption.

If you feel your functionality is of high value to everybody in the Qwik Community, we encourage socializing it in the Qwik Discord channels as the core team may take this up for inclusion in the core.

_— Build primitives is our mantra_

-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos
