### PR TITLE
Fixed CI not uploading dot files

### DIFF
--- a/.changeset/popular-dragons-greet.md
+++ b/.changeset/popular-dragons-greet.md
@@ -1,5 +1,5 @@
 ---
-'@builder.io/qwik': path
+'@builder.io/qwik': patch
 ---
 
 fix: SSG Link componet strips search parameters

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifact-qwik-no-optimizer
+          include-hidden-files: true
           path: packages/qwik/dist/
           if-no-files-found: error
 
@@ -300,6 +301,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifact-bindings-${{ matrix.settings.target }}
+          include-hidden-files: true
           path: packages/qwik/bindings/
           if-no-files-found: error
 
@@ -356,6 +358,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifact-qwik
+          include-hidden-files: true
           path: |
             packages/qwik/bindings
             packages/qwik/dist
@@ -433,6 +436,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifact-qwikcity
+          include-hidden-files: true
           path: packages/qwik-city/lib/
           if-no-files-found: error
 
@@ -443,6 +447,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifact-qwiklabs
+          include-hidden-files: true
           path: |
             packages/qwik-labs/lib/
             packages/qwik-labs/vite/
@@ -456,6 +461,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifact-qwikreact
+          include-hidden-files: true
           path: |
             packages/qwik-react/lib/
             packages/qwik-react/package.json
@@ -468,6 +474,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifact-create-qwik
+          include-hidden-files: true
           path: packages/create-qwik/dist/
           if-no-files-found: error
 
@@ -478,6 +485,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifact-eslint-plugin-qwik
+          include-hidden-files: true
           path: packages/eslint-plugin-qwik/dist/
           if-no-files-found: error
 
@@ -582,6 +590,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: artifact-docs
+          include-hidden-files: true
           path: |
             packages/docs/dist
             packages/docs/server


### PR DESCRIPTION
# Overview

It took us a few hours of debugging to realize that our new version doesn't have a `.eslintrc.cjs` file because there [was a hidden breaking change](https://github.com/actions/upload-artifact/issues/602) introduced in a minor version of `upload-artifact`

Plus this PR fixes a typo in one of the changeset files

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos
