### PR TITLE
fix(request-handler) change from 302 to 301

### DIFF
--- a/packages/qwik-city/src/middleware/request-handler/resolve-request-handlers.ts
+++ b/packages/qwik-city/src/middleware/request-handler/resolve-request-handlers.ts
@@ -361,13 +361,16 @@ function fixTrailingSlash(ev: RequestEvent) {
       // must have a trailing slash
       if (!pathname.endsWith('/')) {
         // add slash to existing pathname
-        throw ev.redirect(HttpStatus.Found, pathname + '/' + url.search);
+        throw ev.redirect(HttpStatus.MovedPermanently, pathname + '/' + url.search);
       }
     } else {
       // should not have a trailing slash
       if (pathname.endsWith('/')) {
         // remove slash from existing pathname
-        throw ev.redirect(HttpStatus.Found, pathname.slice(0, pathname.length - 1) + url.search);
+        throw ev.redirect(
+          HttpStatus.MovedPermanently,
+          pathname.slice(0, pathname.length - 1) + url.search
+        );
       }
     }
   }


### PR DESCRIPTION
#  What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos
- [ ] Infra

# Description

The search engine should update the URLs and for this we would have to declare them as 301 and not as 302 as is currently the case.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have made corresponding changes to the Qwik docs
- [ ] Added new tests to cover the fix / functionality
