### PR TITLE
docs: fix typo in using useStore()

### DIFF
--- a/.changeset/flat-pans-crash.md
+++ b/.changeset/flat-pans-crash.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': patch
+---
+
+FIX: fix typo in using useStore()

--- a/packages/docs/src/routes/demo/state/counter-store-deep/index.tsx
+++ b/packages/docs/src/routes/demo/state/counter-store-deep/index.tsx
@@ -23,7 +23,7 @@ export default component$(() => {
       <button
         onClick$={() => {
           // Because store is deep watched, this will trigger a re-render
-          store.list.push(`Item ${store.list.length}`);
+          store.list.push(`Item ${store.list.length + 1}`);
         }}
       >
         Add to list

--- a/packages/docs/src/routes/docs/(qwik)/components/state/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/state/index.mdx
@@ -151,7 +151,7 @@ export default component$(() => {
       <button
         onClick$={() => {
           // Because store is deep watched, this will trigger a re-render
-          store.list.push(`Item ${store.list.length}`);
+          store.list.push(`Item ${store.list.length + 1}`);
         }}
       >
         Add to list


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.
-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos
- [ ] Infra

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

Fixed typo in order to avoid the following situation:
![image](https://github.com/user-attachments/assets/d659a463-ae60-4cee-866d-dcf5944c44f3)


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have ran `pnpm change` and documented my changes
- [x] I have made corresponding changes to the Qwik docs
- [ ] Added new tests to cover the fix / functionality
