### PR TITLE
feat(qwik-city): usePreventNavigate

### DIFF
--- a/.changeset/wise-olives-compete.md
+++ b/.changeset/wise-olives-compete.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik-city': minor
+---
+
+`usePreventNavigate` lets you prevent navigation while your app's state is unsaved. It works asynchronously for SPA navigation and falls back to the browser's default dialogs for other navigations.

--- a/packages/docs/src/routes/api/qwik-city/api.json
+++ b/packages/docs/src/routes/api/qwik-city/api.json
@@ -451,6 +451,20 @@
       "mdFile": "qwik-city.pathparams.md"
     },
     {
+      "name": "PreventNavigateCallback",
+      "id": "preventnavigatecallback",
+      "hierarchy": [
+        {
+          "name": "PreventNavigateCallback",
+          "id": "preventnavigatecallback"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "Before SPA navigation (via `<Link />` or `useNavigate()`<!-- -->), this will be called to check if the navigation should be prevented.\n\nThis can be used to show a nice dialog to the user, and wait for the user to confirm.\n\nReturn `true` to prevent navigation. If you return a Promise, the navigation will be blocked until the promise resolves.\n\nHowever, when the user navigates away by clicking on a regular `<a />` or using the browser's back/forward buttons, this callback will not be awaited. This is because the browser does not provide a way to asynchronously prevent these navigations. In this case, returning a Promise or returning `true` will tell the browser to show a confirmation dialog, which cannot be customized.\n\nWhen the callback is called from the browser, the `fromBrowser` parameter will be `true`<!-- -->. Use this to know whether to show a dialog or just return `true` to prevent the navigation.\n\n\n```typescript\nexport type PreventNavigateCallback = (fromBrowser?: boolean) => ValueOrPromise<boolean>;\n```",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-city/src/runtime/src/types.ts",
+      "mdFile": "qwik-city.preventnavigatecallback.md"
+    },
+    {
       "name": "QWIK_CITY_SCROLLER",
       "id": "qwik_city_scroller",
       "hierarchy": [
@@ -841,6 +855,20 @@
       "content": "```typescript\nuseNavigate: () => RouteNavigate\n```\n**Returns:**\n\n[RouteNavigate](#routenavigate)",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-city/src/runtime/src/use-functions.ts",
       "mdFile": "qwik-city.usenavigate.md"
+    },
+    {
+      "name": "usePreventNavigate$",
+      "id": "usepreventnavigate_",
+      "hierarchy": [
+        {
+          "name": "usePreventNavigate$",
+          "id": "usepreventnavigate_"
+        }
+      ],
+      "kind": "Function",
+      "content": "Prevents navigation when the callback returns a truthy value. Use this to prevent data loss when the application has unsaved state\n\n\n```typescript\nusePreventNavigate$: (qrl: PreventNavigateCallback) => void\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\n[PreventNavigateCallback](#preventnavigatecallback)\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\nvoid",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-city/src/runtime/src/use-functions.ts",
+      "mdFile": "qwik-city.usepreventnavigate_.md"
     },
     {
       "name": "validator$",

--- a/packages/docs/src/routes/api/qwik-city/index.md
+++ b/packages/docs/src/routes/api/qwik-city/index.md
@@ -1682,6 +1682,26 @@ export declare type PathParams = Record<string, string>;
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-city/src/runtime/src/types.ts)
 
+## PreventNavigateCallback
+
+Before SPA navigation (via `<Link />` or `useNavigate()`), this will be called to check if the navigation should be prevented.
+
+This can be used to show a nice dialog to the user, and wait for the user to confirm.
+
+Return `true` to prevent navigation. If you return a Promise, the navigation will be blocked until the promise resolves.
+
+However, when the user navigates away by clicking on a regular `<a />` or using the browser's back/forward buttons, this callback will not be awaited. This is because the browser does not provide a way to asynchronously prevent these navigations. In this case, returning a Promise or returning `true` will tell the browser to show a confirmation dialog, which cannot be customized.
+
+When the callback is called from the browser, the `fromBrowser` parameter will be `true`. Use this to know whether to show a dialog or just return `true` to prevent the navigation.
+
+```typescript
+export type PreventNavigateCallback = (
+  fromBrowser?: boolean,
+) => ValueOrPromise<boolean>;
+```
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-city/src/runtime/src/types.ts)
+
 ## QWIK_CITY_SCROLLER
 
 ```typescript
@@ -2384,6 +2404,45 @@ useNavigate: () => RouteNavigate;
 **Returns:**
 
 [RouteNavigate](#routenavigate)
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-city/src/runtime/src/use-functions.ts)
+
+## usePreventNavigate$
+
+Prevents navigation when the callback returns a truthy value. Use this to prevent data loss when the application has unsaved state
+
+```typescript
+usePreventNavigate$: (qrl: PreventNavigateCallback) => void
+```
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+qrl
+
+</td><td>
+
+[PreventNavigateCallback](#preventnavigatecallback)
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+void
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-city/src/runtime/src/use-functions.ts)
 

--- a/packages/qwik-city/src/runtime/src/api.md
+++ b/packages/qwik-city/src/runtime/src/api.md
@@ -308,6 +308,9 @@ export interface PageModule extends RouteModule {
 // @public (undocumented)
 export type PathParams = Record<string, string>;
 
+// @public
+export type PreventNavigateCallback = (fromBrowser?: boolean) => ValueOrPromise<boolean>;
+
 // @public (undocumented)
 export const QWIK_CITY_SCROLLER = "_qCityScroller";
 
@@ -470,6 +473,14 @@ export const useLocation: () => RouteLocation;
 
 // @public (undocumented)
 export const useNavigate: () => RouteNavigate;
+
+// @public
+export const usePreventNavigate$: (qrl: PreventNavigateCallback) => void;
+
+// Warning: (ae-internal-missing-underscore) The name "usePreventNavigateQrl" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export const usePreventNavigateQrl: (fn: QRL<PreventNavigateCallback>) => void;
 
 // Warning: (ae-forgotten-export) The symbol "ValidatorConstructor" needs to be exported by the entry point index.d.ts
 //

--- a/packages/qwik-city/src/runtime/src/contexts.ts
+++ b/packages/qwik-city/src/runtime/src/contexts.ts
@@ -6,6 +6,7 @@ import type {
   RouteAction,
   RouteLocation,
   RouteNavigate,
+  RoutePreventNavigate,
   RouteStateInternal,
 } from './types';
 
@@ -25,3 +26,6 @@ export const RouteActionContext = /*#__PURE__*/ createContextId<RouteAction>('qc
 
 export const RouteInternalContext =
   /*#__PURE__*/ createContextId<Signal<RouteStateInternal>>('qc-ir');
+
+export const RoutePreventNavigateContext =
+  /*#__PURE__*/ createContextId<RoutePreventNavigate>('qc-p');

--- a/packages/qwik-city/src/runtime/src/index.ts
+++ b/packages/qwik-city/src/runtime/src/index.ts
@@ -1,47 +1,57 @@
 export type { FormSubmitCompletedDetail as FormSubmitSuccessDetail } from './form-component';
 
 export type {
-  MenuData,
+  Action,
+  ActionConstructor,
+  ActionReturn,
+  ActionStore,
   ContentHeading,
   ContentMenu,
   Cookie,
   CookieOptions,
   CookieValue,
+  DataValidator,
+  DeferReturn,
   DocumentHead,
   DocumentHeadProps,
   DocumentHeadValue,
   DocumentLink,
   DocumentMeta,
-  DocumentStyle,
   DocumentScript,
+  DocumentStyle,
+  FailOfRest,
+  FailReturn,
+  GetValidatorType,
+  JSONObject,
+  JSONValue,
+  Loader,
+  LoaderSignal,
+  MenuData,
+  NavigationType,
   PageModule,
   PathParams,
-  RequestHandler,
-  RequestEvent,
-  RequestEventLoader,
-  RequestEventAction,
-  RequestEventCommon,
+  PreventNavigateCallback,
   QwikCityPlan,
+  RequestEvent,
+  RequestEventAction,
+  RequestEventBase,
+  RequestEventCommon,
+  RequestEventLoader,
+  RequestHandler,
   ResolvedDocumentHead,
   RouteData,
   RouteLocation,
-  StaticGenerateHandler,
-  Action,
-  Loader,
-  ActionStore,
-  LoaderSignal,
-  ActionConstructor,
-  FailReturn,
-  ZodConstructor,
-  StaticGenerate,
   RouteNavigate,
-  NavigationType,
-  DeferReturn,
-  RequestEventBase,
-  JSONObject,
-  JSONValue,
-  ValidatorErrorType,
+  ServerFunction,
+  ServerQRL,
+  StaticGenerate,
+  StaticGenerateHandler,
+  StrictUnion,
+  TypedDataValidator,
   ValidatorErrorKeyDotNotation,
+  ValidatorErrorType,
+  ValidatorReturn,
+  ZodConstructor,
 } from './types';
 
 export { RouterOutlet } from './router-outlet-component';
@@ -55,6 +65,7 @@ export {
 export { type LinkProps, Link } from './link-component';
 export { ServiceWorkerRegister } from './sw-component';
 export { useDocumentHead, useLocation, useContent, useNavigate } from './use-functions';
+export { usePreventNavigate$, usePreventNavigateQrl } from './use-functions';
 export { routeAction$, routeActionQrl } from './server-functions';
 export { globalAction$, globalActionQrl } from './server-functions';
 export { routeLoader$, routeLoaderQrl } from './server-functions';
@@ -66,15 +77,3 @@ export { z } from 'zod';
 
 export { Form } from './form-component';
 export type { FormProps } from './form-component';
-
-export type {
-  TypedDataValidator,
-  DataValidator,
-  GetValidatorType,
-  FailOfRest,
-  ActionReturn,
-  StrictUnion,
-  ValidatorReturn,
-  ServerQRL,
-  ServerFunction,
-} from './types';

--- a/packages/qwik-city/src/runtime/src/types.ts
+++ b/packages/qwik-city/src/runtime/src/types.ts
@@ -80,6 +80,31 @@ export type RouteStateInternal = {
   scroll?: boolean;
 };
 
+/**
+ * Before SPA navigation (via `<Link />` or `useNavigate()`), this will be called to check if the
+ * navigation should be prevented.
+ *
+ * This can be used to show a nice dialog to the user, and wait for the user to confirm.
+ *
+ * Return `true` to prevent navigation. If you return a Promise, the navigation will be blocked
+ * until the promise resolves.
+ *
+ * However, when the user navigates away by clicking on a regular `<a />` or using the browser's
+ * back/forward buttons, this callback will not be awaited. This is because the browser does not
+ * provide a way to asynchronously prevent these navigations. In this case, returning a Promise or
+ * returning `true` will tell the browser to show a confirmation dialog, which cannot be
+ * customized.
+ *
+ * When the callback is called from the browser, the `fromBrowser` parameter will be `true`. Use
+ * this to know whether to show a dialog or just return `true` to prevent the navigation.
+ *
+ * @public
+ */
+export type PreventNavigateCallback = (fromBrowser?: boolean) => ValueOrPromise<boolean>;
+
+/** @internal registers prevent navigate handler and returns cleanup function */
+export type RoutePreventNavigate = QRL<(cb$: QRL<PreventNavigateCallback>) => () => void>;
+
 export type ScrollState = {
   x: number;
   y: number;

--- a/packages/qwik-city/src/runtime/src/use-functions.ts
+++ b/packages/qwik-city/src/runtime/src/use-functions.ts
@@ -1,10 +1,18 @@
-import { noSerialize, useContext, useServerData } from '@builder.io/qwik';
+import {
+  implicit$FirstArg,
+  noSerialize,
+  useContext,
+  useServerData,
+  useVisibleTask$,
+  type QRL,
+} from '@builder.io/qwik';
 import {
   ContentContext,
   DocumentHeadContext,
   RouteActionContext,
   RouteLocationContext,
   RouteNavigateContext,
+  RoutePreventNavigateContext,
 } from './contexts';
 import type {
   RouteLocation,
@@ -12,6 +20,7 @@ import type {
   RouteNavigate,
   QwikCityEnvData,
   RouteAction,
+  PreventNavigateCallback,
 } from './types';
 
 /** @public */
@@ -31,6 +40,19 @@ export const useLocation = (): RouteLocation => useContext(RouteLocationContext)
 
 /** @public */
 export const useNavigate = (): RouteNavigate => useContext(RouteNavigateContext);
+
+/** @internal */
+export const usePreventNavigateQrl = (fn: QRL<PreventNavigateCallback>): void => {
+  const registerPreventNav = useContext(RoutePreventNavigateContext);
+  // Note: we have to use a visible task because:
+  // - the onbeforeunload event is synchronous, so we need to preload the callbacks
+  // - to unregister the callback, we need to run code on unmount, which means a visible task
+  // - it allows removing the onbeforeunload event listener when no callbacks are registered, which is better for older Firefox versions
+  // - preventing navigation implies user interaction, so we'll need to load the framework anyway
+  useVisibleTask$(() => registerPreventNav(fn));
+};
+/** @public Prevents navigation when the callback returns a truthy value. Use this to prevent data loss when the application has unsaved state */
+export const usePreventNavigate$ = implicit$FirstArg(usePreventNavigateQrl);
 
 export const useAction = (): RouteAction => useContext(RouteActionContext);
 

--- a/packages/qwik/src/optimizer/src/plugins/vite-dev-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-dev-server.ts
@@ -110,7 +110,9 @@ export async function configureDevServer(
     // we just needed the symbolMapper
     return;
   }
-
+  const hasQwikCity = server.config.plugins?.some(
+    (plugin) => plugin.name === 'vite-plugin-qwik-city'
+  );
   // qwik middleware injected BEFORE vite internal middlewares
   server.middlewares.use(async (req, res, next) => {
     try {
@@ -119,8 +121,17 @@ export async function configureDevServer(
       const url = new URL(req.originalUrl!, domain);
 
       if (shouldSsrRender(req, url)) {
+        const { _qwikEnvData } = res as QwikViteDevResponse;
+        if (!_qwikEnvData && hasQwikCity) {
+          console.error(`not SSR rendering ${url} because Qwik City Env data did not populate`);
+          res.statusCode ||= 404;
+          res.setHeader('Content-Type', 'text/plain');
+          res.writeHead(res.statusCode);
+          res.end('Not a SSR URL according to Qwik City');
+          return;
+        }
         const serverData: Record<string, any> = {
-          ...(res as QwikViteDevResponse)._qwikEnvData,
+          ..._qwikEnvData,
           url: url.href,
         };
 

--- a/starters/apps/qwikcity-test/src/routes/prevent-navigate/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/prevent-navigate/index.tsx
@@ -1,0 +1,23 @@
+import { component$, useSignal } from "@builder.io/qwik";
+import { Link, usePreventNavigate$ } from "@builder.io/qwik-city";
+
+export default component$(() => {
+  const isDirty = useSignal(false);
+  const runCount = useSignal(0);
+  usePreventNavigate$(() => {
+    runCount.value++;
+    return isDirty.value;
+  });
+
+  return (
+    <div>
+      <div id="pn-runcount">{runCount.value}</div>
+      <button id="pn-button" onClick$={() => (isDirty.value = !isDirty.value)}>
+        is {isDirty.value ? "dirty" : "clean"}
+      </button>
+      <Link id="pn-link" href="/qwikcity-test/">
+        Go home
+      </Link>
+    </div>
+  );
+});

--- a/starters/dev-server.ts
+++ b/starters/dev-server.ts
@@ -213,7 +213,7 @@ export {
           disableVendorScan: true,
           vendorRoots: enableCityServer ? [qwikCityMjs] : [],
           entryStrategy: {
-            type: "single",
+            type: "segment",
           },
           client: {
             manifestOutput(manifest) {

--- a/starters/e2e/qwikcity/nav.spec.ts
+++ b/starters/e2e/qwikcity/nav.spec.ts
@@ -183,6 +183,39 @@ test.describe("actions", () => {
         expect(page.url()).toBe(startUrl);
       }
     });
+
+    test("preventNavigate", async ({ page }) => {
+      await page.goto("/qwikcity-test/prevent-navigate/");
+      const button = page.locator("#pn-button");
+      const link = page.locator("#pn-link");
+      const count = page.locator("#pn-runcount");
+      await expect(count).toHaveText("0");
+      await link.click();
+      await expect(link).not.toBeVisible();
+      expect(new URL(page.url()).pathname).toBe("/qwikcity-test/");
+      await page.goBack();
+      await expect(count).toHaveText("0");
+      await expect(button).toHaveText("is clean");
+      await button.click();
+      await expect(button).toHaveText("is dirty");
+      let didTrigger = false;
+      page.on("dialog", async (dialog) => {
+        didTrigger = true;
+        expect(dialog.type()).toBe("beforeunload");
+        await dialog.accept();
+      });
+      await page.reload();
+      expect(didTrigger).toBe(true);
+      await expect(count).toHaveText("0");
+      await button.click();
+      await link.click();
+      await expect(count).toHaveText("1");
+      await link.click();
+      await expect(count).toHaveText("2");
+      expect(new URL(page.url()).pathname).toBe(
+        "/qwikcity-test/prevent-navigate/",
+      );
+    });
   }
 
   function tests() {


### PR DESCRIPTION
this enables preventing navigation when the application state is dirty.

The API needs to be ratified still, so marking as draft even though everything works.