### PR TITLE
chore: start the experiment with modulepreload on qwik.dev

### DIFF
--- a/packages/docs/src/entry.ssr.tsx
+++ b/packages/docs/src/entry.ssr.tsx
@@ -14,5 +14,16 @@ export default function (opts: RenderToStreamOptions) {
       lang: 'en',
       ...opts.containerAttributes,
     },
+    // Core Web Vitals experiment until October 1: Do not remove and do not bring back any SW until then! Reach out to @maiieul first if you believe you have a good reason to change this.
+    prefetchStrategy: {
+      implementation: {
+        linkInsert: 'html-append',
+        linkRel: 'modulepreload',
+      },
+    },
+    // Core Web Vitals experiment until October 1: Do not remove and do not bring back any SW until then! Reach out to @maiieul first if you believe you have a good reason to change this.
+    qwikPrefetchServiceWorker: {
+      include: false,
+    },
   });
 }

--- a/packages/docs/src/root.tsx
+++ b/packages/docs/src/root.tsx
@@ -1,5 +1,5 @@
 import { component$, useContextProvider, useStore } from '@builder.io/qwik';
-import { QwikCityProvider, RouterOutlet, ServiceWorkerRegister } from '@builder.io/qwik-city';
+import { QwikCityProvider, RouterOutlet } from '@builder.io/qwik-city';
 import RealMetricsOptimization from './components/real-metrics-optimization/real-metrics-optimization';
 import { RouterHead } from './components/router-head/router-head';
 import { GlobalStore, type SiteStore } from './context';
@@ -54,7 +54,8 @@ export default component$(() => {
         <meta charset="utf-8" />
         <script dangerouslySetInnerHTML={uwu} />
         <RouterHead />
-        <ServiceWorkerRegister />
+        {/* Core Web Vitals experiment until October 1: Do not bring back any SW until then! Reach out to @maiieul first if you believe you have a good reason to change this. */}
+        {/* <ServiceWorkerRegister /> */}
         {/* <script dangerouslySetInnerHTML={`(${collectSymbols})()`} /> */}
         <Insights publicApiKey={import.meta.env.PUBLIC_QWIK_INSIGHTS_KEY} />
       </head>
@@ -66,6 +67,7 @@ export default component$(() => {
       >
         <RouterOutlet />
         <RealMetricsOptimization builderApiKey={BUILDER_PUBLIC_API_KEY} />
+        {/* Core Web Vitals experiment until October 1: Do not bring back any SW until then! Reach out to @maiieul first if you believe you have a good reason to change this. */}
       </body>
     </QwikCityProvider>
   );


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.
-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos
- [ ] Infra

# Description

As discussed, `modulepreload` doubles the FCP/LCP on lighthouse default throttling and therefore pagespeed (which uses lighthouse default throttling). We need to gather real data for `modulepreload` to see how it impacts FCP/LCP on real devices/connections. Perhaps it's only on the lighthouse simulations that FCP/LCP isn't good.

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have made corresponding changes to the Qwik docs
- [ ] Added new tests to cover the fix / functionality
