### PR TITLE
fix(starter): update CLI version of storybook

### DIFF
--- a/starters/features/storybook/package.json
+++ b/starters/features/storybook/package.json
@@ -9,14 +9,14 @@
     ]
   },
   "devDependencies": {
-    "@storybook/addon-essentials": "^7.4.6",
-    "@storybook/addon-links": "^7.4.6",
-    "@storybook/blocks": "^7.4.6",
-    "@storybook/builder-vite": "^7.4.6",
-    "@storybook/html": "^7.4.6",
-    "@storybook/html-vite": "^7.4.6",
-    "storybook": "^7.4.6",
-    "storybook-framework-qwik": "^0.2.4"
+    "@storybook/addon-essentials": "^8.2.8",
+    "@storybook/addon-links": "^8.2.8",
+    "@storybook/blocks": "^8.2.8",
+    "@storybook/builder-vite": "^8.2.8",
+    "@storybook/html": "^8.2.8",
+    "@storybook/html-vite": "^8.2.8",
+    "storybook": "^8.2.8",
+    "storybook-framework-qwik": "^0.4.0"
   },
   "scripts": {
     "build-storybook": "storybook build",


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.
-->

# What is it?
Current   cli version of  `npx qwik add storybook` will run into 
![image](https://github.com/user-attachments/assets/d6542e17-6454-4b6f-b662-e8d4eeefe755)

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos
- [ ] Infra

# Description
the pr update the  starter to a healthy version 
here a stackblitz with  the said version 
https://stackblitz.com/edit/github-sy5fgo-s1yms4?file=storyboard%2FREADME.md
<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist:

- [x ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ x] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have made corresponding changes to the Qwik docs
- [ ] Added new tests to cover the fix / functionality
