### PR TITLE
fix: qwikVite transforming id's with ?raw

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -487,11 +487,7 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
     },
 
     transform(code, id, transformOpts) {
-      if (id.startsWith('\0') || !fileFilter(id, 'transform')) {
-        return null;
-      }
-
-      if (id.endsWith('?raw')) {
+      if (id.startsWith('\0') || !fileFilter(id, 'transform') || id.includes('?raw')) {
         return null;
       }
 

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -490,6 +490,11 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
       if (id.startsWith('\0') || !fileFilter(id, 'transform')) {
         return null;
       }
+
+      if (id.endsWith('?raw')) {
+        return null;
+      }
+
       if (isClientDevOnly) {
         const parsedId = parseId(id);
         if (parsedId.params.has(VITE_DEV_CLIENT_QS)) {


### PR DESCRIPTION
Bug in either vite or how we handle the transform of `?raw`. Prevents `?raw` imports from being transformed w/ qwikVite

<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.
-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos
- [ ] Infra

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have made corresponding changes to the Qwik docs
- [ ] Added new tests to cover the fix / functionality
