### PR TITLE
feat(dev): add parent filename to qrl segments

### DIFF
--- a/.changeset/clean-queens-reflect.md
+++ b/.changeset/clean-queens-reflect.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': patch
+---
+
+in dev mode, qrl segments now start with their parent filename so it's easy to see where they came from. Furthermore, in production builds these filenames are also used so that origins in q-manifest.json are easy to understand.

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_1.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_1.snap
@@ -18,11 +18,11 @@ const renderHeader = component($(() => {
   return render;
 }));
 
-============================= renderheader_zbbhwn4e8cg.tsx (ENTRY POINT)==
+============================= test.tsx_renderheader_zbbhwn4e8cg.tsx (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 export const renderHeader_zBbHWn4e8Cg = ()=>{
-    return <div onClick={/*#__PURE__*/ qrl(()=>import("./renderheader_div_onclick_fv2uzal99u4"), "renderHeader_div_onClick_fV2uzAL99u4")}/>;
+    return <div onClick={/*#__PURE__*/ qrl(()=>import("./test.tsx_renderheader_div_onclick_fv2uzal99u4"), "renderHeader_div_onClick_fV2uzAL99u4")}/>;
 };
 export { _hW } from "@builder.io/qwik";
 
@@ -33,9 +33,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "renderHeader_zBbHWn4e8Cg",
   "entry": null,
-  "displayName": "renderHeader",
+  "displayName": "test.tsx_renderHeader",
   "hash": "zBbHWn4e8Cg",
-  "canonicalFilename": "renderheader_zbbhwn4e8cg",
+  "canonicalFilename": "test.tsx_renderheader_zbbhwn4e8cg",
   "path": "",
   "extension": "tsx",
   "parent": null,
@@ -48,7 +48,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= renderheader_component_u6kkv07sbpq.tsx (ENTRY POINT)==
+============================= test.tsx_renderheader_component_u6kkv07sbpq.tsx (ENTRY POINT)==
 
 export const renderHeader_component_U6Kkv07sbpQ = ()=>{
     console.log("mount");
@@ -63,9 +63,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "renderHeader_component_U6Kkv07sbpQ",
   "entry": null,
-  "displayName": "renderHeader_component",
+  "displayName": "test.tsx_renderHeader_component",
   "hash": "U6Kkv07sbpQ",
-  "canonicalFilename": "renderheader_component_u6kkv07sbpq",
+  "canonicalFilename": "test.tsx_renderheader_component_u6kkv07sbpq",
   "path": "",
   "extension": "tsx",
   "parent": null,
@@ -82,12 +82,12 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { qrl } from "@builder.io/qwik";
 import { component } from '@builder.io/qwik';
-export const renderHeader = /*#__PURE__*/ qrl(()=>import("./renderheader_zbbhwn4e8cg"), "renderHeader_zBbHWn4e8Cg");
-const renderHeader = component(/*#__PURE__*/ qrl(()=>import("./renderheader_component_u6kkv07sbpq"), "renderHeader_component_U6Kkv07sbpQ"));
+export const renderHeader = /*#__PURE__*/ qrl(()=>import("./test.tsx_renderheader_zbbhwn4e8cg"), "renderHeader_zBbHWn4e8Cg");
+const renderHeader = component(/*#__PURE__*/ qrl(()=>import("./test.tsx_renderheader_component_u6kkv07sbpq"), "renderHeader_component_U6Kkv07sbpQ"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";AACA,SAAY,SAAS,QAAkB,mBAAmB;AAE1D,OAAO,MAAM,uGAIV;AACH,MAAM,eAAe\"}")
-============================= renderheader_div_onclick_fv2uzal99u4.tsx (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";AACA,SAAY,SAAS,QAAkB,mBAAmB;AAE1D,OAAO,MAAM,gHAIV;AACH,MAAM,eAAe\"}")
+============================= test.tsx_renderheader_div_onclick_fv2uzal99u4.tsx (ENTRY POINT)==
 
 export const renderHeader_div_onClick_fV2uzAL99u4 = (ctx)=>console.log(ctx);
 export { _hW } from "@builder.io/qwik";
@@ -99,9 +99,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "renderHeader_div_onClick_fV2uzAL99u4",
   "entry": null,
-  "displayName": "renderHeader_div_onClick",
+  "displayName": "test.tsx_renderHeader_div_onClick",
   "hash": "fV2uzAL99u4",
-  "canonicalFilename": "renderheader_div_onclick_fv2uzal99u4",
+  "canonicalFilename": "test.tsx_renderheader_div_onclick_fv2uzal99u4",
   "path": "",
   "extension": "tsx",
   "parent": "renderHeader_zBbHWn4e8Cg",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_10.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_10.snap
@@ -26,7 +26,7 @@ const Header = $((decl1, {decl2}, [decl3]) => {
     )
 });
 
-============================= project/header_wlr3xni6u38.tsx (ENTRY POINT)==
+============================= project/test.tsx_header_wlr3xni6u38.tsx (ENTRY POINT)==
 
 export const Header_WlR3xnI6u38 = (decl1, { decl2 }, [decl3])=>{
     ident1.no;
@@ -57,9 +57,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\"
   "origin": "project/test.tsx",
   "name": "Header_WlR3xnI6u38",
   "entry": null,
-  "displayName": "Header",
+  "displayName": "test.tsx_Header",
   "hash": "WlR3xnI6u38",
-  "canonicalFilename": "header_wlr3xni6u38",
+  "canonicalFilename": "test.tsx_header_wlr3xni6u38",
   "path": "project",
   "extension": "tsx",
   "parent": null,
@@ -75,7 +75,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\"
 ============================= project/test.tsx ==
 
 import { qrl } from "@builder.io/qwik";
-/*#__PURE__*/ qrl(()=>import("./header_wlr3xni6u38"), "Header_WlR3xnI6u38");
+/*#__PURE__*/ qrl(()=>import("./test.tsx_header_wlr3xni6u38"), "Header_WlR3xnI6u38");
 
 
 Some("{\"version\":3,\"sources\":[],\"names\":[],\"mappings\":\"\"}")

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_11.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_11.snap
@@ -25,7 +25,7 @@ export const App = component$(() => {
     );
 });
 
-============================= project/header_component_header_onclick_kjd9tcnknxy.tsx ==
+============================= project/test.tsx_header_component_header_onclick_kjd9tcnknxy.tsx ==
 
 import dep3 from "dep3/something";
 export const Header_component_Header_onClick_KjD9TCNkNxY = (ev)=>dep3(ev);
@@ -38,9 +38,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\"
   "origin": "project/test.tsx",
   "name": "Header_component_Header_onClick_KjD9TCNkNxY",
   "entry": "entry_segments",
-  "displayName": "Header_component_Header_onClick",
+  "displayName": "test.tsx_Header_component_Header_onClick",
   "hash": "KjD9TCNkNxY",
-  "canonicalFilename": "header_component_header_onclick_kjd9tcnknxy",
+  "canonicalFilename": "test.tsx_header_component_header_onclick_kjd9tcnknxy",
   "path": "project",
   "extension": "tsx",
   "parent": "Header_component_UVBJuFYfvDo",
@@ -53,28 +53,28 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\"
   ]
 }
 */
-============================= project/header_component_uvbjufyfvdo.tsx ==
+============================= project/test.tsx_header_component_uvbjufyfvdo.tsx ==
 
 import { Header } from "./test";
 import { bar as bbar } from "../state";
 import * as dep2 from "dep2";
 import { qrl } from "@builder.io/qwik";
 export const Header_component_UVBJuFYfvDo = ()=>{
-    return <Header onClick={/*#__PURE__*/ qrl(()=>import("./header_component_header_onclick_kjd9tcnknxy"), "Header_component_Header_onClick_KjD9TCNkNxY")}>
+    return <Header onClick={/*#__PURE__*/ qrl(()=>import("./test.tsx_header_component_header_onclick_kjd9tcnknxy"), "Header_component_Header_onClick_KjD9TCNkNxY")}>
             {dep2.stuff()}{bbar()}
         </Header>;
 };
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\":[],\"mappings\":\";;;;4CAMiC;IAC7B,QACK,OAAO,wIAA8B;YAClC,CAAC,KAAK,KAAK,IAAI,OAAO;QAC1B,EAAE;AAEV\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\":[],\"mappings\":\";;;;4CAMiC;IAC7B,QACK,OAAO,iJAA8B;YAClC,CAAC,KAAK,KAAK,IAAI,OAAO;QAC1B,EAAE;AAEV\"}")
 /*
 {
   "origin": "project/test.tsx",
   "name": "Header_component_UVBJuFYfvDo",
   "entry": "entry_segments",
-  "displayName": "Header_component",
+  "displayName": "test.tsx_Header_component",
   "hash": "UVBJuFYfvDo",
-  "canonicalFilename": "header_component_uvbjufyfvdo",
+  "canonicalFilename": "test.tsx_header_component_uvbjufyfvdo",
   "path": "project",
   "extension": "tsx",
   "parent": null,
@@ -87,7 +87,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\"
   ]
 }
 */
-============================= project/app_component_wgkrhwxaqjs.tsx ==
+============================= project/test.tsx_app_component_wgkrhwxaqjs.tsx ==
 
 import { Header } from "./test";
 import { foo } from "../state";
@@ -102,9 +102,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\"
   "origin": "project/test.tsx",
   "name": "App_component_wGkRHWXaqjs",
   "entry": "entry_segments",
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "wGkRHWXaqjs",
-  "canonicalFilename": "app_component_wgkrhwxaqjs",
+  "canonicalFilename": "test.tsx_app_component_wgkrhwxaqjs",
   "path": "project",
   "extension": "tsx",
   "parent": null,
@@ -121,11 +121,11 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\"
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./header_component_uvbjufyfvdo"), "Header_component_UVBJuFYfvDo"));
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_wgkrhwxaqjs"), "App_component_wGkRHWXaqjs"));
+export const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_header_component_uvbjufyfvdo"), "Header_component_UVBJuFYfvDo"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_wgkrhwxaqjs"), "App_component_wGkRHWXaqjs"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\":[],\"mappings\":\";;AAMA,OAAO,MAAM,uBAAS,8GAMnB;AAEH,OAAO,MAAM,oBAAM,wGAIhB\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\":[],\"mappings\":\";;AAMA,OAAO,MAAM,uBAAS,uHAMnB;AAEH,OAAO,MAAM,oBAAM,iHAIhB\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_2.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_2.snap
@@ -14,12 +14,12 @@ export const Header = component$(() => {
     );
 });
 
-============================= header_component_j4uyihabnr4.tsx (ENTRY POINT)==
+============================= test.tsx_header_component_j4uyihabnr4.tsx (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 export const Header_component_J4uyIhaBNR4 = ()=>{
     console.log("mount");
-    return <div onClick={/*#__PURE__*/ qrl(()=>import("./header_component_div_onclick_i7ekvwh3674"), "Header_component_div_onClick_i7ekvWH3674")}/>;
+    return <div onClick={/*#__PURE__*/ qrl(()=>import("./test.tsx_header_component_div_onclick_i7ekvwh3674"), "Header_component_div_onClick_i7ekvWH3674")}/>;
 };
 
 
@@ -29,9 +29,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Header_component_J4uyIhaBNR4",
   "entry": null,
-  "displayName": "Header_component",
+  "displayName": "test.tsx_Header_component",
   "hash": "J4uyIhaBNR4",
-  "canonicalFilename": "header_component_j4uyihabnr4",
+  "canonicalFilename": "test.tsx_header_component_j4uyihabnr4",
   "path": "",
   "extension": "tsx",
   "parent": null,
@@ -48,11 +48,11 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./header_component_j4uyihabnr4"), "Header_component_J4uyIhaBNR4"));
+export const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_header_component_j4uyihabnr4"), "Header_component_J4uyIhaBNR4"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAEA,OAAO,MAAM,uBAAS,8GAKnB\"}")
-============================= header_component_div_onclick_i7ekvwh3674.tsx (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAEA,OAAO,MAAM,uBAAS,uHAKnB\"}")
+============================= test.tsx_header_component_div_onclick_i7ekvwh3674.tsx (ENTRY POINT)==
 
 export const Header_component_div_onClick_i7ekvWH3674 = (ctx)=>console.log(ctx);
 export { _hW } from "@builder.io/qwik";
@@ -64,9 +64,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Header_component_div_onClick_i7ekvWH3674",
   "entry": null,
-  "displayName": "Header_component_div_onClick",
+  "displayName": "test.tsx_Header_component_div_onClick",
   "hash": "i7ekvWH3674",
-  "canonicalFilename": "header_component_div_onclick_i7ekvwh3674",
+  "canonicalFilename": "test.tsx_header_component_div_onclick_i7ekvwh3674",
   "path": "",
   "extension": "tsx",
   "parent": "Header_component_J4uyIhaBNR4",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_3.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_3.snap
@@ -17,12 +17,12 @@ export const App = () => {
     return Header;
 });
 
-============================= app_header_component_b9f3yeqco1w.tsx (ENTRY POINT)==
+============================= test.tsx_app_header_component_b9f3yeqco1w.tsx (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 export const App_Header_component_B9F3YeqcO1w = ()=>{
     console.log("mount");
-    return <div onClick={/*#__PURE__*/ qrl(()=>import("./app_header_component_div_onclick_ao7ui7iw6oq"), "App_Header_component_div_onClick_aO7uI7Iw6oQ")}/>;
+    return <div onClick={/*#__PURE__*/ qrl(()=>import("./test.tsx_app_header_component_div_onclick_ao7ui7iw6oq"), "App_Header_component_div_onClick_aO7uI7Iw6oQ")}/>;
 };
 
 
@@ -32,9 +32,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_Header_component_B9F3YeqcO1w",
   "entry": null,
-  "displayName": "App_Header_component",
+  "displayName": "test.tsx_App_Header_component",
   "hash": "B9F3YeqcO1w",
-  "canonicalFilename": "app_header_component_b9f3yeqco1w",
+  "canonicalFilename": "test.tsx_app_header_component_b9f3yeqco1w",
   "path": "",
   "extension": "tsx",
   "parent": null,
@@ -47,7 +47,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_header_component_div_onclick_ao7ui7iw6oq.tsx (ENTRY POINT)==
+============================= test.tsx_app_header_component_div_onclick_ao7ui7iw6oq.tsx (ENTRY POINT)==
 
 export const App_Header_component_div_onClick_aO7uI7Iw6oQ = (ctx)=>console.log(ctx);
 export { _hW } from "@builder.io/qwik";
@@ -59,9 +59,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_Header_component_div_onClick_aO7uI7Iw6oQ",
   "entry": null,
-  "displayName": "App_Header_component_div_onClick",
+  "displayName": "test.tsx_App_Header_component_div_onClick",
   "hash": "aO7uI7Iw6oQ",
-  "canonicalFilename": "app_header_component_div_onclick_ao7ui7iw6oq",
+  "canonicalFilename": "test.tsx_app_header_component_div_onclick_ao7ui7iw6oq",
   "path": "",
   "extension": "tsx",
   "parent": "App_Header_component_B9F3YeqcO1w",
@@ -79,7 +79,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
 export const App = ()=>{
-    const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_header_component_b9f3yeqco1w"), "App_Header_component_B9F3YeqcO1w"));
+    const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_header_component_b9f3yeqco1w"), "App_Header_component_B9F3YeqcO1w"));
     return Header;
 };
 

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_4.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_4.snap
@@ -17,12 +17,12 @@ export function App() {
     return Header;
 }
 
-============================= app_header_component_b9f3yeqco1w.tsx (ENTRY POINT)==
+============================= test.tsx_app_header_component_b9f3yeqco1w.tsx (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 export const App_Header_component_B9F3YeqcO1w = ()=>{
     console.log("mount");
-    return <div onClick={/*#__PURE__*/ qrl(()=>import("./app_header_component_div_onclick_ao7ui7iw6oq"), "App_Header_component_div_onClick_aO7uI7Iw6oQ")}/>;
+    return <div onClick={/*#__PURE__*/ qrl(()=>import("./test.tsx_app_header_component_div_onclick_ao7ui7iw6oq"), "App_Header_component_div_onClick_aO7uI7Iw6oQ")}/>;
 };
 
 
@@ -32,9 +32,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_Header_component_B9F3YeqcO1w",
   "entry": null,
-  "displayName": "App_Header_component",
+  "displayName": "test.tsx_App_Header_component",
   "hash": "B9F3YeqcO1w",
-  "canonicalFilename": "app_header_component_b9f3yeqco1w",
+  "canonicalFilename": "test.tsx_app_header_component_b9f3yeqco1w",
   "path": "",
   "extension": "tsx",
   "parent": null,
@@ -47,7 +47,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_header_component_div_onclick_ao7ui7iw6oq.tsx (ENTRY POINT)==
+============================= test.tsx_app_header_component_div_onclick_ao7ui7iw6oq.tsx (ENTRY POINT)==
 
 export const App_Header_component_div_onClick_aO7uI7Iw6oQ = (ctx)=>console.log(ctx);
 export { _hW } from "@builder.io/qwik";
@@ -59,9 +59,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_Header_component_div_onClick_aO7uI7Iw6oQ",
   "entry": null,
-  "displayName": "App_Header_component_div_onClick",
+  "displayName": "test.tsx_App_Header_component_div_onClick",
   "hash": "aO7uI7Iw6oQ",
-  "canonicalFilename": "app_header_component_div_onclick_ao7ui7iw6oq",
+  "canonicalFilename": "test.tsx_app_header_component_div_onclick_ao7ui7iw6oq",
   "path": "",
   "extension": "tsx",
   "parent": "App_Header_component_B9F3YeqcO1w",
@@ -79,7 +79,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
 export function App() {
-    const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_header_component_b9f3yeqco1w"), "App_Header_component_B9F3YeqcO1w"));
+    const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_header_component_b9f3yeqco1w"), "App_Header_component_B9F3YeqcO1w"));
     return Header;
 }
 

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_5.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_5.snap
@@ -16,26 +16,26 @@ export const Header = component$(() => {
     );
 });
 
-============================= header_component_j4uyihabnr4.tsx (ENTRY POINT)==
+============================= test.tsx_header_component_j4uyihabnr4.tsx (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 export const Header_component_J4uyIhaBNR4 = ()=>{
     return <>
             <div onClick={(ctx)=>console.log("1")}/>
-            <div onClick={/*#__PURE__*/ qrl(()=>import("./header_component_div_onclick_i7ekvwh3674"), "Header_component_div_onClick_i7ekvWH3674")}/>
+            <div onClick={/*#__PURE__*/ qrl(()=>import("./test.tsx_header_component_div_onclick_i7ekvwh3674"), "Header_component_div_onClick_i7ekvWH3674")}/>
         </>;
 };
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";4CAEiC;IAC7B,SACM;YACE,CAAC,IAAI,SAAS,CAAC,MAAQ,QAAQ,GAAG,CAAC,OAAO;YAC1C,CAAC,IAAI,mIAAwC;QACjD;AAER\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";4CAEiC;IAC7B,SACM;YACE,CAAC,IAAI,SAAS,CAAC,MAAQ,QAAQ,GAAG,CAAC,OAAO;YAC1C,CAAC,IAAI,4IAAwC;QACjD;AAER\"}")
 /*
 {
   "origin": "test.tsx",
   "name": "Header_component_J4uyIhaBNR4",
   "entry": null,
-  "displayName": "Header_component",
+  "displayName": "test.tsx_Header_component",
   "hash": "J4uyIhaBNR4",
-  "canonicalFilename": "header_component_j4uyihabnr4",
+  "canonicalFilename": "test.tsx_header_component_j4uyihabnr4",
   "path": "",
   "extension": "tsx",
   "parent": null,
@@ -52,11 +52,11 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./header_component_j4uyihabnr4"), "Header_component_J4uyIhaBNR4"));
+export const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_header_component_j4uyihabnr4"), "Header_component_J4uyIhaBNR4"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAEA,OAAO,MAAM,uBAAS,8GAOnB\"}")
-============================= header_component_div_onclick_i7ekvwh3674.tsx (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAEA,OAAO,MAAM,uBAAS,uHAOnB\"}")
+============================= test.tsx_header_component_div_onclick_i7ekvwh3674.tsx (ENTRY POINT)==
 
 export const Header_component_div_onClick_i7ekvWH3674 = (ctx)=>console.log("2");
 export { _hW } from "@builder.io/qwik";
@@ -68,9 +68,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Header_component_div_onClick_i7ekvWH3674",
   "entry": null,
-  "displayName": "Header_component_div_onClick",
+  "displayName": "test.tsx_Header_component_div_onClick",
   "hash": "i7ekvWH3674",
-  "canonicalFilename": "header_component_div_onclick_i7ekvwh3674",
+  "canonicalFilename": "test.tsx_header_component_div_onclick_i7ekvwh3674",
   "path": "",
   "extension": "tsx",
   "parent": "Header_component_J4uyIhaBNR4",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_6.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_6.snap
@@ -9,7 +9,7 @@ expression: output
 import { $, component$ } from '@builder.io/qwik';
 export const sym1 = $((ctx) => console.log("1"));
 
-============================= sym1_axurpxx5lak.tsx (ENTRY POINT)==
+============================= test.tsx_sym1_axurpxx5lak.tsx (ENTRY POINT)==
 
 export const sym1_aXUrPXX5Lak = (ctx)=>console.log("1");
 export { _hW } from "@builder.io/qwik";
@@ -21,9 +21,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "sym1_aXUrPXX5Lak",
   "entry": null,
-  "displayName": "sym1",
+  "displayName": "test.tsx_sym1",
   "hash": "aXUrPXX5Lak",
-  "canonicalFilename": "sym1_axurpxx5lak",
+  "canonicalFilename": "test.tsx_sym1_axurpxx5lak",
   "path": "",
   "extension": "tsx",
   "parent": null,
@@ -39,10 +39,10 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 ============================= test.tsx ==
 
 import { qrl } from "@builder.io/qwik";
-export const sym1 = /*#__PURE__*/ qrl(()=>import("./sym1_axurpxx5lak"), "sym1_aXUrPXX5Lak");
+export const sym1 = /*#__PURE__*/ qrl(()=>import("./test.tsx_sym1_axurpxx5lak"), "sym1_aXUrPXX5Lak");
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";AAEA,OAAO,MAAM,+EAAoC\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";AAEA,OAAO,MAAM,wFAAoC\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_7.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_7.snap
@@ -21,12 +21,12 @@ const App = component$(() => {
     );
 });
 
-============================= header_component_j4uyihabnr4.tsx (ENTRY POINT)==
+============================= test.tsx_header_component_j4uyihabnr4.tsx (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 export const Header_component_J4uyIhaBNR4 = ()=>{
     console.log("mount");
-    return <div onClick={/*#__PURE__*/ qrl(()=>import("./header_component_div_onclick_i7ekvwh3674"), "Header_component_div_onClick_i7ekvWH3674")}/>;
+    return <div onClick={/*#__PURE__*/ qrl(()=>import("./test.tsx_header_component_div_onclick_i7ekvwh3674"), "Header_component_div_onClick_i7ekvWH3674")}/>;
 };
 
 
@@ -36,9 +36,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Header_component_J4uyIhaBNR4",
   "entry": null,
-  "displayName": "Header_component",
+  "displayName": "test.tsx_Header_component",
   "hash": "J4uyIhaBNR4",
-  "canonicalFilename": "header_component_j4uyihabnr4",
+  "canonicalFilename": "test.tsx_header_component_j4uyihabnr4",
   "path": "",
   "extension": "tsx",
   "parent": null,
@@ -55,12 +55,12 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./header_component_j4uyihabnr4"), "Header_component_J4uyIhaBNR4"));
-/*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
+export const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_header_component_j4uyihabnr4"), "Header_component_J4uyIhaBNR4"));
+/*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,uBAAS,8GAKjB;cAEO\"}")
-============================= app_component_ckepmxzlub0.tsx (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,uBAAS,uHAKjB;cAEO\"}")
+============================= test.tsx_app_component_ckepmxzlub0.tsx (ENTRY POINT)==
 
 import { Header } from "./test";
 export const App_component_ckEPmXZlub0 = ()=>{
@@ -74,9 +74,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "tsx",
   "parent": null,
@@ -89,7 +89,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= header_component_div_onclick_i7ekvwh3674.tsx (ENTRY POINT)==
+============================= test.tsx_header_component_div_onclick_i7ekvwh3674.tsx (ENTRY POINT)==
 
 export const Header_component_div_onClick_i7ekvWH3674 = (ctx)=>console.log(ctx);
 export { _hW } from "@builder.io/qwik";
@@ -101,9 +101,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Header_component_div_onClick_i7ekvWH3674",
   "entry": null,
-  "displayName": "Header_component_div_onClick",
+  "displayName": "test.tsx_Header_component_div_onClick",
   "hash": "i7ekvWH3674",
-  "canonicalFilename": "header_component_div_onclick_i7ekvwh3674",
+  "canonicalFilename": "test.tsx_header_component_div_onclick_i7ekvwh3674",
   "path": "",
   "extension": "tsx",
   "parent": "Header_component_J4uyIhaBNR4",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_8.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_8.snap
@@ -19,11 +19,11 @@ export const Header = component$(() => {
     });
 });
 
-============================= header_component_j4uyihabnr4.tsx (ENTRY POINT)==
+============================= test.tsx_header_component_j4uyihabnr4.tsx (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 export const Header_component_J4uyIhaBNR4 = ()=>{
-    return /*#__PURE__*/ qrl(()=>import("./header_component_1_2b8d0oh9zwc"), "Header_component_1_2B8d0oH9ZWc");
+    return /*#__PURE__*/ qrl(()=>import("./test.tsx_header_component_1_2b8d0oh9zwc"), "Header_component_1_2B8d0oH9ZWc");
 };
 
 
@@ -33,9 +33,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Header_component_J4uyIhaBNR4",
   "entry": null,
-  "displayName": "Header_component",
+  "displayName": "test.tsx_Header_component",
   "hash": "J4uyIhaBNR4",
-  "canonicalFilename": "header_component_j4uyihabnr4",
+  "canonicalFilename": "test.tsx_header_component_j4uyihabnr4",
   "path": "",
   "extension": "tsx",
   "parent": null,
@@ -48,7 +48,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= header_component_1_2b8d0oh9zwc.tsx (ENTRY POINT)==
+============================= test.tsx_header_component_1_2b8d0oh9zwc.tsx (ENTRY POINT)==
 
 import { Header } from "./test";
 export const Header_component_1_2B8d0oH9ZWc = (hola)=>{
@@ -66,9 +66,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Header_component_1_2B8d0oH9ZWc",
   "entry": null,
-  "displayName": "Header_component_1",
+  "displayName": "test.tsx_Header_component_1",
   "hash": "2B8d0oH9ZWc",
-  "canonicalFilename": "header_component_1_2b8d0oh9zwc",
+  "canonicalFilename": "test.tsx_header_component_1_2b8d0oh9zwc",
   "path": "",
   "extension": "tsx",
   "parent": "Header_component_J4uyIhaBNR4",
@@ -85,10 +85,10 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./header_component_j4uyihabnr4"), "Header_component_J4uyIhaBNR4"));
+export const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_header_component_j4uyihabnr4"), "Header_component_J4uyIhaBNR4"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,uBAAS,8GASnB\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,uBAAS,uHASnB\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_9.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_9.snap
@@ -19,7 +19,7 @@ const Header = $((decl1, {decl2}, [decl3]) => {
     try{}catch({decl19}){}
 });
 
-============================= header_wjuauqn7oxg.tsx (ENTRY POINT)==
+============================= test.tsx_header_wjuauqn7oxg.tsx (ENTRY POINT)==
 
 export const Header_WjUaUQN7Oxg = (decl1, { decl2 }, [decl3])=>{
     const { decl4, key: decl5 } = this;
@@ -34,9 +34,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Header_WjUaUQN7Oxg",
   "entry": null,
-  "displayName": "Header",
+  "displayName": "test.tsx_Header",
   "hash": "WjUaUQN7Oxg",
-  "canonicalFilename": "header_wjuauqn7oxg",
+  "canonicalFilename": "test.tsx_header_wjuauqn7oxg",
   "path": "",
   "extension": "tsx",
   "parent": null,
@@ -52,7 +52,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 ============================= test.tsx ==
 
 import { qrl } from "@builder.io/qwik";
-/*#__PURE__*/ qrl(()=>import("./header_wjuauqn7oxg"), "Header_WjUaUQN7Oxg");
+/*#__PURE__*/ qrl(()=>import("./test.tsx_header_wjuauqn7oxg"), "Header_WjUaUQN7Oxg");
 
 
 Some("{\"version\":3,\"sources\":[],\"names\":[],\"mappings\":\"\"}")

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_build_server.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_build_server.snap
@@ -43,11 +43,11 @@ export const App = component$(() => {
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
 export const functionThatNeedsWindow = ()=>{};
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./s_ckepmxzlub0"), "s_ckEPmXZlub0"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0"), "s_ckEPmXZlub0"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAQA,OAAO,MAAM,0BAA0B,KAMvC,EAAE;AAEF,OAAO,MAAM,oBAAM,gFAehB\"}")
-============================= s_ckepmxzlub0.tsx (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAQA,OAAO,MAAM,0BAA0B,KAMvC,EAAE;AAEF,OAAO,MAAM,oBAAM,qGAehB\"}")
+============================= test.tsx_app_component_ckepmxzlub0.tsx (ENTRY POINT)==
 
 import { mongodb } from "mondodb";
 export const s_ckEPmXZlub0 = ()=>{
@@ -67,9 +67,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "s_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "s_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "tsx",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_capture_imports.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_capture_imports.snap
@@ -20,11 +20,11 @@ export const App = component$(() => {
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAMA,OAAO,MAAM,oBAAM,wGAGjB\"}")
-============================= app_component_usestyles_t35nsa5uv7u.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAMA,OAAO,MAAM,oBAAM,iHAGjB\"}")
+============================= test.tsx_app_component_usestyles_t35nsa5uv7u.js (ENTRY POINT)==
 
 import css1 from "./global.css";
 import css2 from "./style.css";
@@ -37,9 +37,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_useStyles_t35nSa5UV7U",
   "entry": null,
-  "displayName": "App_component_useStyles",
+  "displayName": "test.tsx_App_component_useStyles",
   "hash": "t35nSa5UV7U",
-  "canonicalFilename": "app_component_usestyles_t35nsa5uv7u",
+  "canonicalFilename": "test.tsx_app_component_usestyles_t35nsa5uv7u",
   "path": "",
   "extension": "js",
   "parent": "App_component_ckEPmXZlub0",
@@ -52,13 +52,13 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_ckepmxzlub0.js (ENTRY POINT)==
+============================= test.tsx_app_component_ckepmxzlub0.js (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 import { useStylesQrl } from "@builder.io/qwik";
 export const App_component_ckEPmXZlub0 = ()=>{
-    useStylesQrl(/*#__PURE__*/ qrl(()=>import("./app_component_usestyles_t35nsa5uv7u"), "App_component_useStyles_t35nSa5UV7U"));
-    useStylesQrl(/*#__PURE__*/ qrl(()=>import("./app_component_usestyles_1_xbk4w0zkwe8"), "App_component_useStyles_1_xBK4W0ZKWe8"));
+    useStylesQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_usestyles_t35nsa5uv7u"), "App_component_useStyles_t35nSa5UV7U"));
+    useStylesQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_usestyles_1_xbk4w0zkwe8"), "App_component_useStyles_1_xBK4W0ZKWe8"));
 };
 
 
@@ -68,9 +68,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -83,7 +83,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_usestyles_1_xbk4w0zkwe8.js (ENTRY POINT)==
+============================= test.tsx_app_component_usestyles_1_xbk4w0zkwe8.js (ENTRY POINT)==
 
 import css3 from "./style.css";
 export const App_component_useStyles_1_xBK4W0ZKWe8 = css3;
@@ -95,9 +95,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_useStyles_1_xBK4W0ZKWe8",
   "entry": null,
-  "displayName": "App_component_useStyles_1",
+  "displayName": "test.tsx_App_component_useStyles_1",
   "hash": "xBK4W0ZKWe8",
-  "canonicalFilename": "app_component_usestyles_1_xbk4w0zkwe8",
+  "canonicalFilename": "test.tsx_app_component_usestyles_1_xbk4w0zkwe8",
   "path": "",
   "extension": "js",
   "parent": "App_component_ckEPmXZlub0",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_capturing_fn_class.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_capturing_fn_class.snap
@@ -28,15 +28,15 @@ export const App = component$(() => {
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,wGAcjB\"}")
-============================= app_component_ckepmxzlub0.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,iHAcjB\"}")
+============================= test.tsx_app_component_ckepmxzlub0.js (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 export const App_component_ckEPmXZlub0 = ()=>{
-    return /*#__PURE__*/ qrl(()=>import("./app_component_1_w0t0o3qmovu"), "App_component_1_w0t0o3QMovU");
+    return /*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_1_w0t0o3qmovu"), "App_component_1_w0t0o3QMovU");
 };
 
 
@@ -46,9 +46,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -61,7 +61,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_1_w0t0o3qmovu.js (ENTRY POINT)==
+============================= test.tsx_app_component_1_w0t0o3qmovu.js (ENTRY POINT)==
 
 import { _jsxQ } from "@builder.io/qwik";
 export const App_component_1_w0t0o3QMovU = ()=>{
@@ -78,9 +78,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_1_w0t0o3QMovU",
   "entry": null,
-  "displayName": "App_component_1",
+  "displayName": "test.tsx_App_component_1",
   "hash": "w0t0o3QMovU",
-  "canonicalFilename": "app_component_1_w0t0o3qmovu",
+  "canonicalFilename": "test.tsx_app_component_1_w0t0o3qmovu",
   "path": "",
   "extension": "js",
   "parent": "App_component_ckEPmXZlub0",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_class_name.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_class_name.snap
@@ -30,11 +30,11 @@ export const App2 = component$(() => {
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const App2 = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app2_component_3yvemqbq3fs.js"), "App2_component_3yveMqbQ3Fs"));
+export const App2 = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app2_component_3yvemqbq3fs.js"), "App2_component_3yveMqbQ3Fs"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,qBAAO,6GAgBjB\"}")
-============================= app2_component_3yvemqbq3fs.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,qBAAO,sHAgBjB\"}")
+============================= test.tsx_app2_component_3yvemqbq3fs.js (ENTRY POINT)==
 
 import { Fragment as _Fragment } from "@builder.io/qwik/jsx-runtime";
 import { _IMMUTABLE } from "@builder.io/qwik";
@@ -96,9 +96,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App2_component_3yveMqbQ3Fs",
   "entry": null,
-  "displayName": "App2_component",
+  "displayName": "test.tsx_App2_component",
   "hash": "3yveMqbQ3Fs",
-  "canonicalFilename": "app2_component_3yvemqbq3fs",
+  "canonicalFilename": "test.tsx_app2_component_3yvemqbq3fs",
   "path": "",
   "extension": "js",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_custom_inlined_functions.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_custom_inlined_functions.snap
@@ -39,14 +39,14 @@ export const useMemoQrl = (qrt)=>{
     useEffect(qrt);
 };
 export const useMemo$ = wrap(useMemoQrl);
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
 export const Lightweight = (props)=>{
-    useMemoQrl(/*#__PURE__*/ qrl(()=>import("./lightweight_usememo_uicxvtqf1a8"), "Lightweight_useMemo_UIcxVTQF1a8"));
+    useMemoQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_lightweight_usememo_uicxvtqf1a8"), "Lightweight_useMemo_UIcxVTQF1a8"));
 };
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AACA,SAAkC,IAAI,EAAE,SAAS,QAAQ,mBAAmB;AAE5E,OAAO,MAAM,aAAa,CAAC;IACvB,UAAU;AACd,EAAE;AAEF,OAAO,MAAM,WAAW,KAAK,YAAY;AAEzC,OAAO,MAAM,oBAAM,wGAQhB;AAEH,OAAO,MAAM,cAAc,CAAC;IACxB;AAGJ,EAAG\"}")
-============================= app_component_usememo_6sc9kvki3y0.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AACA,SAAkC,IAAI,EAAE,SAAS,QAAQ,mBAAmB;AAE5E,OAAO,MAAM,aAAa,CAAC;IACvB,UAAU;AACd,EAAE;AAEF,OAAO,MAAM,WAAW,KAAK,YAAY;AAEzC,OAAO,MAAM,oBAAM,iHAQhB;AAEH,OAAO,MAAM,cAAc,CAAC;IACxB;AAGJ,EAAG\"}")
+============================= test.tsx_app_component_usememo_6sc9kvki3y0.js (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
 export const App_component_useMemo_6Sc9KVki3Y0 = ()=>{
@@ -61,9 +61,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_useMemo_6Sc9KVki3Y0",
   "entry": null,
-  "displayName": "App_component_useMemo",
+  "displayName": "test.tsx_App_component_useMemo",
   "hash": "6Sc9KVki3Y0",
-  "canonicalFilename": "app_component_usememo_6sc9kvki3y0",
+  "canonicalFilename": "test.tsx_app_component_usememo_6sc9kvki3y0",
   "path": "",
   "extension": "js",
   "parent": "App_component_ckEPmXZlub0",
@@ -76,7 +76,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= lightweight_usememo_uicxvtqf1a8.js (ENTRY POINT)==
+============================= test.tsx_lightweight_usememo_uicxvtqf1a8.js (ENTRY POINT)==
 
 export const Lightweight_useMemo_UIcxVTQF1a8 = ()=>{
     console.log(state.count);
@@ -89,9 +89,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Lightweight_useMemo_UIcxVTQF1a8",
   "entry": null,
-  "displayName": "Lightweight_useMemo",
+  "displayName": "test.tsx_Lightweight_useMemo",
   "hash": "UIcxVTQF1a8",
-  "canonicalFilename": "lightweight_usememo_uicxvtqf1a8",
+  "canonicalFilename": "test.tsx_lightweight_usememo_uicxvtqf1a8",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -104,7 +104,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_ckepmxzlub0.js (ENTRY POINT)==
+============================= test.tsx_app_component_ckepmxzlub0.js (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 import { useMemoQrl } from "./test";
@@ -113,10 +113,10 @@ export const App_component_ckEPmXZlub0 = (props)=>{
     const state = useStore({
         count: 0
     });
-    useMemoQrl(/*#__PURE__*/ qrl(()=>import("./app_component_usememo_6sc9kvki3y0"), "App_component_useMemo_6Sc9KVki3Y0", [
+    useMemoQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_usememo_6sc9kvki3y0"), "App_component_useMemo_6Sc9KVki3Y0", [
         state
     ]));
-    return /*#__PURE__*/ qrl(()=>import("./app_component_1_w0t0o3qmovu"), "App_component_1_w0t0o3QMovU", [
+    return /*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_1_w0t0o3qmovu"), "App_component_1_w0t0o3QMovU", [
         state
     ]);
 };
@@ -128,9 +128,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -143,7 +143,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_1_w0t0o3qmovu.js (ENTRY POINT)==
+============================= test.tsx_app_component_1_w0t0o3qmovu.js (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
 import { _fnSignal } from "@builder.io/qwik";
@@ -163,9 +163,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_1_w0t0o3QMovU",
   "entry": null,
-  "displayName": "App_component_1",
+  "displayName": "test.tsx_App_component_1",
   "hash": "w0t0o3QMovU",
-  "canonicalFilename": "app_component_1_w0t0o3qmovu",
+  "canonicalFilename": "test.tsx_app_component_1_w0t0o3qmovu",
   "path": "",
   "extension": "js",
   "parent": "App_component_ckEPmXZlub0",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_dead_code.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_dead_code.snap
@@ -20,7 +20,7 @@ export const Foo = component$(({foo}) => {
     );
 })
 
-============================= foo_component_htdrsvublie.tsx (ENTRY POINT)==
+============================= test.tsx_foo_component_htdrsvublie.tsx (ENTRY POINT)==
 
 export const Foo_component_HTDRsvUbLiE = (props)=>{
     useMount$(()=>{});
@@ -34,9 +34,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_HTDRsvUbLiE",
   "entry": null,
-  "displayName": "Foo_component",
+  "displayName": "test.tsx_Foo_component",
   "hash": "HTDRsvUbLiE",
-  "canonicalFilename": "foo_component_htdrsvublie",
+  "canonicalFilename": "test.tsx_foo_component_htdrsvublie",
   "path": "",
   "extension": "tsx",
   "parent": null,
@@ -53,10 +53,10 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Foo = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./foo_component_htdrsvublie"), "Foo_component_HTDRsvUbLiE"));
+export const Foo = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_htdrsvublie"), "Foo_component_HTDRsvUbLiE"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAIA,OAAO,MAAM,oBAAM,wGASjB\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAIA,OAAO,MAAM,oBAAM,iHASjB\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_default_export.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_default_export.snap
@@ -21,11 +21,11 @@ export default component$(() => {
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export default /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./slug_component_0am8hpnkns4.js"), "slug_component_0AM8HPnkNs4"));
+export default /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./[[...slug]].tsx_slug_component_0am8hpnkns4.js"), "slug_component_0AM8HPnkNs4"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/src/routes/_repl/[id]/[[...slug]].tsx\"],\"names\":[],\"mappings\":\";;AAIA,6BAAe,6GAKZ\"}")
-============================= src/routes/_repl/[id]/slug_component_div_onclick_xevvy0qc7pa.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/src/routes/_repl/[id]/[[...slug]].tsx\"],\"names\":[],\"mappings\":\";;AAIA,6BAAe,6HAKZ\"}")
+============================= src/routes/_repl/[id]/[[...slug]].tsx_slug_component_div_onclick_xevvy0qc7pa.js (ENTRY POINT)==
 
 import { sibling } from "./sibling";
 export const slug_component_div_onClick_xevvy0Qc7pA = ()=>console.log(mongodb, sibling);
@@ -37,9 +37,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/src/routes/_repl/[id]/[[...sl
   "origin": "src/routes/_repl/[id]/[[...slug]].tsx",
   "name": "slug_component_div_onClick_xevvy0Qc7pA",
   "entry": null,
-  "displayName": "slug_component_div_onClick",
+  "displayName": "[[...slug]].tsx_slug_component_div_onClick",
   "hash": "xevvy0Qc7pA",
-  "canonicalFilename": "slug_component_div_onclick_xevvy0qc7pa",
+  "canonicalFilename": "[[...slug]].tsx_slug_component_div_onclick_xevvy0qc7pa",
   "path": "src/routes/_repl/[id]",
   "extension": "js",
   "parent": "slug_component_0AM8HPnkNs4",
@@ -52,13 +52,13 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/src/routes/_repl/[id]/[[...sl
   ]
 }
 */
-============================= src/routes/_repl/[id]/slug_component_0am8hpnkns4.js ==
+============================= src/routes/_repl/[id]/[[...slug]].tsx_slug_component_0am8hpnkns4.js ==
 
 import { _jsxQ } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
 export const slug_component_0AM8HPnkNs4 = ()=>{
     return /*#__PURE__*/ _jsxQ("div", null, {
-        onClick$: /*#__PURE__*/ qrl(()=>import("./slug_component_div_onclick_xevvy0qc7pa.js"), "slug_component_div_onClick_xevvy0Qc7pA")
+        onClick$: /*#__PURE__*/ qrl(()=>import("./[[...slug]].tsx_slug_component_div_onclick_xevvy0qc7pa.js"), "slug_component_div_onClick_xevvy0Qc7pA")
     }, null, 3, "W4_0");
 };
 
@@ -69,9 +69,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/src/routes/_repl/[id]/[[...sl
   "origin": "src/routes/_repl/[id]/[[...slug]].tsx",
   "name": "slug_component_0AM8HPnkNs4",
   "entry": "src/routes/_repl/[id]/[[...slug]].tsx_entry_[[...slug]]",
-  "displayName": "slug_component",
+  "displayName": "[[...slug]].tsx_slug_component",
   "hash": "0AM8HPnkNs4",
-  "canonicalFilename": "slug_component_0am8hpnkns4",
+  "canonicalFilename": "[[...slug]].tsx_slug_component_0am8hpnkns4",
   "path": "src/routes/_repl/[id]",
   "extension": "js",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_default_export_invalid_ident.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_default_export_invalid_ident.snap
@@ -20,28 +20,28 @@ export default component$(() => {
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export default /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./_404_component_zrvowc98eqo"), "_404_component_zRvoWc98eqo"));
+export default /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./404.tsx__404_component_zrvowc98eqo"), "_404_component_zRvoWc98eqo"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/src/components/mongo/404.tsx\"],\"names\":[],\"mappings\":\";;AAGA,6BAAe,0GAKZ\"}")
-============================= src/components/mongo/_404_component_zrvowc98eqo.tsx (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/src/components/mongo/404.tsx\"],\"names\":[],\"mappings\":\";;AAGA,6BAAe,kHAKZ\"}")
+============================= src/components/mongo/404.tsx__404_component_zrvowc98eqo.tsx (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 export const _404_component_zRvoWc98eqo = ()=>{
-    return <div onClick$={/*#__PURE__*/ qrl(()=>import("./_404_component_div_onclick_oimo9dvew9q"), "_404_component_div_onClick_OiMo9dvEW9Q")}>
+    return <div onClick$={/*#__PURE__*/ qrl(()=>import("./404.tsx__404_component_div_onclick_oimo9dvew9q"), "_404_component_div_onClick_OiMo9dvEW9Q")}>
         </div>;
 };
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/src/components/mongo/404.tsx\"],\"names\":[],\"mappings\":\";0CAG0B;IACtB,QACK,IAAI,+HAAsC;QAC3C,EAAE;AAEV\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/src/components/mongo/404.tsx\"],\"names\":[],\"mappings\":\";0CAG0B;IACtB,QACK,IAAI,uIAAsC;QAC3C,EAAE;AAEV\"}")
 /*
 {
   "origin": "src/components/mongo/404.tsx",
   "name": "_404_component_zRvoWc98eqo",
   "entry": null,
-  "displayName": "_404_component",
+  "displayName": "404.tsx__404_component",
   "hash": "zRvoWc98eqo",
-  "canonicalFilename": "_404_component_zrvowc98eqo",
+  "canonicalFilename": "404.tsx__404_component_zrvowc98eqo",
   "path": "src/components/mongo",
   "extension": "tsx",
   "parent": null,
@@ -54,7 +54,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/src/components/mongo/404.tsx\
   ]
 }
 */
-============================= src/components/mongo/_404_component_div_onclick_oimo9dvew9q.tsx (ENTRY POINT)==
+============================= src/components/mongo/404.tsx__404_component_div_onclick_oimo9dvew9q.tsx (ENTRY POINT)==
 
 export const _404_component_div_onClick_OiMo9dvEW9Q = ()=>console.log(mongodb);
 
@@ -65,9 +65,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/src/components/mongo/404.tsx\
   "origin": "src/components/mongo/404.tsx",
   "name": "_404_component_div_onClick_OiMo9dvEW9Q",
   "entry": null,
-  "displayName": "_404_component_div_onClick",
+  "displayName": "404.tsx__404_component_div_onClick",
   "hash": "OiMo9dvEW9Q",
-  "canonicalFilename": "_404_component_div_onclick_oimo9dvew9q",
+  "canonicalFilename": "404.tsx__404_component_div_onclick_oimo9dvew9q",
   "path": "src/components/mongo",
   "extension": "tsx",
   "parent": "_404_component_zRvoWc98eqo",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_dev_mode.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_dev_mode.snap
@@ -20,16 +20,16 @@ export const App = component$(() => {
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrlDEV } from "@builder.io/qwik";
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrlDEV(()=>import("./app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0", {
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrlDEV(()=>import("./test.tsx_app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0", {
     file: "/user/qwik/src/test.tsx",
     lo: 90,
     hi: 229,
-    displayName: "App_component"
+    displayName: "test.tsx_App_component"
 }));
 
 
 Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM;;;;;IAMhB\"}")
-============================= app_component_ckepmxzlub0.js (ENTRY POINT)==
+============================= test.tsx_app_component_ckepmxzlub0.js (ENTRY POINT)==
 
 import { _jsxC } from "@builder.io/qwik";
 import { _jsxQ } from "@builder.io/qwik";
@@ -38,11 +38,11 @@ export const App_component_ckEPmXZlub0 = ()=>{
     return /*#__PURE__*/ _jsxC(Cmp, {
         children: /*#__PURE__*/ _jsxQ("p", null, {
             class: "stuff",
-            onClick$: /*#__PURE__*/ qrlDEV(()=>import("./app_component_cmp_p_onclick_vuxzfutkpto"), "App_component_Cmp_p_onClick_vuXzfUTkpto", {
+            onClick$: /*#__PURE__*/ qrlDEV(()=>import("./test.tsx_app_component_cmp_p_onclick_vuxzfutkpto"), "App_component_Cmp_p_onClick_vuXzfUTkpto", {
                 file: "/user/qwik/src/test.tsx",
                 lo: 164,
                 hi: 189,
-                displayName: "App_component_Cmp_p_onClick"
+                displayName: "test.tsx_App_component_Cmp_p_onClick"
             })
         }, "Hello Qwik", 3, null, {
             fileName: "test.tsx",
@@ -63,9 +63,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -78,7 +78,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_cmp_p_onclick_vuxzfutkpto.js (ENTRY POINT)==
+============================= test.tsx_app_component_cmp_p_onclick_vuxzfutkpto.js (ENTRY POINT)==
 
 export const App_component_Cmp_p_onClick_vuXzfUTkpto = ()=>console.log('warn');
 
@@ -89,9 +89,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_Cmp_p_onClick_vuXzfUTkpto",
   "entry": null,
-  "displayName": "App_component_Cmp_p_onClick",
+  "displayName": "test.tsx_App_component_Cmp_p_onClick",
   "hash": "vuXzfUTkpto",
-  "canonicalFilename": "app_component_cmp_p_onclick_vuxzfutkpto",
+  "canonicalFilename": "test.tsx_app_component_cmp_p_onclick_vuxzfutkpto",
   "path": "",
   "extension": "js",
   "parent": "App_component_ckEPmXZlub0",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_dev_mode_inlined.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_dev_mode_inlined.snap
@@ -30,7 +30,7 @@ export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ inlinedQrlDEV(()=>{
                 file: "/user/qwik/src/test.tsx",
                 lo: 164,
                 hi: 189,
-                displayName: "App_component_Cmp_p_onClick"
+                displayName: "test.tsx_App_component_Cmp_p_onClick"
             })
         }, "Hello Qwik", 3, null, {
             fileName: "test.tsx",
@@ -46,7 +46,7 @@ export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ inlinedQrlDEV(()=>{
     file: "/user/qwik/src/test.tsx",
     lo: 90,
     hi: 229,
-    displayName: "App_component"
+    displayName: "test.tsx_App_component"
 }));
 
 

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_drop_side_effects.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_drop_side_effects.snap
@@ -53,18 +53,18 @@ export const api = serverQrl(/*#__PURE__*/ _noopQrlDEV("api_server_JonPp043gH0",
     file: "/user/qwik/src/test.tsx",
     lo: 0,
     hi: 0,
-    displayName: "api_server"
+    displayName: "test.tsx_api_server"
 }));
-export default /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrlDEV(()=>import("./test_component_luxexe0dqrg"), "test_component_LUXeXe0DQrg", {
+export default /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrlDEV(()=>import("./test.tsx_test_component_luxexe0dqrg"), "test_component_LUXeXe0DQrg", {
     file: "/user/qwik/src/test.tsx",
     lo: 522,
     hi: 605,
-    displayName: "test_component"
+    displayName: "test.tsx_test_component"
 }));
 
 
 Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;AAMA,SAAS,UAAU,QAAQ,WAAW;AAKtC,CAAC;IACG,QAAQ,GAAG,CAAC;AACd,CAAC;AACD,CAAC;IACC,QAAQ,GAAG,CAAC;AACd,CAAC;AAEH;AAEA,OAAO,MAAM,MAAM;;;;;IAEhB;AAEH,6BAAe;;;;;IAIV\"}")
-============================= test_component_button_onclick_dgk9xlyroka.js (ENTRY POINT)==
+============================= test.tsx_test_component_button_onclick_dgk9xlyroka.js (ENTRY POINT)==
 
 import { api } from "./test";
 export const test_component_button_onClick_DGk9xLyRokA = ()=>await api();
@@ -76,9 +76,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "test_component_button_onClick_DGk9xLyRokA",
   "entry": null,
-  "displayName": "test_component_button_onClick",
+  "displayName": "test.tsx_test_component_button_onClick",
   "hash": "DGk9xLyRokA",
-  "canonicalFilename": "test_component_button_onclick_dgk9xlyroka",
+  "canonicalFilename": "test.tsx_test_component_button_onclick_dgk9xlyroka",
   "path": "",
   "extension": "js",
   "parent": "test_component_LUXeXe0DQrg",
@@ -91,17 +91,17 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= test_component_luxexe0dqrg.js (ENTRY POINT)==
+============================= test.tsx_test_component_luxexe0dqrg.js (ENTRY POINT)==
 
 import { _jsxQ } from "@builder.io/qwik";
 import { qrlDEV } from "@builder.io/qwik";
 export const test_component_LUXeXe0DQrg = ()=>{
     return /*#__PURE__*/ _jsxQ("button", null, {
-        onClick$: /*#__PURE__*/ qrlDEV(()=>import("./test_component_button_onclick_dgk9xlyroka"), "test_component_button_onClick_DGk9xLyRokA", {
+        onClick$: /*#__PURE__*/ qrlDEV(()=>import("./test.tsx_test_component_button_onclick_dgk9xlyroka"), "test_component_button_onClick_DGk9xLyRokA", {
             file: "/user/qwik/src/test.tsx",
             lo: 567,
             hi: 584,
-            displayName: "test_component_button_onClick"
+            displayName: "test.tsx_test_component_button_onClick"
         })
     }, null, 3, "u6_0", {
         fileName: "test.tsx",
@@ -117,9 +117,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "test_component_LUXeXe0DQrg",
   "entry": null,
-  "displayName": "test_component",
+  "displayName": "test.tsx_test_component",
   "hash": "LUXeXe0DQrg",
-  "canonicalFilename": "test_component_luxexe0dqrg",
+  "canonicalFilename": "test.tsx_test_component_luxexe0dqrg",
   "path": "",
   "extension": "js",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_explicit_ext_no_transpile.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_explicit_ext_no_transpile.snap
@@ -19,11 +19,11 @@ export const App = component$((props) => {
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_ckepmxzlub0.tsx"), "App_component_ckEPmXZlub0"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0.tsx"), "App_component_ckEPmXZlub0"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,4GAKhB\"}")
-============================= app_component_usestyles_t35nsa5uv7u.tsx ==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,qHAKhB\"}")
+============================= test.tsx_app_component_usestyles_t35nsa5uv7u.tsx ==
 
 export const App_component_useStyles_t35nSa5UV7U = 'hola';
 
@@ -34,9 +34,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_useStyles_t35nSa5UV7U",
   "entry": "entry_segments",
-  "displayName": "App_component_useStyles",
+  "displayName": "test.tsx_App_component_useStyles",
   "hash": "t35nSa5UV7U",
-  "canonicalFilename": "app_component_usestyles_t35nsa5uv7u",
+  "canonicalFilename": "test.tsx_app_component_usestyles_t35nsa5uv7u",
   "path": "",
   "extension": "tsx",
   "parent": "App_component_ckEPmXZlub0",
@@ -49,13 +49,13 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_ckepmxzlub0.tsx ==
+============================= test.tsx_app_component_ckepmxzlub0.tsx ==
 
 import { qrl } from "@builder.io/qwik";
 import { useStylesQrl } from "@builder.io/qwik";
 export const App_component_ckEPmXZlub0 = (props)=>{
-    useStylesQrl(/*#__PURE__*/ qrl(()=>import("./app_component_usestyles_t35nsa5uv7u.tsx"), "App_component_useStyles_t35nSa5UV7U"));
-    return /*#__PURE__*/ qrl(()=>import("./app_component_1_w0t0o3qmovu.tsx"), "App_component_1_w0t0o3QMovU");
+    useStylesQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_usestyles_t35nsa5uv7u.tsx"), "App_component_useStyles_t35nSa5UV7U"));
+    return /*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_1_w0t0o3qmovu.tsx"), "App_component_1_w0t0o3QMovU");
 };
 
 
@@ -65,9 +65,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": "entry_segments",
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "tsx",
   "parent": null,
@@ -80,7 +80,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_1_w0t0o3qmovu.tsx ==
+============================= test.tsx_app_component_1_w0t0o3qmovu.tsx ==
 
 export const App_component_1_w0t0o3QMovU = ()=><div></div>;
 export { _hW } from "@builder.io/qwik";
@@ -92,9 +92,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_1_w0t0o3QMovU",
   "entry": "entry_segments",
-  "displayName": "App_component_1",
+  "displayName": "test.tsx_App_component_1",
   "hash": "w0t0o3QMovU",
-  "canonicalFilename": "app_component_1_w0t0o3qmovu",
+  "canonicalFilename": "test.tsx_app_component_1_w0t0o3qmovu",
   "path": "",
   "extension": "tsx",
   "parent": "App_component_ckEPmXZlub0",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_explicit_ext_transpile.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_explicit_ext_transpile.snap
@@ -19,11 +19,11 @@ export const App = component$((props) => {
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_ckepmxzlub0.js"), "App_component_ckEPmXZlub0"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0.js"), "App_component_ckEPmXZlub0"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,2GAKhB\"}")
-============================= app_component_usestyles_t35nsa5uv7u.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,oHAKhB\"}")
+============================= test.tsx_app_component_usestyles_t35nsa5uv7u.js (ENTRY POINT)==
 
 export const App_component_useStyles_t35nSa5UV7U = 'hola';
 
@@ -34,9 +34,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_useStyles_t35nSa5UV7U",
   "entry": null,
-  "displayName": "App_component_useStyles",
+  "displayName": "test.tsx_App_component_useStyles",
   "hash": "t35nSa5UV7U",
-  "canonicalFilename": "app_component_usestyles_t35nsa5uv7u",
+  "canonicalFilename": "test.tsx_app_component_usestyles_t35nsa5uv7u",
   "path": "",
   "extension": "js",
   "parent": "App_component_ckEPmXZlub0",
@@ -49,13 +49,13 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_ckepmxzlub0.js (ENTRY POINT)==
+============================= test.tsx_app_component_ckepmxzlub0.js (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 import { useStylesQrl } from "@builder.io/qwik";
 export const App_component_ckEPmXZlub0 = (props)=>{
-    useStylesQrl(/*#__PURE__*/ qrl(()=>import("./app_component_usestyles_t35nsa5uv7u.js"), "App_component_useStyles_t35nSa5UV7U"));
-    return /*#__PURE__*/ qrl(()=>import("./app_component_1_w0t0o3qmovu.js"), "App_component_1_w0t0o3QMovU");
+    useStylesQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_usestyles_t35nsa5uv7u.js"), "App_component_useStyles_t35nSa5UV7U"));
+    return /*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_1_w0t0o3qmovu.js"), "App_component_1_w0t0o3QMovU");
 };
 
 
@@ -65,9 +65,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -80,7 +80,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_1_w0t0o3qmovu.js (ENTRY POINT)==
+============================= test.tsx_app_component_1_w0t0o3qmovu.js (ENTRY POINT)==
 
 import { _jsxQ } from "@builder.io/qwik";
 export const App_component_1_w0t0o3QMovU = ()=>/*#__PURE__*/ _jsxQ("div", null, null, null, 3, "u6_0");
@@ -93,9 +93,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_1_w0t0o3QMovU",
   "entry": null,
-  "displayName": "App_component_1",
+  "displayName": "test.tsx_App_component_1",
   "hash": "w0t0o3QMovU",
-  "canonicalFilename": "app_component_1_w0t0o3qmovu",
+  "canonicalFilename": "test.tsx_app_component_1_w0t0o3qmovu",
   "path": "",
   "extension": "js",
   "parent": "App_component_ckEPmXZlub0",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_export_issue.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_export_issue.snap
@@ -30,16 +30,16 @@ export default App;
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
-export const Root = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./root_component_royhjyacbye"), "Root_component_royhjYaCbYE"));
+const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
+export const Root = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_root_component_royhjyacbye"), "Root_component_royhjYaCbYE"));
 const Other = 12;
 export { Other as App };
 export default App;
 export { App as _auto_App };
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,MAAM,oBAAM;AAOZ,OAAO,MAAM,qBAAO,0GAIjB;AAEH,MAAM,QAAQ;AACd,SAAS,SAAS,GAAG,GAAG;AAExB,eAAe,IAAI\"}")
-============================= root_component_royhjyacbye.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,MAAM,oBAAM;AAOZ,OAAO,MAAM,qBAAO,mHAIjB;AAEH,MAAM,QAAQ;AACd,SAAS,SAAS,GAAG,GAAG;AAExB,eAAe,IAAI\"}")
+============================= test.tsx_root_component_royhjyacbye.js (ENTRY POINT)==
 
 import { _auto_App as App } from "./test";
 import { _jsxC } from "@builder.io/qwik";
@@ -54,9 +54,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Root_component_royhjYaCbYE",
   "entry": null,
-  "displayName": "Root_component",
+  "displayName": "test.tsx_Root_component",
   "hash": "royhjYaCbYE",
-  "canonicalFilename": "root_component_royhjyacbye",
+  "canonicalFilename": "test.tsx_root_component_royhjyacbye",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -69,7 +69,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_ckepmxzlub0.js (ENTRY POINT)==
+============================= test.tsx_app_component_ckepmxzlub0.js (ENTRY POINT)==
 
 import { _jsxQ } from "@builder.io/qwik";
 export const App_component_ckEPmXZlub0 = ()=>{
@@ -83,9 +83,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "js",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_exports.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_exports.snap
@@ -30,11 +30,11 @@ export const Header = component$(() => {
 
 export const Footer = component$();
 
-============================= project/header_component_uvbjufyfvdo.jsx (ENTRY POINT)==
+============================= project/test.tsx_header_component_uvbjufyfvdo.jsx (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 export const Header_component_UVBJuFYfvDo = ()=>{
-    return /*#__PURE__*/ qrl(()=>import("./header_component_1_uwm1kg0igo0"), "Header_component_1_uWM1kg0IGO0");
+    return /*#__PURE__*/ qrl(()=>import("./test.tsx_header_component_1_uwm1kg0igo0"), "Header_component_1_uWM1kg0IGO0");
 };
 
 
@@ -44,9 +44,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\"
   "origin": "project/test.tsx",
   "name": "Header_component_UVBJuFYfvDo",
   "entry": null,
-  "displayName": "Header_component",
+  "displayName": "test.tsx_Header_component",
   "hash": "UVBJuFYfvDo",
-  "canonicalFilename": "header_component_uvbjufyfvdo",
+  "canonicalFilename": "test.tsx_header_component_uvbjufyfvdo",
   "path": "project",
   "extension": "jsx",
   "parent": null,
@@ -71,12 +71,12 @@ export function foo() {}
 export class bar {
 }
 export default function DefaultFn() {}
-export const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./header_component_uvbjufyfvdo"), "Header_component_UVBJuFYfvDo"));
+export const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_header_component_uvbjufyfvdo"), "Header_component_UVBJuFYfvDo"));
 export const Footer = /*#__PURE__*/ componentQrl();
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,CAAC,GAAG,EAAC,CAAC,EAAE,IAAI,CAAC,EAAE,EAAE,IAAE,EAAE,EAAE,GAAG,GAAE,EAAE,IAAE,EAAE,EAAE,GAAG,EAAE,GAAG,IAAI;AAE7D,MAAM,OAAO;AACb,MAAM,WAAW;AACjB,SAAQ,IAAI,EAAE,YAAY,KAAK,GAAE;AAEjC,OAAO,SAAS,OAAQ;AACxB,OAAO,MAAM;AAAK;AAElB,eAAe,SAAS,aAAa;AAErC,OAAO,MAAM,uBAAS,8GAOnB;AAEH,OAAO,MAAM,uBAAS,eAAa\"}")
-============================= project/header_component_1_uwm1kg0igo0.jsx (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,CAAC,GAAG,EAAC,CAAC,EAAE,IAAI,CAAC,EAAE,EAAE,IAAE,EAAE,EAAE,GAAG,GAAE,EAAE,IAAE,EAAE,EAAE,GAAG,EAAE,GAAG,IAAI;AAE7D,MAAM,OAAO;AACb,MAAM,WAAW;AACjB,SAAQ,IAAI,EAAE,YAAY,KAAK,GAAE;AAEjC,OAAO,SAAS,OAAQ;AACxB,OAAO,MAAM;AAAK;AAElB,eAAe,SAAS,aAAa;AAErC,OAAO,MAAM,uBAAS,uHAOnB;AAEH,OAAO,MAAM,uBAAS,eAAa\"}")
+============================= project/test.tsx_header_component_1_uwm1kg0igo0.jsx (ENTRY POINT)==
 
 import { default as DefaultFn } from "./test";
 import { Footer } from "./test";
@@ -103,9 +103,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\"
   "origin": "project/test.tsx",
   "name": "Header_component_1_uWM1kg0IGO0",
   "entry": null,
-  "displayName": "Header_component_1",
+  "displayName": "test.tsx_Header_component_1",
   "hash": "uWM1kg0IGO0",
-  "canonicalFilename": "header_component_1_uwm1kg0igo0",
+  "canonicalFilename": "test.tsx_header_component_1_uwm1kg0igo0",
   "path": "project",
   "extension": "jsx",
   "parent": "Header_component_UVBJuFYfvDo",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_fix_dynamic_import.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_fix_dynamic_import.snap
@@ -22,7 +22,7 @@ export const Header = component$(() => {
     );
 });
 
-============================= project/folder/header_component_rggm7ks9qwi.tsx ==
+============================= project/folder/test.tsx_header_component_rggm7ks9qwi.tsx ==
 
 import thing from "../state";
 export const Header_component_RGgm7Ks9QWI = ()=>{
@@ -39,9 +39,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/folder/test.tsx\"],\"
   "origin": "project/folder/test.tsx",
   "name": "Header_component_RGgm7Ks9QWI",
   "entry": "entry_segments",
-  "displayName": "Header_component",
+  "displayName": "test.tsx_Header_component",
   "hash": "RGgm7Ks9QWI",
-  "canonicalFilename": "header_component_rggm7ks9qwi",
+  "canonicalFilename": "test.tsx_header_component_rggm7ks9qwi",
   "path": "project/folder",
   "extension": "tsx",
   "parent": null,
@@ -61,10 +61,10 @@ import { qrl } from "@builder.io/qwik";
 export function foo() {
     return import("../foo/state2");
 }
-export const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./header_component_rggm7ks9qwi"), "Header_component_RGgm7Ks9QWI"));
+export const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_header_component_rggm7ks9qwi"), "Header_component_RGgm7Ks9QWI"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/folder/test.tsx\"],\"names\":[],\"mappings\":\";;AAIA,OAAO,SAAS;IACZ,OAAO,MAAM,CAAC;AAClB;AAEA,OAAO,MAAM,uBAAS,8GAOnB\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/folder/test.tsx\"],\"names\":[],\"mappings\":\";;AAIA,OAAO,SAAS;IACZ,OAAO,MAAM,CAAC;AAClB;AAEA,OAAO,MAAM,uBAAS,uHAOnB\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_functional_component.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_functional_component.snap
@@ -16,7 +16,7 @@ const Header = component$(() => {
     );
 });
 
-============================= header_component_j4uyihabnr4.tsx (ENTRY POINT)==
+============================= test.tsx_header_component_j4uyihabnr4.tsx (ENTRY POINT)==
 
 import { useStore } from "@builder.io/qwik";
 export const Header_component_J4uyIhaBNR4 = ()=>{
@@ -32,9 +32,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Header_component_J4uyIhaBNR4",
   "entry": null,
-  "displayName": "Header_component",
+  "displayName": "test.tsx_Header_component",
   "hash": "J4uyIhaBNR4",
-  "canonicalFilename": "header_component_j4uyihabnr4",
+  "canonicalFilename": "test.tsx_header_component_j4uyihabnr4",
   "path": "",
   "extension": "tsx",
   "parent": null,
@@ -52,7 +52,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
 import { $, component$, useStore } from '@builder.io/qwik';
-const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./header_component_j4uyihabnr4"), "Header_component_J4uyIhaBNR4"));
+const Header = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_header_component_j4uyihabnr4"), "Header_component_J4uyIhaBNR4"));
 
 
 Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AACA,SAAS,CAAC,EAAE,UAAU,EAAE,QAAQ,QAAQ,mBAAmB;AAC3D,MAAM,uBAAS\"}")

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_functional_component_2.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_functional_component_2.snap
@@ -46,11 +46,11 @@ export const useCounter = ()=>{
     });
 };
 export const STEP = 1;
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AACA,SAAwB,QAAQ,QAAQ,mBAAmB;AAC3D,OAAO,MAAM,aAAa;IACtB,OAAO,SAAS;QAAC,OAAO;IAAC;AAC7B,EAAC;AAED,OAAO,MAAM,OAAO,EAAE;AAEtB,OAAO,MAAM,oBAAM,wGAoBjB\"}")
-============================= app_component_div_onclick_1cgetmfzx0g.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AACA,SAAwB,QAAQ,QAAQ,mBAAmB;AAC3D,OAAO,MAAM,aAAa;IACtB,OAAO,SAAS;QAAC,OAAO;IAAC;AAC7B,EAAC;AAED,OAAO,MAAM,OAAO,EAAE;AAEtB,OAAO,MAAM,oBAAM,iHAoBjB\"}")
+============================= test.tsx_app_component_div_onclick_1cgetmfzx0g.js (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
 export const App_component_div_onClick_1CGetmFZx0g = ()=>{
@@ -65,9 +65,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_div_onClick_1CGetmFZx0g",
   "entry": null,
-  "displayName": "App_component_div_onClick",
+  "displayName": "test.tsx_App_component_div_onClick",
   "hash": "1CGetmFZx0g",
-  "canonicalFilename": "app_component_div_onclick_1cgetmfzx0g",
+  "canonicalFilename": "test.tsx_app_component_div_onclick_1cgetmfzx0g",
   "path": "",
   "extension": "js",
   "parent": "App_component_ckEPmXZlub0",
@@ -80,7 +80,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_div_button_onclick_f5nww9e63a4.js (ENTRY POINT)==
+============================= test.tsx_app_component_div_button_onclick_f5nww9e63a4.js (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
 import { STEP } from "./test";
@@ -96,9 +96,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_div_button_onClick_f5NwW9e63a4",
   "entry": null,
-  "displayName": "App_component_div_button_onClick",
+  "displayName": "test.tsx_App_component_div_button_onClick",
   "hash": "f5NwW9e63a4",
-  "canonicalFilename": "app_component_div_button_onclick_f5nww9e63a4",
+  "canonicalFilename": "test.tsx_app_component_div_button_onclick_f5nww9e63a4",
   "path": "",
   "extension": "js",
   "parent": "App_component_ckEPmXZlub0",
@@ -111,7 +111,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_ckepmxzlub0.js (ENTRY POINT)==
+============================= test.tsx_app_component_ckepmxzlub0.js (ENTRY POINT)==
 
 import { _fnSignal } from "@builder.io/qwik";
 import { _jsxQ } from "@builder.io/qwik";
@@ -126,7 +126,7 @@ export const App_component_ckEPmXZlub0 = (props)=>{
     });
     const count2 = state.count * 2;
     return /*#__PURE__*/ _jsxQ("div", {
-        onClick$: /*#__PURE__*/ qrl(()=>import("./app_component_div_onclick_1cgetmfzx0g"), "App_component_div_onClick_1CGetmFZx0g", [
+        onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_div_onclick_1cgetmfzx0g"), "App_component_div_onClick_1CGetmFZx0g", [
             count2,
             state
         ])
@@ -135,7 +135,7 @@ export const App_component_ckEPmXZlub0 = (props)=>{
             state
         ], "p0.count"), 3, null),
         buttons.map((btn)=>/*#__PURE__*/ _jsxQ("button", {
-                onClick$: /*#__PURE__*/ qrl(()=>import("./app_component_div_button_onclick_f5nww9e63a4"), "App_component_div_button_onClick_f5NwW9e63a4", [
+                onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_div_button_onclick_f5nww9e63a4"), "App_component_div_button_onClick_f5NwW9e63a4", [
                     btn,
                     props,
                     state,
@@ -152,9 +152,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "js",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_functional_component_capture_props.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_functional_component_capture_props.snap
@@ -26,11 +26,11 @@ export const App = component$(({count, rest: [I2, {I3, v1: [I4], I5=v2, ...I6}, 
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,wGAYjB\"}")
-============================= app_component_div_onclick_1cgetmfzx0g.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,iHAYjB\"}")
+============================= test.tsx_app_component_div_onclick_1cgetmfzx0g.js (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
 export const App_component_div_onClick_1CGetmFZx0g = ()=>{
@@ -45,9 +45,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_div_onClick_1CGetmFZx0g",
   "entry": null,
-  "displayName": "App_component_div_onClick",
+  "displayName": "test.tsx_App_component_div_onClick",
   "hash": "1CGetmFZx0g",
-  "canonicalFilename": "app_component_div_onclick_1cgetmfzx0g",
+  "canonicalFilename": "test.tsx_app_component_div_onclick_1cgetmfzx0g",
   "path": "",
   "extension": "js",
   "parent": "App_component_1_w0t0o3QMovU",
@@ -60,7 +60,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_ckepmxzlub0.js (ENTRY POINT)==
+============================= test.tsx_app_component_ckepmxzlub0.js (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 import { useStore } from "@builder.io/qwik";
@@ -69,7 +69,7 @@ export const App_component_ckEPmXZlub0 = ({ count, rest: [I2, { I3, v1: [I4], I5
         count: 0
     });
     const { rest: [C2, { C3, v1: [C4], C5 = v2, ...C6 }, C7 = v3, ...C8] } = foo();
-    return /*#__PURE__*/ qrl(()=>import("./app_component_1_w0t0o3qmovu"), "App_component_1_w0t0o3QMovU", [
+    return /*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_1_w0t0o3qmovu"), "App_component_1_w0t0o3QMovU", [
         C2,
         C3,
         C4,
@@ -96,9 +96,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -111,7 +111,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_1_w0t0o3qmovu.js (ENTRY POINT)==
+============================= test.tsx_app_component_1_w0t0o3qmovu.js (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
 import { _jsxQ } from "@builder.io/qwik";
@@ -119,7 +119,7 @@ import { qrl } from "@builder.io/qwik";
 export const App_component_1_w0t0o3QMovU = ()=>{
     const [C2, C3, C4, C5, C6, C7, C8, I2, I3, I4, I5, I6, I7, I8, count, state] = useLexicalScope();
     return /*#__PURE__*/ _jsxQ("div", {
-        onClick$: /*#__PURE__*/ qrl(()=>import("./app_component_div_onclick_1cgetmfzx0g"), "App_component_div_onClick_1CGetmFZx0g", [
+        onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_div_onclick_1cgetmfzx0g"), "App_component_div_onClick_1CGetmFZx0g", [
             count,
             state
         ])
@@ -152,9 +152,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_1_w0t0o3QMovU",
   "entry": null,
-  "displayName": "App_component_1",
+  "displayName": "test.tsx_App_component_1",
   "hash": "w0t0o3QMovU",
-  "canonicalFilename": "app_component_1_w0t0o3qmovu",
+  "canonicalFilename": "test.tsx_app_component_1_w0t0o3qmovu",
   "path": "",
   "extension": "js",
   "parent": "App_component_ckEPmXZlub0",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_getter_generation.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_getter_generation.snap
@@ -43,12 +43,12 @@ export const Cmp = component$((props) => {
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
-export const Cmp = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./cmp_component_4rykjtokjwe"), "Cmp_component_4ryKJTOKjWE"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
+export const Cmp = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_cmp_component_4rykjtokjwe"), "Cmp_component_4ryKJTOKjWE"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,wGAoBhB;AAEH,OAAO,MAAM,oBAAM,wGAOhB\"}")
-============================= cmp_component_4rykjtokjwe.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,iHAoBhB;AAEH,OAAO,MAAM,oBAAM,iHAOhB\"}")
+============================= test.tsx_cmp_component_4rykjtokjwe.js (ENTRY POINT)==
 
 import { Fragment as _Fragment } from "@builder.io/qwik/jsx-runtime";
 import { _fnSignal } from "@builder.io/qwik";
@@ -82,9 +82,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Cmp_component_4ryKJTOKjWE",
   "entry": null,
-  "displayName": "Cmp_component",
+  "displayName": "test.tsx_Cmp_component",
   "hash": "4ryKJTOKjWE",
-  "canonicalFilename": "cmp_component_4rykjtokjwe",
+  "canonicalFilename": "test.tsx_cmp_component_4rykjtokjwe",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -97,7 +97,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_ckepmxzlub0.js (ENTRY POINT)==
+============================= test.tsx_app_component_ckepmxzlub0.js (ENTRY POINT)==
 
 import { Cmp } from "./test";
 import { _IMMUTABLE } from "@builder.io/qwik";
@@ -154,9 +154,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "js",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_immutable_analysis.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_immutable_analysis.snap
@@ -56,7 +56,7 @@ export const App = component$((props) => {
     );
 });
 
-============================= app_component_fragment_div_onevent_zrfduybt3xm.js (ENTRY POINT)==
+============================= test.tsx_app_component_fragment_div_onevent_zrfduybt3xm.js (ENTRY POINT)==
 
 export const App_component_Fragment_Div_onEvent_zrFduYbT3xM = ()=>console.log('stuff');
 
@@ -67,9 +67,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_Fragment_Div_onEvent_zrFduYbT3xM",
   "entry": null,
-  "displayName": "App_component_Fragment_Div_onEvent",
+  "displayName": "test.tsx_App_component_Fragment_Div_onEvent",
   "hash": "zrFduYbT3xM",
-  "canonicalFilename": "app_component_fragment_div_onevent_zrfduybt3xm",
+  "canonicalFilename": "test.tsx_app_component_fragment_div_onevent_zrfduybt3xm",
   "path": "",
   "extension": "js",
   "parent": "App_component_ckEPmXZlub0",
@@ -86,11 +86,11 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAKA,OAAO,MAAM,oBAAM,wGA4ChB\"}")
-============================= app_component_fragment_div_immutable4_2zf7ja3yti0.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAKA,OAAO,MAAM,oBAAM,iHA4ChB\"}")
+============================= test.tsx_app_component_fragment_div_immutable4_2zf7ja3yti0.js (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
 export const App_component_Fragment_Div_immutable4_2zF7jA3Yti0 = (ev)=>{
@@ -105,9 +105,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_Fragment_Div_immutable4_2zF7jA3Yti0",
   "entry": null,
-  "displayName": "App_component_Fragment_Div_immutable4",
+  "displayName": "test.tsx_App_component_Fragment_Div_immutable4",
   "hash": "2zF7jA3Yti0",
-  "canonicalFilename": "app_component_fragment_div_immutable4_2zf7ja3yti0",
+  "canonicalFilename": "test.tsx_app_component_fragment_div_immutable4_2zf7ja3yti0",
   "path": "",
   "extension": "js",
   "parent": "App_component_ckEPmXZlub0",
@@ -120,7 +120,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_fragment_div_transparent_eedek6em1oo.js (ENTRY POINT)==
+============================= test.tsx_app_component_fragment_div_transparent_eedek6em1oo.js (ENTRY POINT)==
 
 export const App_component_Fragment_Div_transparent_eeDEK6EM1oo = ()=>{
     console.log('stuff');
@@ -133,9 +133,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_Fragment_Div_transparent_eeDEK6EM1oo",
   "entry": null,
-  "displayName": "App_component_Fragment_Div_transparent",
+  "displayName": "test.tsx_App_component_Fragment_Div_transparent",
   "hash": "eeDEK6EM1oo",
-  "canonicalFilename": "app_component_fragment_div_transparent_eedek6em1oo",
+  "canonicalFilename": "test.tsx_app_component_fragment_div_transparent_eedek6em1oo",
   "path": "",
   "extension": "js",
   "parent": "App_component_ckEPmXZlub0",
@@ -148,7 +148,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_ckepmxzlub0.js (ENTRY POINT)==
+============================= test.tsx_app_component_ckepmxzlub0.js (ENTRY POINT)==
 
 import { Fragment as _Fragment } from "@builder.io/qwik/jsx-runtime";
 import { _IMMUTABLE } from "@builder.io/qwik";
@@ -163,7 +163,7 @@ export const App_component_ckEPmXZlub0 = (props)=>{
     const state = useStore({
         count: 0
     });
-    const remove = /*#__PURE__*/ qrl(()=>import("./app_component_remove_pu6yoc5p6sy"), "App_component_remove_pU6yOC5P6sY", [
+    const remove = /*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_remove_pu6yoc5p6sy"), "App_component_remove_pU6yOC5P6sY", [
         state
     ]);
     return /*#__PURE__*/ _jsxC(_Fragment, {
@@ -181,15 +181,15 @@ export const App_component_ckEPmXZlub0 = (props)=>{
                     return window.document;
                 },
                 onClick$: props.onClick$,
-                onEvent$: /*#__PURE__*/ qrl(()=>import("./app_component_fragment_div_onevent_zrfduybt3xm"), "App_component_Fragment_Div_onEvent_zrFduYbT3xM"),
-                transparent$: /*#__PURE__*/ qrl(()=>import("./app_component_fragment_div_transparent_eedek6em1oo"), "App_component_Fragment_Div_transparent_eeDEK6EM1oo"),
+                onEvent$: /*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_fragment_div_onevent_zrfduybt3xm"), "App_component_Fragment_Div_onEvent_zrFduYbT3xM"),
+                transparent$: /*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_fragment_div_transparent_eedek6em1oo"), "App_component_Fragment_Div_transparent_eeDEK6EM1oo"),
                 immutable1: "stuff",
                 immutable2: {
                     foo: 'bar',
                     baz: importedValue ? true : false
                 },
                 immutable3: 2,
-                immutable4$: /*#__PURE__*/ qrl(()=>import("./app_component_fragment_div_immutable4_2zf7ja3yti0"), "App_component_Fragment_Div_immutable4_2zF7jA3Yti0", [
+                immutable4$: /*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_fragment_div_immutable4_2zf7ja3yti0"), "App_component_Fragment_Div_immutable4_2zF7jA3Yti0", [
                     state
                 ]),
                 immutable5: [
@@ -254,9 +254,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -269,7 +269,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_remove_pu6yoc5p6sy.js (ENTRY POINT)==
+============================= test.tsx_app_component_remove_pu6yoc5p6sy.js (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
 export const App_component_remove_pU6yOC5P6sY = (id)=>{
@@ -286,9 +286,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_remove_pU6yOC5P6sY",
   "entry": null,
-  "displayName": "App_component_remove",
+  "displayName": "test.tsx_App_component_remove",
   "hash": "pU6yOC5P6sY",
-  "canonicalFilename": "app_component_remove_pu6yoc5p6sy",
+  "canonicalFilename": "test.tsx_app_component_remove_pu6yoc5p6sy",
   "path": "",
   "extension": "js",
   "parent": "App_component_ckEPmXZlub0",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_import_assertion.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_import_assertion.snap
@@ -17,11 +17,11 @@ export const Greeter = component$(() => {
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Greeter = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./greeter_component_n7hug2hhu0q"), "Greeter_component_n7HuG2hhU0Q"));
+export const Greeter = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_greeter_component_n7hug2hhu0q"), "Greeter_component_n7HuG2hhU0Q"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAIA,OAAO,MAAM,wBAAU,gHAEpB\"}")
-============================= greeter_component_n7hug2hhu0q.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAIA,OAAO,MAAM,wBAAU,yHAEpB\"}")
+============================= test.tsx_greeter_component_n7hug2hhu0q.js (ENTRY POINT)==
 
 import json from "./foo.json" with {
     type: "json"
@@ -37,9 +37,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Greeter_component_n7HuG2hhU0Q",
   "entry": null,
-  "displayName": "Greeter_component",
+  "displayName": "test.tsx_Greeter_component",
   "hash": "n7HuG2hhU0Q",
-  "canonicalFilename": "greeter_component_n7hug2hhu0q",
+  "canonicalFilename": "test.tsx_greeter_component_n7hug2hhu0q",
   "path": "",
   "extension": "js",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_invalid_references.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_invalid_references.snap
@@ -32,7 +32,7 @@ const [I2, { I3, v1: [I4], I5 = v2, ...I6 }, I7 = v3, ...I8] = obj;
 function I9() {}
 class I10 {
 }
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
 export { I1 as _auto_I1 };
 export { I10 as _auto_I10 };
 export { I2 as _auto_I2 };
@@ -45,8 +45,8 @@ export { I8 as _auto_I8 };
 export { I9 as _auto_I9 };
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,MAAM,KAAK;AACX,MAAM,CAAC,IAAI,EAAC,EAAE,EAAE,IAAI,CAAC,GAAG,EAAE,KAAG,EAAE,EAAE,GAAG,IAAG,EAAE,KAAG,EAAE,EAAE,GAAG,GAAG,GAAG;AACzD,SAAS,MAAM;AACf,MAAM;AAAK;AAEX,OAAO,MAAM,oBAAM,wGAQjB\"}")
-============================= app_component_ckepmxzlub0.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,MAAM,KAAK;AACX,MAAM,CAAC,IAAI,EAAC,EAAE,EAAE,IAAI,CAAC,GAAG,EAAE,KAAG,EAAE,EAAE,GAAG,IAAG,EAAE,KAAG,EAAE,EAAE,GAAG,GAAG,GAAG;AACzD,SAAS,MAAM;AACf,MAAM;AAAK;AAEX,OAAO,MAAM,oBAAM,iHAQjB\"}")
+============================= test.tsx_app_component_ckepmxzlub0.js (ENTRY POINT)==
 
 import { _auto_I1 as I1 } from "./test";
 import { _auto_I2 as I2 } from "./test";
@@ -61,7 +61,7 @@ import { qrl } from "@builder.io/qwik";
 export const App_component_ckEPmXZlub0 = (props)=>{
     console.log(I1, I2, I3, I4, I5, I6, I7, I8, I9);
     console.log(itsok, v1, v2, v3, obj);
-    return /*#__PURE__*/ qrl(()=>import("./app_component_1_w0t0o3qmovu"), "App_component_1_w0t0o3QMovU");
+    return /*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_1_w0t0o3qmovu"), "App_component_1_w0t0o3QMovU");
 };
 
 
@@ -71,9 +71,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -86,7 +86,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_1_w0t0o3qmovu.js (ENTRY POINT)==
+============================= test.tsx_app_component_1_w0t0o3qmovu.js (ENTRY POINT)==
 
 import { _auto_I10 as I10 } from "./test";
 import { _jsxC } from "@builder.io/qwik";
@@ -102,9 +102,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_1_w0t0o3QMovU",
   "entry": null,
-  "displayName": "App_component_1",
+  "displayName": "test.tsx_App_component_1",
   "hash": "w0t0o3QMovU",
-  "canonicalFilename": "app_component_1_w0t0o3qmovu",
+  "canonicalFilename": "test.tsx_app_component_1_w0t0o3qmovu",
   "path": "",
   "extension": "js",
   "parent": "App_component_ckEPmXZlub0",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_invalid_segment_expr1.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_invalid_segment_expr1.snap
@@ -25,11 +25,11 @@ export const App = component$(() => {
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAKA,OAAO,MAAM,oBAAM,wGASjB\"}")
-============================= app_component_usestyles_t35nsa5uv7u.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAKA,OAAO,MAAM,oBAAM,iHASjB\"}")
+============================= test.tsx_app_component_usestyles_t35nsa5uv7u.js (ENTRY POINT)==
 
 export const App_component_useStyles_t35nSa5UV7U = style;
 
@@ -40,9 +40,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_useStyles_t35nSa5UV7U",
   "entry": null,
-  "displayName": "App_component_useStyles",
+  "displayName": "test.tsx_App_component_useStyles",
   "hash": "t35nSa5UV7U",
-  "canonicalFilename": "app_component_usestyles_t35nsa5uv7u",
+  "canonicalFilename": "test.tsx_app_component_usestyles_t35nsa5uv7u",
   "path": "",
   "extension": "js",
   "parent": "App_component_ckEPmXZlub0",
@@ -55,13 +55,13 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_ckepmxzlub0.js (ENTRY POINT)==
+============================= test.tsx_app_component_ckepmxzlub0.js (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 import { useStylesQrl } from "@builder.io/qwik";
 export const App_component_ckEPmXZlub0 = ()=>{
-    useStylesQrl(/*#__PURE__*/ qrl(()=>import("./app_component_usestyles_t35nsa5uv7u"), "App_component_useStyles_t35nSa5UV7U"));
-    return /*#__PURE__*/ qrl(()=>import("./app_component_1_w0t0o3qmovu"), "App_component_1_w0t0o3QMovU");
+    useStylesQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_usestyles_t35nsa5uv7u"), "App_component_useStyles_t35nSa5UV7U"));
+    return /*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_1_w0t0o3qmovu"), "App_component_1_w0t0o3QMovU");
 };
 
 
@@ -71,9 +71,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -86,7 +86,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_1_w0t0o3qmovu.js (ENTRY POINT)==
+============================= test.tsx_app_component_1_w0t0o3qmovu.js (ENTRY POINT)==
 
 export const App_component_1_w0t0o3QMovU = render;
 export { _hW } from "@builder.io/qwik";
@@ -98,9 +98,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_1_w0t0o3QMovU",
   "entry": null,
-  "displayName": "App_component_1",
+  "displayName": "test.tsx_App_component_1",
   "hash": "w0t0o3QMovU",
-  "canonicalFilename": "app_component_1_w0t0o3qmovu",
+  "canonicalFilename": "test.tsx_app_component_1_w0t0o3qmovu",
   "path": "",
   "extension": "js",
   "parent": "App_component_ckEPmXZlub0",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_jsx.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_jsx.snap
@@ -64,17 +64,17 @@ export const Lightweight = (props)=>{
         ]
     }, 1, "u6_0"), 1, "u6_1");
 };
-export const Foo = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./foo_component_htdrsvublie"), "Foo_component_HTDRsvUbLiE"), {
+export const Foo = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_htdrsvublie"), "Foo_component_HTDRsvUbLiE"), {
     tagName: "my-foo"
 });
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;;AAGA,OAAO,MAAM,cAAc,CAAC;IACxB,qBACI,MAAC,iCACG;;0BACI,MAAC;0BACD,MAAC;gBAAQ,GAAG,KAAK;;;;AAIjC,EAAE;AAEF,OAAO,MAAM,oBAAM,wGAuBhB;IACC,SAAS;AACb,GAAG\"}")
-============================= foo_component_htdrsvublie.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;;AAGA,OAAO,MAAM,cAAc,CAAC;IACxB,qBACI,MAAC,iCACG;;0BACI,MAAC;0BACD,MAAC;gBAAQ,GAAG,KAAK;;;;AAIjC,EAAE;AAEF,OAAO,MAAM,oBAAM,iHAuBhB;IACC,SAAS;AACb,GAAG\"}")
+============================= test.tsx_foo_component_htdrsvublie.js (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 export const Foo_component_HTDRsvUbLiE = (props)=>{
-    return /*#__PURE__*/ qrl(()=>import("./foo_component_1_dvu6fitwgly"), "Foo_component_1_DvU6FitWglY", [
+    return /*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_1_dvu6fitwgly"), "Foo_component_1_DvU6FitWglY", [
         props
     ]);
 };
@@ -86,9 +86,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_HTDRsvUbLiE",
   "entry": null,
-  "displayName": "Foo_component",
+  "displayName": "test.tsx_Foo_component",
   "hash": "HTDRsvUbLiE",
-  "canonicalFilename": "foo_component_htdrsvublie",
+  "canonicalFilename": "test.tsx_foo_component_htdrsvublie",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -101,7 +101,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= foo_component_1_dvu6fitwgly.js (ENTRY POINT)==
+============================= test.tsx_foo_component_1_dvu6fitwgly.js (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
 import { Lightweight } from "./test";
@@ -150,9 +150,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_1_DvU6FitWglY",
   "entry": null,
-  "displayName": "Foo_component_1",
+  "displayName": "test.tsx_Foo_component_1",
   "hash": "DvU6FitWglY",
-  "canonicalFilename": "foo_component_1_dvu6fitwgly",
+  "canonicalFilename": "test.tsx_foo_component_1_dvu6fitwgly",
   "path": "",
   "extension": "js",
   "parent": "Foo_component_HTDRsvUbLiE",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_jsx_import_source.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_jsx_import_source.snap
@@ -26,11 +26,11 @@ import { jsx as _jsx } from "react/jsx-runtime";
 export const App = ()=>/*#__PURE__*/ _jsx("div", {
         onClick$: ()=>console.log('App')
     });
-export const App2 = qwikifyQrl(/*#__PURE__*/ qrl(()=>import("./app2_qwikify_rkjw7ocmds4.js"), "App2_qwikify_RKJW7oCMdS4"));
+export const App2 = qwikifyQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app2_qwikify_rkjw7ocmds4.js"), "App2_qwikify_RKJW7oCMdS4"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"AACA,0BAA0B;;;AAI1B,OAAO,MAAM,MAAM,kBACf,KAAC;QAAI,UAAU,IAAI,QAAQ,GAAG,CAAC;OACjC;AAEF,OAAO,MAAM,OAAO,uGAEjB\"}")
-============================= app2_qwikify_rkjw7ocmds4.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"AACA,0BAA0B;;;AAI1B,OAAO,MAAM,MAAM,kBACf,KAAC;QAAI,UAAU,IAAI,QAAQ,GAAG,CAAC;OACjC;AAEF,OAAO,MAAM,OAAO,gHAEjB\"}")
+============================= test.tsx_app2_qwikify_rkjw7ocmds4.js (ENTRY POINT)==
 
 import { jsx as _jsx } from "react/jsx-runtime";
 export const App2_qwikify_RKJW7oCMdS4 = ()=>/*#__PURE__*/ _jsx("div", {
@@ -44,9 +44,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App2_qwikify_RKJW7oCMdS4",
   "entry": null,
-  "displayName": "App2_qwikify",
+  "displayName": "test.tsx_App2_qwikify",
   "hash": "RKJW7oCMdS4",
-  "canonicalFilename": "app2_qwikify_rkjw7ocmds4",
+  "canonicalFilename": "test.tsx_app2_qwikify_rkjw7ocmds4",
   "path": "",
   "extension": "js",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_jsx_keyed.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_jsx_keyed.snap
@@ -24,11 +24,11 @@ export const App = component$((props: Stuff) => {
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_ckepmxzlub0.js"), "App_component_ckEPmXZlub0"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0.js"), "App_component_ckEPmXZlub0"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,2GAUhB\"}")
-============================= app_component_ckepmxzlub0.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,oHAUhB\"}")
+============================= test.tsx_app_component_ckepmxzlub0.js (ENTRY POINT)==
 
 import { Fragment as _Fragment } from "@builder.io/qwik/jsx-runtime";
 import { _IMMUTABLE } from "@builder.io/qwik";
@@ -63,9 +63,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "js",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_jsx_keyed_dev.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_jsx_keyed_dev.snap
@@ -24,16 +24,16 @@ export const App = component$((props: Stuff) => {
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrlDEV } from "@builder.io/qwik";
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrlDEV(()=>import("./app_component_kglyfbhvjc0.js"), "App_component_KGLYFBhvJc0", {
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrlDEV(()=>import("./index.tsx_app_component_kglyfbhvjc0.js"), "App_component_KGLYFBhvJc0", {
     file: "/src/project/project/index.tsx",
     lo: 90,
     hi: 348,
-    displayName: "App_component"
+    displayName: "index.tsx_App_component"
 }));
 
 
 Some("{\"version\":3,\"sources\":[\"/src/project/project/index.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM;;;;;IAUhB\"}")
-============================= project/app_component_kglyfbhvjc0.js (ENTRY POINT)==
+============================= project/index.tsx_app_component_kglyfbhvjc0.js (ENTRY POINT)==
 
 import { Fragment as _Fragment } from "@builder.io/qwik/jsx-runtime";
 import { _IMMUTABLE } from "@builder.io/qwik";
@@ -92,9 +92,9 @@ Some("{\"version\":3,\"sources\":[\"/src/project/project/index.tsx\"],\"names\":
   "origin": "project/index.tsx",
   "name": "App_component_KGLYFBhvJc0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "index.tsx_App_component",
   "hash": "KGLYFBhvJc0",
-  "canonicalFilename": "app_component_kglyfbhvjc0",
+  "canonicalFilename": "index.tsx_app_component_kglyfbhvjc0",
   "path": "project",
   "extension": "js",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_jsx_listeners.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_jsx_listeners.snap
@@ -38,7 +38,7 @@ export const Foo = component$(() => {
     tagName: "my-foo",
 });
 
-============================= foo_component_div_host_ondocumentscroll_zip7mifsjry.js (ENTRY POINT)==
+============================= test.tsx_foo_component_div_host_ondocumentscroll_zip7mifsjry.js (ENTRY POINT)==
 
 export const Foo_component_div_host_onDocumentScroll_Zip7mifsjRY = ()=>console.log('host:onDocument:scroll');
 
@@ -49,9 +49,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_div_host_onDocumentScroll_Zip7mifsjRY",
   "entry": null,
-  "displayName": "Foo_component_div_host_onDocumentScroll",
+  "displayName": "test.tsx_Foo_component_div_host_onDocumentScroll",
   "hash": "Zip7mifsjRY",
-  "canonicalFilename": "foo_component_div_host_ondocumentscroll_zip7mifsjry",
+  "canonicalFilename": "test.tsx_foo_component_div_host_ondocumentscroll_zip7mifsjry",
   "path": "",
   "extension": "js",
   "parent": "Foo_component_1_DvU6FitWglY",
@@ -68,17 +68,17 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Foo = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./foo_component_htdrsvublie"), "Foo_component_HTDRsvUbLiE"), {
+export const Foo = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_htdrsvublie"), "Foo_component_HTDRsvUbLiE"), {
     tagName: "my-foo"
 });
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,wGA0BhB;IACC,SAAS;AACb,GAAG\"}")
-============================= foo_component_htdrsvublie.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,iHA0BhB;IACC,SAAS;AACb,GAAG\"}")
+============================= test.tsx_foo_component_htdrsvublie.js (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 export const Foo_component_HTDRsvUbLiE = ()=>{
-    return /*#__PURE__*/ qrl(()=>import("./foo_component_1_dvu6fitwgly"), "Foo_component_1_DvU6FitWglY");
+    return /*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_1_dvu6fitwgly"), "Foo_component_1_DvU6FitWglY");
 };
 
 
@@ -88,9 +88,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_HTDRsvUbLiE",
   "entry": null,
-  "displayName": "Foo_component",
+  "displayName": "test.tsx_Foo_component",
   "hash": "HTDRsvUbLiE",
-  "canonicalFilename": "foo_component_htdrsvublie",
+  "canonicalFilename": "test.tsx_foo_component_htdrsvublie",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -103,7 +103,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= foo_component_div_host_onclick_cpeh970jbey.js (ENTRY POINT)==
+============================= test.tsx_foo_component_div_host_onclick_cpeh970jbey.js (ENTRY POINT)==
 
 export const Foo_component_div_host_onClick_cPEH970JbEY = ()=>console.log('host:onClick$');
 
@@ -114,9 +114,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_div_host_onClick_cPEH970JbEY",
   "entry": null,
-  "displayName": "Foo_component_div_host_onClick",
+  "displayName": "test.tsx_Foo_component_div_host_onClick",
   "hash": "cPEH970JbEY",
-  "canonicalFilename": "foo_component_div_host_onclick_cpeh970jbey",
+  "canonicalFilename": "test.tsx_foo_component_div_host_onclick_cpeh970jbey",
   "path": "",
   "extension": "js",
   "parent": "Foo_component_1_DvU6FitWglY",
@@ -129,26 +129,26 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= foo_component_1_dvu6fitwgly.js (ENTRY POINT)==
+============================= test.tsx_foo_component_1_dvu6fitwgly.js (ENTRY POINT)==
 
 import { _jsxQ } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
 export const Foo_component_1_DvU6FitWglY = ()=>{
-    const handler = /*#__PURE__*/ qrl(()=>import("./foo_component_handler_h10xztd0e7w"), "Foo_component_handler_H10xZtD0e7w");
+    const handler = /*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_handler_h10xztd0e7w"), "Foo_component_handler_H10xZtD0e7w");
     return /*#__PURE__*/ _jsxQ("div", null, {
-        onClick$: /*#__PURE__*/ qrl(()=>import("./foo_component_div_onclick_m48dyiidsjw"), "Foo_component_div_onClick_M48DYiidSJw"),
-        onDocumentScroll$: /*#__PURE__*/ qrl(()=>import("./foo_component_div_ondocumentscroll_rwfftfivukc"), "Foo_component_div_onDocumentScroll_rwFFtFiVuKc"),
-        onDocumentScroll$: /*#__PURE__*/ qrl(()=>import("./foo_component_div_ondocumentscroll_1_cwneogpmtzi"), "Foo_component_div_onDocumentScroll_1_CwneoGpmTZI"),
-        "on-cLick$": /*#__PURE__*/ qrl(()=>import("./foo_component_div_on_click_ioasjw8vyjc"), "Foo_component_div_on_cLick_IoAsJW8vYJc"),
-        "onDocument-sCroll$": /*#__PURE__*/ qrl(()=>import("./foo_component_div_ondocument_scroll_5vnik61pzom"), "Foo_component_div_onDocument_sCroll_5VNik61PZOM"),
-        "onDocument-scroLL$": /*#__PURE__*/ qrl(()=>import("./foo_component_div_ondocument_scroll_1q0sgr8te3g"), "Foo_component_div_onDocument_scroLL_1q0Sgr8te3g"),
-        "host:onClick$": /*#__PURE__*/ qrl(()=>import("./foo_component_div_host_onclick_cpeh970jbey"), "Foo_component_div_host_onClick_cPEH970JbEY"),
-        "host:onDocumentScroll$": /*#__PURE__*/ qrl(()=>import("./foo_component_div_host_ondocumentscroll_zip7mifsjry"), "Foo_component_div_host_onDocumentScroll_Zip7mifsjRY"),
-        "host:onDocumentScroll$": /*#__PURE__*/ qrl(()=>import("./foo_component_div_host_ondocumentscroll_1_em1lspk7jvg"), "Foo_component_div_host_onDocumentScroll_1_Em1LspK7JVg"),
+        onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_div_onclick_m48dyiidsjw"), "Foo_component_div_onClick_M48DYiidSJw"),
+        onDocumentScroll$: /*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_div_ondocumentscroll_rwfftfivukc"), "Foo_component_div_onDocumentScroll_rwFFtFiVuKc"),
+        onDocumentScroll$: /*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_div_ondocumentscroll_1_cwneogpmtzi"), "Foo_component_div_onDocumentScroll_1_CwneoGpmTZI"),
+        "on-cLick$": /*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_div_on_click_ioasjw8vyjc"), "Foo_component_div_on_cLick_IoAsJW8vYJc"),
+        "onDocument-sCroll$": /*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_div_ondocument_scroll_5vnik61pzom"), "Foo_component_div_onDocument_sCroll_5VNik61PZOM"),
+        "onDocument-scroLL$": /*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_div_ondocument_scroll_1q0sgr8te3g"), "Foo_component_div_onDocument_scroLL_1q0Sgr8te3g"),
+        "host:onClick$": /*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_div_host_onclick_cpeh970jbey"), "Foo_component_div_host_onClick_cPEH970JbEY"),
+        "host:onDocumentScroll$": /*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_div_host_ondocumentscroll_zip7mifsjry"), "Foo_component_div_host_onDocumentScroll_Zip7mifsjRY"),
+        "host:onDocumentScroll$": /*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_div_host_ondocumentscroll_1_em1lspk7jvg"), "Foo_component_div_host_onDocumentScroll_1_Em1LspK7JVg"),
         onKeyup$: handler,
         "onDocument:keyup$": handler,
         "onWindow:keyup$": handler,
-        custom$: /*#__PURE__*/ qrl(()=>import("./foo_component_div_custom_pyhnxab17ms"), "Foo_component_div_custom_pyHnxab17ms")
+        custom$: /*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_div_custom_pyhnxab17ms"), "Foo_component_div_custom_pyHnxab17ms")
     }, null, 3, "u6_0");
 };
 export { _hW } from "@builder.io/qwik";
@@ -160,9 +160,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_1_DvU6FitWglY",
   "entry": null,
-  "displayName": "Foo_component_1",
+  "displayName": "test.tsx_Foo_component_1",
   "hash": "DvU6FitWglY",
-  "canonicalFilename": "foo_component_1_dvu6fitwgly",
+  "canonicalFilename": "test.tsx_foo_component_1_dvu6fitwgly",
   "path": "",
   "extension": "js",
   "parent": "Foo_component_HTDRsvUbLiE",
@@ -175,7 +175,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= foo_component_div_host_ondocumentscroll_1_em1lspk7jvg.js (ENTRY POINT)==
+============================= test.tsx_foo_component_div_host_ondocumentscroll_1_em1lspk7jvg.js (ENTRY POINT)==
 
 export const Foo_component_div_host_onDocumentScroll_1_Em1LspK7JVg = ()=>console.log('host:onWindow:scroll');
 
@@ -186,9 +186,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_div_host_onDocumentScroll_1_Em1LspK7JVg",
   "entry": null,
-  "displayName": "Foo_component_div_host_onDocumentScroll_1",
+  "displayName": "test.tsx_Foo_component_div_host_onDocumentScroll_1",
   "hash": "Em1LspK7JVg",
-  "canonicalFilename": "foo_component_div_host_ondocumentscroll_1_em1lspk7jvg",
+  "canonicalFilename": "test.tsx_foo_component_div_host_ondocumentscroll_1_em1lspk7jvg",
   "path": "",
   "extension": "js",
   "parent": "Foo_component_1_DvU6FitWglY",
@@ -201,7 +201,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= foo_component_div_custom_pyhnxab17ms.js (ENTRY POINT)==
+============================= test.tsx_foo_component_div_custom_pyhnxab17ms.js (ENTRY POINT)==
 
 export const Foo_component_div_custom_pyHnxab17ms = ()=>console.log('custom');
 
@@ -212,9 +212,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_div_custom_pyHnxab17ms",
   "entry": null,
-  "displayName": "Foo_component_div_custom",
+  "displayName": "test.tsx_Foo_component_div_custom",
   "hash": "pyHnxab17ms",
-  "canonicalFilename": "foo_component_div_custom_pyhnxab17ms",
+  "canonicalFilename": "test.tsx_foo_component_div_custom_pyhnxab17ms",
   "path": "",
   "extension": "js",
   "parent": "Foo_component_1_DvU6FitWglY",
@@ -227,7 +227,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= foo_component_div_ondocument_scroll_1q0sgr8te3g.js (ENTRY POINT)==
+============================= test.tsx_foo_component_div_ondocument_scroll_1q0sgr8te3g.js (ENTRY POINT)==
 
 export const Foo_component_div_onDocument_scroLL_1q0Sgr8te3g = ()=>console.log('onDocument-scroLL');
 
@@ -238,9 +238,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_div_onDocument_scroLL_1q0Sgr8te3g",
   "entry": null,
-  "displayName": "Foo_component_div_onDocument_scroLL",
+  "displayName": "test.tsx_Foo_component_div_onDocument_scroLL",
   "hash": "1q0Sgr8te3g",
-  "canonicalFilename": "foo_component_div_ondocument_scroll_1q0sgr8te3g",
+  "canonicalFilename": "test.tsx_foo_component_div_ondocument_scroll_1q0sgr8te3g",
   "path": "",
   "extension": "js",
   "parent": "Foo_component_1_DvU6FitWglY",
@@ -253,7 +253,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= foo_component_div_ondocumentscroll_1_cwneogpmtzi.js (ENTRY POINT)==
+============================= test.tsx_foo_component_div_ondocumentscroll_1_cwneogpmtzi.js (ENTRY POINT)==
 
 export const Foo_component_div_onDocumentScroll_1_CwneoGpmTZI = ()=>console.log('onWindowScroll');
 
@@ -264,9 +264,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_div_onDocumentScroll_1_CwneoGpmTZI",
   "entry": null,
-  "displayName": "Foo_component_div_onDocumentScroll_1",
+  "displayName": "test.tsx_Foo_component_div_onDocumentScroll_1",
   "hash": "CwneoGpmTZI",
-  "canonicalFilename": "foo_component_div_ondocumentscroll_1_cwneogpmtzi",
+  "canonicalFilename": "test.tsx_foo_component_div_ondocumentscroll_1_cwneogpmtzi",
   "path": "",
   "extension": "js",
   "parent": "Foo_component_1_DvU6FitWglY",
@@ -279,7 +279,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= foo_component_div_on_click_ioasjw8vyjc.js (ENTRY POINT)==
+============================= test.tsx_foo_component_div_on_click_ioasjw8vyjc.js (ENTRY POINT)==
 
 export const Foo_component_div_on_cLick_IoAsJW8vYJc = ()=>console.log('on-cLick$');
 
@@ -290,9 +290,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_div_on_cLick_IoAsJW8vYJc",
   "entry": null,
-  "displayName": "Foo_component_div_on_cLick",
+  "displayName": "test.tsx_Foo_component_div_on_cLick",
   "hash": "IoAsJW8vYJc",
-  "canonicalFilename": "foo_component_div_on_click_ioasjw8vyjc",
+  "canonicalFilename": "test.tsx_foo_component_div_on_click_ioasjw8vyjc",
   "path": "",
   "extension": "js",
   "parent": "Foo_component_1_DvU6FitWglY",
@@ -305,7 +305,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= foo_component_div_onclick_m48dyiidsjw.js (ENTRY POINT)==
+============================= test.tsx_foo_component_div_onclick_m48dyiidsjw.js (ENTRY POINT)==
 
 export const Foo_component_div_onClick_M48DYiidSJw = ()=>console.log('onClick$');
 
@@ -316,9 +316,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_div_onClick_M48DYiidSJw",
   "entry": null,
-  "displayName": "Foo_component_div_onClick",
+  "displayName": "test.tsx_Foo_component_div_onClick",
   "hash": "M48DYiidSJw",
-  "canonicalFilename": "foo_component_div_onclick_m48dyiidsjw",
+  "canonicalFilename": "test.tsx_foo_component_div_onclick_m48dyiidsjw",
   "path": "",
   "extension": "js",
   "parent": "Foo_component_1_DvU6FitWglY",
@@ -331,7 +331,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= foo_component_div_ondocumentscroll_rwfftfivukc.js (ENTRY POINT)==
+============================= test.tsx_foo_component_div_ondocumentscroll_rwfftfivukc.js (ENTRY POINT)==
 
 export const Foo_component_div_onDocumentScroll_rwFFtFiVuKc = ()=>console.log('onDocumentScroll');
 
@@ -342,9 +342,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_div_onDocumentScroll_rwFFtFiVuKc",
   "entry": null,
-  "displayName": "Foo_component_div_onDocumentScroll",
+  "displayName": "test.tsx_Foo_component_div_onDocumentScroll",
   "hash": "rwFFtFiVuKc",
-  "canonicalFilename": "foo_component_div_ondocumentscroll_rwfftfivukc",
+  "canonicalFilename": "test.tsx_foo_component_div_ondocumentscroll_rwfftfivukc",
   "path": "",
   "extension": "js",
   "parent": "Foo_component_1_DvU6FitWglY",
@@ -357,7 +357,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= foo_component_handler_h10xztd0e7w.js (ENTRY POINT)==
+============================= test.tsx_foo_component_handler_h10xztd0e7w.js (ENTRY POINT)==
 
 export const Foo_component_handler_H10xZtD0e7w = ()=>console.log('reused');
 export { _hW } from "@builder.io/qwik";
@@ -369,9 +369,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_handler_H10xZtD0e7w",
   "entry": null,
-  "displayName": "Foo_component_handler",
+  "displayName": "test.tsx_Foo_component_handler",
   "hash": "H10xZtD0e7w",
-  "canonicalFilename": "foo_component_handler_h10xztd0e7w",
+  "canonicalFilename": "test.tsx_foo_component_handler_h10xztd0e7w",
   "path": "",
   "extension": "js",
   "parent": "Foo_component_1_DvU6FitWglY",
@@ -384,7 +384,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= foo_component_div_ondocument_scroll_5vnik61pzom.js (ENTRY POINT)==
+============================= test.tsx_foo_component_div_ondocument_scroll_5vnik61pzom.js (ENTRY POINT)==
 
 export const Foo_component_div_onDocument_sCroll_5VNik61PZOM = ()=>console.log('onDocument-sCroll');
 
@@ -395,9 +395,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_div_onDocument_sCroll_5VNik61PZOM",
   "entry": null,
-  "displayName": "Foo_component_div_onDocument_sCroll",
+  "displayName": "test.tsx_Foo_component_div_onDocument_sCroll",
   "hash": "5VNik61PZOM",
-  "canonicalFilename": "foo_component_div_ondocument_scroll_5vnik61pzom",
+  "canonicalFilename": "test.tsx_foo_component_div_ondocument_scroll_5vnik61pzom",
   "path": "",
   "extension": "js",
   "parent": "Foo_component_1_DvU6FitWglY",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_lightweight_functional.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_lightweight_functional.snap
@@ -31,7 +31,7 @@ export const ButtonArrow = ({text, color}) => {
     );
 }
 
-============================= foo_component_htdrsvublie.tsx (ENTRY POINT)==
+============================= test.tsx_foo_component_htdrsvublie.tsx (ENTRY POINT)==
 
 import { Button } from "./test";
 import { ButtonArrow } from "./test";
@@ -49,9 +49,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_HTDRsvUbLiE",
   "entry": null,
-  "displayName": "Foo_component",
+  "displayName": "test.tsx_Foo_component",
   "hash": "HTDRsvUbLiE",
-  "canonicalFilename": "foo_component_htdrsvublie",
+  "canonicalFilename": "test.tsx_foo_component_htdrsvublie",
   "path": "",
   "extension": "tsx",
   "parent": null,
@@ -64,7 +64,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= buttonarrow_button_onclick_9npo43figik.tsx (ENTRY POINT)==
+============================= test.tsx_buttonarrow_button_onclick_9npo43figik.tsx (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
 export const ButtonArrow_button_onClick_9npo43fIGik = ()=>{
@@ -79,9 +79,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "ButtonArrow_button_onClick_9npo43fIGik",
   "entry": null,
-  "displayName": "ButtonArrow_button_onClick",
+  "displayName": "test.tsx_ButtonArrow_button_onClick",
   "hash": "9npo43fIGik",
-  "canonicalFilename": "buttonarrow_button_onclick_9npo43figik",
+  "canonicalFilename": "test.tsx_buttonarrow_button_onclick_9npo43figik",
   "path": "",
   "extension": "tsx",
   "parent": null,
@@ -94,7 +94,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= button_button_onclick_nsm0jyv00jw.tsx (ENTRY POINT)==
+============================= test.tsx_button_button_onclick_nsm0jyv00jw.tsx (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
 export const Button_button_onClick_NsM0JYV00Jw = ()=>{
@@ -109,9 +109,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Button_button_onClick_NsM0JYV00Jw",
   "entry": null,
-  "displayName": "Button_button_onClick",
+  "displayName": "test.tsx_Button_button_onClick",
   "hash": "NsM0JYV00Jw",
-  "canonicalFilename": "button_button_onclick_nsm0jyv00jw",
+  "canonicalFilename": "test.tsx_button_button_onclick_nsm0jyv00jw",
   "path": "",
   "extension": "tsx",
   "parent": null,
@@ -128,24 +128,24 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Foo = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./foo_component_htdrsvublie"), "Foo_component_HTDRsvUbLiE"), {
+export const Foo = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_htdrsvublie"), "Foo_component_HTDRsvUbLiE"), {
     tagName: "my-foo"
 });
 export function Button({ text, color }) {
-    return <button onColor$={color} onClick$={/*#__PURE__*/ qrl(()=>import("./button_button_onclick_nsm0jyv00jw"), "Button_button_onClick_NsM0JYV00Jw", [
+    return <button onColor$={color} onClick$={/*#__PURE__*/ qrl(()=>import("./test.tsx_button_button_onclick_nsm0jyv00jw"), "Button_button_onClick_NsM0JYV00Jw", [
         color,
         text
     ])}>{text}</button>;
 }
 export const ButtonArrow = ({ text, color })=>{
-    return <button onColor$={color} onClick$={/*#__PURE__*/ qrl(()=>import("./buttonarrow_button_onclick_9npo43figik"), "ButtonArrow_button_onClick_9npo43fIGik", [
+    return <button onColor$={color} onClick$={/*#__PURE__*/ qrl(()=>import("./test.tsx_buttonarrow_button_onclick_9npo43figik"), "ButtonArrow_button_onClick_9npo43fIGik", [
         color,
         text
     ])}>{text}</button>;
 };
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,wGAOhB;IACC,SAAS;AACb,GAAG;AAEH,OAAO,SAAS,OAAO,EAAC,IAAI,EAAE,KAAK,EAAC;IAChC,QACK,OAAO,UAAU,OAAO;;;SAAyC,OAAO;AAEjF;AAEA,OAAO,MAAM,cAAc,CAAC,EAAC,IAAI,EAAE,KAAK,EAAC;IACrC,QACK,OAAO,UAAU,OAAO;;;SAAyC,OAAO;AAEjF,EAAC\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,iHAOhB;IACC,SAAS;AACb,GAAG;AAEH,OAAO,SAAS,OAAO,EAAC,IAAI,EAAE,KAAK,EAAC;IAChC,QACK,OAAO,UAAU,OAAO;;;SAAyC,OAAO;AAEjF;AAEA,OAAO,MAAM,cAAc,CAAC,EAAC,IAAI,EAAE,KAAK,EAAC;IACrC,QACK,OAAO,UAAU,OAAO;;;SAAyC,OAAO;AAEjF,EAAC\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_manual_chunks.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_manual_chunks.snap
@@ -45,7 +45,7 @@ export const Child = component$(() => {
     );
 });
 
-============================= parent_component_usetask_gdh1etuwqbu.js ==
+============================= test.tsx_parent_component_usetask_gdh1etuwqbu.js ==
 
 import { useLexicalScope } from "@builder.io/qwik";
 import mongo from "mongodb";
@@ -64,9 +64,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Parent_component_useTask_gDH1EtUWqBU",
   "entry": "test.tsx_entry_Parent",
-  "displayName": "Parent_component_useTask",
+  "displayName": "test.tsx_Parent_component_useTask",
   "hash": "gDH1EtUWqBU",
-  "canonicalFilename": "parent_component_usetask_gdh1etuwqbu",
+  "canonicalFilename": "test.tsx_parent_component_usetask_gdh1etuwqbu",
   "path": "",
   "extension": "js",
   "parent": "Parent_component_0TaiDayHrlo",
@@ -83,12 +83,12 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Parent = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./parent_component_0taidayhrlo"), "Parent_component_0TaiDayHrlo"));
-export const Child = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./child_component_9gyf01gdkqw"), "Child_component_9GyF01GDKqw"));
+export const Parent = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_parent_component_0taidayhrlo"), "Parent_component_0TaiDayHrlo"));
+export const Child = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_child_component_9gyf01gdkqw"), "Child_component_9GyF01GDKqw"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAKA,OAAO,MAAM,uBAAS,8GAgBnB;AAEH,OAAO,MAAM,sBAAQ,4GAelB\"}")
-============================= child_component_usetask_oh4n7zeqjku.js ==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAKA,OAAO,MAAM,uBAAS,uHAgBnB;AAEH,OAAO,MAAM,sBAAQ,qHAelB\"}")
+============================= test.tsx_child_component_usetask_oh4n7zeqjku.js ==
 
 import { useLexicalScope } from "@builder.io/qwik";
 import mongo from "mongodb";
@@ -105,9 +105,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Child_component_useTask_Oh4n7ZeqJkU",
   "entry": "test.tsx_entry_Child",
-  "displayName": "Child_component_useTask",
+  "displayName": "test.tsx_Child_component_useTask",
   "hash": "Oh4n7ZeqJkU",
-  "canonicalFilename": "child_component_usetask_oh4n7zeqjku",
+  "canonicalFilename": "test.tsx_child_component_usetask_oh4n7zeqjku",
   "path": "",
   "extension": "js",
   "parent": "Child_component_9GyF01GDKqw",
@@ -120,7 +120,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= parent_component_0taidayhrlo.js ==
+============================= test.tsx_parent_component_0taidayhrlo.js ==
 
 import { _fnSignal } from "@builder.io/qwik";
 import { _jsxQ } from "@builder.io/qwik";
@@ -132,11 +132,11 @@ export const Parent_component_0TaiDayHrlo = ()=>{
         text: ''
     });
     // Double count watch
-    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./parent_component_usetask_gdh1etuwqbu"), "Parent_component_useTask_gDH1EtUWqBU", [
+    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_parent_component_usetask_gdh1etuwqbu"), "Parent_component_useTask_gDH1EtUWqBU", [
         state
     ]));
     return /*#__PURE__*/ _jsxQ("div", null, {
-        onClick$: /*#__PURE__*/ qrl(()=>import("./parent_component_div_onclick_c5xe49nqd3a"), "Parent_component_div_onClick_C5XE49Nqd3A")
+        onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_parent_component_div_onclick_c5xe49nqd3a"), "Parent_component_div_onClick_C5XE49Nqd3A")
     }, _fnSignal((p0)=>p0.text, [
         state
     ], "p0.text"), 3, "u6_0");
@@ -149,9 +149,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Parent_component_0TaiDayHrlo",
   "entry": "test.tsx_entry_Parent",
-  "displayName": "Parent_component",
+  "displayName": "test.tsx_Parent_component",
   "hash": "0TaiDayHrlo",
-  "canonicalFilename": "parent_component_0taidayhrlo",
+  "canonicalFilename": "test.tsx_parent_component_0taidayhrlo",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -164,7 +164,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= parent_component_div_onclick_c5xe49nqd3a.js (ENTRY POINT)==
+============================= test.tsx_parent_component_div_onclick_c5xe49nqd3a.js (ENTRY POINT)==
 
 export const Parent_component_div_onClick_C5XE49Nqd3A = ()=>console.log('parent');
 
@@ -175,9 +175,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Parent_component_div_onClick_C5XE49Nqd3A",
   "entry": null,
-  "displayName": "Parent_component_div_onClick",
+  "displayName": "test.tsx_Parent_component_div_onClick",
   "hash": "C5XE49Nqd3A",
-  "canonicalFilename": "parent_component_div_onclick_c5xe49nqd3a",
+  "canonicalFilename": "test.tsx_parent_component_div_onclick_c5xe49nqd3a",
   "path": "",
   "extension": "js",
   "parent": "Parent_component_0TaiDayHrlo",
@@ -190,7 +190,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= child_component_9gyf01gdkqw.js ==
+============================= test.tsx_child_component_9gyf01gdkqw.js ==
 
 import { _fnSignal } from "@builder.io/qwik";
 import { _jsxQ } from "@builder.io/qwik";
@@ -202,11 +202,11 @@ export const Child_component_9GyF01GDKqw = ()=>{
         text: ''
     });
     // Double count watch
-    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./child_component_usetask_oh4n7zeqjku"), "Child_component_useTask_Oh4n7ZeqJkU", [
+    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_child_component_usetask_oh4n7zeqjku"), "Child_component_useTask_Oh4n7ZeqJkU", [
         state
     ]));
     return /*#__PURE__*/ _jsxQ("div", null, {
-        onClick$: /*#__PURE__*/ qrl(()=>import("./child_component_div_onclick_ellivsnaioq"), "Child_component_div_onClick_elliVSnAiOQ")
+        onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_child_component_div_onclick_ellivsnaioq"), "Child_component_div_onClick_elliVSnAiOQ")
     }, _fnSignal((p0)=>p0.text, [
         state
     ], "p0.text"), 3, "u6_1");
@@ -219,9 +219,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Child_component_9GyF01GDKqw",
   "entry": "test.tsx_entry_Child",
-  "displayName": "Child_component",
+  "displayName": "test.tsx_Child_component",
   "hash": "9GyF01GDKqw",
-  "canonicalFilename": "child_component_9gyf01gdkqw",
+  "canonicalFilename": "test.tsx_child_component_9gyf01gdkqw",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -234,7 +234,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= child_component_div_onclick_ellivsnaioq.js (ENTRY POINT)==
+============================= test.tsx_child_component_div_onclick_ellivsnaioq.js (ENTRY POINT)==
 
 export const Child_component_div_onClick_elliVSnAiOQ = ()=>console.log('child');
 
@@ -245,9 +245,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Child_component_div_onClick_elliVSnAiOQ",
   "entry": null,
-  "displayName": "Child_component_div_onClick",
+  "displayName": "test.tsx_Child_component_div_onClick",
   "hash": "elliVSnAiOQ",
-  "canonicalFilename": "child_component_div_onclick_ellivsnaioq",
+  "canonicalFilename": "test.tsx_child_component_div_onclick_ellivsnaioq",
   "path": "",
   "extension": "js",
   "parent": "Child_component_9GyF01GDKqw",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_multi_capture.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_multi_capture.snap
@@ -30,11 +30,11 @@ export const Bar = component$(({bar}) => {
     });
 })
 
-============================= foo_component_htdrsvublie.jsx (ENTRY POINT)==
+============================= test.tsx_foo_component_htdrsvublie.jsx (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 export const Foo_component_HTDRsvUbLiE = (props)=>{
-    return /*#__PURE__*/ qrl(()=>import("./foo_component_1_dvu6fitwgly"), "Foo_component_1_DvU6FitWglY", [
+    return /*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_1_dvu6fitwgly"), "Foo_component_1_DvU6FitWglY", [
         props
     ]);
 };
@@ -46,9 +46,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_HTDRsvUbLiE",
   "entry": null,
-  "displayName": "Foo_component",
+  "displayName": "test.tsx_Foo_component",
   "hash": "HTDRsvUbLiE",
-  "canonicalFilename": "foo_component_htdrsvublie",
+  "canonicalFilename": "test.tsx_foo_component_htdrsvublie",
   "path": "",
   "extension": "jsx",
   "parent": null,
@@ -65,16 +65,16 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Foo = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./foo_component_htdrsvublie"), "Foo_component_HTDRsvUbLiE"));
-export const Bar = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./bar_component_l80ps8hxf1y"), "Bar_component_L80pS8Hxf1Y"));
+export const Foo = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_htdrsvublie"), "Foo_component_HTDRsvUbLiE"));
+export const Bar = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_bar_component_l80ps8hxf1y"), "Bar_component_L80pS8Hxf1Y"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,wGAUjB;AAEF,OAAO,MAAM,oBAAM,wGAQjB\"}")
-============================= bar_component_l80ps8hxf1y.jsx (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,iHAUjB;AAEF,OAAO,MAAM,oBAAM,iHAQjB\"}")
+============================= test.tsx_bar_component_l80ps8hxf1y.jsx (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 export const Bar_component_L80pS8Hxf1Y = (props)=>{
-    return /*#__PURE__*/ qrl(()=>import("./bar_component_1_0xsynsnvu3k"), "Bar_component_1_0xSyNSnVu3k", [
+    return /*#__PURE__*/ qrl(()=>import("./test.tsx_bar_component_1_0xsynsnvu3k"), "Bar_component_1_0xSyNSnVu3k", [
         props
     ]);
 };
@@ -86,9 +86,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Bar_component_L80pS8Hxf1Y",
   "entry": null,
-  "displayName": "Bar_component",
+  "displayName": "test.tsx_Bar_component",
   "hash": "L80pS8Hxf1Y",
-  "canonicalFilename": "bar_component_l80ps8hxf1y",
+  "canonicalFilename": "test.tsx_bar_component_l80ps8hxf1y",
   "path": "",
   "extension": "jsx",
   "parent": null,
@@ -101,7 +101,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= foo_component_1_dvu6fitwgly.jsx (ENTRY POINT)==
+============================= test.tsx_foo_component_1_dvu6fitwgly.jsx (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
 export const Foo_component_1_DvU6FitWglY = ()=>{
@@ -120,9 +120,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_1_DvU6FitWglY",
   "entry": null,
-  "displayName": "Foo_component_1",
+  "displayName": "test.tsx_Foo_component_1",
   "hash": "DvU6FitWglY",
-  "canonicalFilename": "foo_component_1_dvu6fitwgly",
+  "canonicalFilename": "test.tsx_foo_component_1_dvu6fitwgly",
   "path": "",
   "extension": "jsx",
   "parent": "Foo_component_HTDRsvUbLiE",
@@ -135,7 +135,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= bar_component_1_0xsynsnvu3k.jsx (ENTRY POINT)==
+============================= test.tsx_bar_component_1_0xsynsnvu3k.jsx (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
 export const Bar_component_1_0xSyNSnVu3k = ()=>{
@@ -153,9 +153,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Bar_component_1_0xSyNSnVu3k",
   "entry": null,
-  "displayName": "Bar_component_1",
+  "displayName": "test.tsx_Bar_component_1",
   "hash": "0xSyNSnVu3k",
-  "canonicalFilename": "bar_component_1_0xsynsnvu3k",
+  "canonicalFilename": "test.tsx_bar_component_1_0xsynsnvu3k",
   "path": "",
   "extension": "jsx",
   "parent": "Bar_component_L80pS8Hxf1Y",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_noop_dev_mode.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_noop_dev_mode.snap
@@ -34,16 +34,16 @@ export const App = component$(() => {
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrlDEV } from "@builder.io/qwik";
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrlDEV(()=>import("./app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0", {
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrlDEV(()=>import("./test.tsx_app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0", {
     file: "/user/qwik/src/test.tsx",
     lo: 107,
     hi: 569,
-    displayName: "App_component"
+    displayName: "test.tsx_App_component"
 }));
 
 
 Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM;;;;;IAoBhB\"}")
-============================= app_component_ckepmxzlub0.js (ENTRY POINT)==
+============================= test.tsx_app_component_ckepmxzlub0.js (ENTRY POINT)==
 
 import { _jsxC } from "@builder.io/qwik";
 import { _jsxQ } from "@builder.io/qwik";
@@ -56,7 +56,7 @@ export const App_component_ckEPmXZlub0 = ()=>{
         file: "/user/qwik/src/test.tsx",
         lo: 0,
         hi: 0,
-        displayName: "App_component_serverStuff"
+        displayName: "test.tsx_App_component_serverStuff"
     }, [
         stuff
     ]));
@@ -64,7 +64,7 @@ export const App_component_ckEPmXZlub0 = ()=>{
         file: "/user/qwik/src/test.tsx",
         lo: 0,
         hi: 0,
-        displayName: "App_component_serverStuff_1"
+        displayName: "test.tsx_App_component_serverStuff_1"
     }));
     return /*#__PURE__*/ _jsxC(Cmp, {
         children: /*#__PURE__*/ _jsxQ("p", null, {
@@ -73,7 +73,7 @@ export const App_component_ckEPmXZlub0 = ()=>{
                 file: "/user/qwik/src/test.tsx",
                 lo: 0,
                 hi: 0,
-                displayName: "App_component_Cmp_p_shouldRemove"
+                displayName: "test.tsx_App_component_Cmp_p_shouldRemove"
             }, [
                 stuff
             ]),
@@ -81,7 +81,7 @@ export const App_component_ckEPmXZlub0 = ()=>{
                 file: "/user/qwik/src/test.tsx",
                 lo: 0,
                 hi: 0,
-                displayName: "App_component_Cmp_p_onClick"
+                displayName: "test.tsx_App_component_Cmp_p_onClick"
             })
         }, "Hello Qwik", 3, null, {
             fileName: "test.tsx",
@@ -102,9 +102,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "js",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_of_synchronous_qrl.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_of_synchronous_qrl.snap
@@ -27,11 +27,11 @@ expression: output
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export default /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test_component_luxexe0dqrg"), "test_component_LUXeXe0DQrg"));
+export default /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_test_component_luxexe0dqrg"), "test_component_LUXeXe0DQrg"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGQ,6BAAe,0GAaZ\"}")
-============================= test_component_luxexe0dqrg.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGQ,6BAAe,mHAaZ\"}")
+============================= test.tsx_test_component_luxexe0dqrg.js (ENTRY POINT)==
 
 import { Fragment as _Fragment } from "@builder.io/qwik/jsx-runtime";
 import { _jsxC } from "@builder.io/qwik";
@@ -65,9 +65,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "test_component_LUXeXe0DQrg",
   "entry": null,
-  "displayName": "test_component",
+  "displayName": "test.tsx_test_component",
   "hash": "LUXeXe0DQrg",
-  "canonicalFilename": "test_component_luxexe0dqrg",
+  "canonicalFilename": "test.tsx_test_component_luxexe0dqrg",
   "path": "",
   "extension": "js",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_preserve_filenames_segments.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_preserve_filenames_segments.snap
@@ -23,12 +23,12 @@ export const foo = () => console.log('foo');
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_ckepmxzlub0.js"), "App_component_ckEPmXZlub0"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0.js"), "App_component_ckEPmXZlub0"));
 export const foo = ()=>console.log('foo');
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,2GAOhB;AAEH,OAAO,MAAM,MAAM,IAAM,QAAQ,GAAG,CAAC,OAAO\"}")
-============================= app_component_ckepmxzlub0.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,oHAOhB;AAEH,OAAO,MAAM,MAAM,IAAM,QAAQ,GAAG,CAAC,OAAO\"}")
+============================= test.tsx_app_component_ckepmxzlub0.js (ENTRY POINT)==
 
 import { _jsxC } from "@builder.io/qwik";
 import { _jsxQ } from "@builder.io/qwik";
@@ -39,7 +39,7 @@ export const App_component_ckEPmXZlub0 = (props)=>{
     return /*#__PURE__*/ _jsxC(Cmp, {
         children: /*#__PURE__*/ _jsxQ("p", null, {
             class: "stuff",
-            onClick$: /*#__PURE__*/ qrl(()=>import("./app_component_cmp_p_onclick_vuxzfutkpto.js"), "App_component_Cmp_p_onClick_vuXzfUTkpto")
+            onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_cmp_p_onclick_vuxzfutkpto.js"), "App_component_Cmp_p_onClick_vuXzfUTkpto")
         }, "Hello Qwik", 3, null)
     }, 3, "u6_0");
 };
@@ -51,9 +51,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -66,7 +66,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_cmp_p_onclick_vuxzfutkpto.js (ENTRY POINT)==
+============================= test.tsx_app_component_cmp_p_onclick_vuxzfutkpto.js (ENTRY POINT)==
 
 export const App_component_Cmp_p_onClick_vuXzfUTkpto = ()=>console.log('warn');
 
@@ -77,9 +77,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_Cmp_p_onClick_vuXzfUTkpto",
   "entry": null,
-  "displayName": "App_component_Cmp_p_onClick",
+  "displayName": "test.tsx_App_component_Cmp_p_onClick",
   "hash": "vuXzfUTkpto",
-  "canonicalFilename": "app_component_cmp_p_onclick_vuxzfutkpto",
+  "canonicalFilename": "test.tsx_app_component_cmp_p_onclick_vuxzfutkpto",
   "path": "",
   "extension": "js",
   "parent": "App_component_ckEPmXZlub0",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_prod_node.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_prod_node.snap
@@ -18,27 +18,27 @@ export const Foo = component$(() => {
     );
 });
 
-============================= s_htdrsvublie.tsx (ENTRY POINT)==
+============================= test.tsx_foo_component_htdrsvublie.tsx (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 export const s_HTDRsvUbLiE = ()=>{
     return <div>
-            <div onClick$={/*#__PURE__*/ qrl(()=>import("./s_9dcjc0ujddo"), "s_9DcJc0uJDDo")}/>
-            <div onClick$={/*#__PURE__*/ qrl(()=>import("./s_rjqdy8i0mxc"), "s_RjQdy8I0MXc")}/>
-            <div onClick$={/*#__PURE__*/ qrl(()=>import("./s_w9ptfrbvk1e"), "s_w9ptFRBVK1E")}/>
+            <div onClick$={/*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_div_div_onclick_9dcjc0ujddo"), "s_9DcJc0uJDDo")}/>
+            <div onClick$={/*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_div_div_onclick_1_rjqdy8i0mxc"), "s_RjQdy8I0MXc")}/>
+            <div onClick$={/*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_div_div_onclick_2_w9ptfrbvk1e"), "s_w9ptFRBVK1E")}/>
         </div>;
 };
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";6BAG8B;IAC1B,QACK,IAAI;YACD,CAAC,IAAI,8EAAuC;YAC5C,CAAC,IAAI,8EAAwC;YAC7C,CAAC,IAAI,8EAAuC;QAChD,EAAE;AAEV\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";6BAG8B;IAC1B,QACK,IAAI;YACD,CAAC,IAAI,mHAAuC;YAC5C,CAAC,IAAI,qHAAwC;YAC7C,CAAC,IAAI,qHAAuC;QAChD,EAAE;AAEV\"}")
 /*
 {
   "origin": "test.tsx",
   "name": "s_HTDRsvUbLiE",
   "entry": null,
-  "displayName": "Foo_component",
+  "displayName": "test.tsx_Foo_component",
   "hash": "HTDRsvUbLiE",
-  "canonicalFilename": "s_htdrsvublie",
+  "canonicalFilename": "test.tsx_foo_component_htdrsvublie",
   "path": "",
   "extension": "tsx",
   "parent": null,
@@ -51,7 +51,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= s_9dcjc0ujddo.tsx (ENTRY POINT)==
+============================= test.tsx_foo_component_div_div_onclick_9dcjc0ujddo.tsx (ENTRY POINT)==
 
 export const s_9DcJc0uJDDo = ()=>console.log('first');
 
@@ -62,9 +62,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "s_9DcJc0uJDDo",
   "entry": null,
-  "displayName": "Foo_component_div_div_onClick",
+  "displayName": "test.tsx_Foo_component_div_div_onClick",
   "hash": "9DcJc0uJDDo",
-  "canonicalFilename": "s_9dcjc0ujddo",
+  "canonicalFilename": "test.tsx_foo_component_div_div_onclick_9dcjc0ujddo",
   "path": "",
   "extension": "tsx",
   "parent": "s_HTDRsvUbLiE",
@@ -77,7 +77,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= s_w9ptfrbvk1e.tsx (ENTRY POINT)==
+============================= test.tsx_foo_component_div_div_onclick_2_w9ptfrbvk1e.tsx (ENTRY POINT)==
 
 export const s_w9ptFRBVK1E = ()=>console.log('third');
 
@@ -88,9 +88,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "s_w9ptFRBVK1E",
   "entry": null,
-  "displayName": "Foo_component_div_div_onClick_2",
+  "displayName": "test.tsx_Foo_component_div_div_onClick_2",
   "hash": "w9ptFRBVK1E",
-  "canonicalFilename": "s_w9ptfrbvk1e",
+  "canonicalFilename": "test.tsx_foo_component_div_div_onclick_2_w9ptfrbvk1e",
   "path": "",
   "extension": "tsx",
   "parent": "s_HTDRsvUbLiE",
@@ -103,7 +103,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= s_rjqdy8i0mxc.tsx (ENTRY POINT)==
+============================= test.tsx_foo_component_div_div_onclick_1_rjqdy8i0mxc.tsx (ENTRY POINT)==
 
 export const s_RjQdy8I0MXc = ()=>console.log('second');
 
@@ -114,9 +114,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "s_RjQdy8I0MXc",
   "entry": null,
-  "displayName": "Foo_component_div_div_onClick_1",
+  "displayName": "test.tsx_Foo_component_div_div_onClick_1",
   "hash": "RjQdy8I0MXc",
-  "canonicalFilename": "s_rjqdy8i0mxc",
+  "canonicalFilename": "test.tsx_foo_component_div_div_onclick_1_rjqdy8i0mxc",
   "path": "",
   "extension": "tsx",
   "parent": "s_HTDRsvUbLiE",
@@ -133,10 +133,10 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Foo = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./s_htdrsvublie"), "s_HTDRsvUbLiE"));
+export const Foo = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_htdrsvublie"), "s_HTDRsvUbLiE"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,gFAQhB\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,qGAQhB\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_qwik_conflict.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_qwik_conflict.snap
@@ -47,16 +47,16 @@ export const hW = 12;
 export const handleWatch = 42;
 const componentQrl1 = ()=>console.log('not this', qrl1());
 componentQrl1();
-export const Foo = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./foo_component_htdrsvublie"), "Foo_component_HTDRsvUbLiE"), {
+export const Foo = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_htdrsvublie"), "Foo_component_HTDRsvUbLiE"), {
     tagName: "my-foo"
 });
-export const Root = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./root_component_royhjyacbye"), "Root_component_royhjYaCbYE"), {
+export const Root = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_root_component_royhjyacbye"), "Root_component_royhjYaCbYE"), {
     tagName: "my-foo"
 });
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAEA,SAAS,OAAA,IAAG,QAAQ,wBAAwB;AAE5C,OAAO,MAAM,KAAK,GAAG;AACrB,OAAO,MAAM,cAAc,GAAG;AAE9B,MAAM,gBAAe,IAAM,QAAQ,GAAG,CAAC,YAAY;AAEnD;AACA,OAAO,MAAM,oBAAM,wGAQhB;IACC,SAAS;AACb,GAAG;AAEH,OAAO,MAAM,qBAAO,0GAOjB;IACC,SAAS;AACb,GAAG\"}")
-============================= foo_component_htdrsvublie.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAEA,SAAS,OAAA,IAAG,QAAQ,wBAAwB;AAE5C,OAAO,MAAM,KAAK,GAAG;AACrB,OAAO,MAAM,cAAc,GAAG;AAE9B,MAAM,gBAAe,IAAM,QAAQ,GAAG,CAAC,YAAY;AAEnD;AACA,OAAO,MAAM,oBAAM,iHAQhB;IACC,SAAS;AACb,GAAG;AAEH,OAAO,MAAM,qBAAO,mHAOjB;IACC,SAAS;AACb,GAAG\"}")
+============================= test.tsx_foo_component_htdrsvublie.js (ENTRY POINT)==
 
 import { _jsxQ } from "@builder.io/qwik";
 import { hW } from "./test";
@@ -67,7 +67,7 @@ export const Foo_component_HTDRsvUbLiE = ()=>{
     const qwik = hW + handleWatch;
     console.log(qwik);
     return /*#__PURE__*/ _jsxQ("div", null, {
-        onClick$: /*#__PURE__*/ qrl(()=>import("./foo_component_div_onclick_m48dyiidsjw"), "Foo_component_div_onClick_M48DYiidSJw")
+        onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_div_onclick_m48dyiidsjw"), "Foo_component_div_onClick_M48DYiidSJw")
     }, null, 3, "u6_0");
 };
 
@@ -78,9 +78,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_HTDRsvUbLiE",
   "entry": null,
-  "displayName": "Foo_component",
+  "displayName": "test.tsx_Foo_component",
   "hash": "HTDRsvUbLiE",
-  "canonicalFilename": "foo_component_htdrsvublie",
+  "canonicalFilename": "test.tsx_foo_component_htdrsvublie",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -93,7 +93,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= root_component_usestyles_u5dkuxgrgnu.js (ENTRY POINT)==
+============================= test.tsx_root_component_usestyles_u5dkuxgrgnu.js (ENTRY POINT)==
 
 export const Root_component_useStyles_u5DkUxGrGnU = 'thing';
 export { _hW } from "@builder.io/qwik";
@@ -105,9 +105,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Root_component_useStyles_u5DkUxGrGnU",
   "entry": null,
-  "displayName": "Root_component_useStyles",
+  "displayName": "test.tsx_Root_component_useStyles",
   "hash": "u5DkUxGrGnU",
-  "canonicalFilename": "root_component_usestyles_u5dkuxgrgnu",
+  "canonicalFilename": "test.tsx_root_component_usestyles_u5dkuxgrgnu",
   "path": "",
   "extension": "js",
   "parent": "Root_component_royhjYaCbYE",
@@ -120,13 +120,13 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= root_component_royhjyacbye.js (ENTRY POINT)==
+============================= test.tsx_root_component_royhjyacbye.js (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 import { useStyles } from "@builder.io/qwik";
 export const Root_component_royhjYaCbYE = ()=>{
-    useStyles(/*#__PURE__*/ qrl(()=>import("./root_component_usestyles_u5dkuxgrgnu"), "Root_component_useStyles_u5DkUxGrGnU"));
-    return /*#__PURE__*/ qrl(()=>import("./root_component_1_cbpqnyduhi4"), "Root_component_1_cBpQNYDUHI4");
+    useStyles(/*#__PURE__*/ qrl(()=>import("./test.tsx_root_component_usestyles_u5dkuxgrgnu"), "Root_component_useStyles_u5DkUxGrGnU"));
+    return /*#__PURE__*/ qrl(()=>import("./test.tsx_root_component_1_cbpqnyduhi4"), "Root_component_1_cBpQNYDUHI4");
 };
 
 
@@ -136,9 +136,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Root_component_royhjYaCbYE",
   "entry": null,
-  "displayName": "Root_component",
+  "displayName": "test.tsx_Root_component",
   "hash": "royhjYaCbYE",
-  "canonicalFilename": "root_component_royhjyacbye",
+  "canonicalFilename": "test.tsx_root_component_royhjyacbye",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -151,7 +151,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= root_component_1_cbpqnyduhi4.js (ENTRY POINT)==
+============================= test.tsx_root_component_1_cbpqnyduhi4.js (ENTRY POINT)==
 
 import { _jsxQ } from "@builder.io/qwik";
 export const Root_component_1_cBpQNYDUHI4 = ()=>{
@@ -166,9 +166,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Root_component_1_cBpQNYDUHI4",
   "entry": null,
-  "displayName": "Root_component_1",
+  "displayName": "test.tsx_Root_component_1",
   "hash": "cBpQNYDUHI4",
-  "canonicalFilename": "root_component_1_cbpqnyduhi4",
+  "canonicalFilename": "test.tsx_root_component_1_cbpqnyduhi4",
   "path": "",
   "extension": "js",
   "parent": "Root_component_royhjYaCbYE",
@@ -181,7 +181,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= foo_component_div_onclick_m48dyiidsjw.js (ENTRY POINT)==
+============================= test.tsx_foo_component_div_onclick_m48dyiidsjw.js (ENTRY POINT)==
 
 export const Foo_component_div_onClick_M48DYiidSJw = ()=>console.log(23);
 
@@ -192,9 +192,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_div_onClick_M48DYiidSJw",
   "entry": null,
-  "displayName": "Foo_component_div_onClick",
+  "displayName": "test.tsx_Foo_component_div_onClick",
   "hash": "M48DYiidSJw",
-  "canonicalFilename": "foo_component_div_onclick_m48dyiidsjw",
+  "canonicalFilename": "test.tsx_foo_component_div_onclick_m48dyiidsjw",
   "path": "",
   "extension": "js",
   "parent": "Foo_component_HTDRsvUbLiE",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_qwik_react.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_qwik_react.snap
@@ -97,7 +97,7 @@ async function renderToString(rootNode, opts) {
 
 export { qwikify$, qwikifyQrl, renderToString };
         
-============================= ../node_modules/@builder.io/qwik-react/qwikifyqrl_component_usewatch_x04jc5xep1u.mjs (ENTRY POINT)==
+============================= ../node_modules/@builder.io/qwik-react/index.qwik.mjs_qwikifyqrl_component_usewatch_x04jc5xep1u.mjs (ENTRY POINT)==
 
 import { _auto_filterProps as filterProps } from "./index.qwik.mjs";
 import { isBrowser } from "@builder.io/qwik/build";
@@ -136,9 +136,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-rea
   "origin": "../node_modules/@builder.io/qwik-react/index.qwik.mjs",
   "name": "qwikifyQrl_component_useWatch_x04JC5xeP1U",
   "entry": null,
-  "displayName": "qwikifyQrl_component_useWatch",
+  "displayName": "index.qwik.mjs_qwikifyQrl_component_useWatch",
   "hash": "x04JC5xeP1U",
-  "canonicalFilename": "qwikifyqrl_component_usewatch_x04jc5xep1u",
+  "canonicalFilename": "index.qwik.mjs_qwikifyqrl_component_usewatch_x04jc5xep1u",
   "path": "../node_modules/@builder.io/qwik-react",
   "extension": "mjs",
   "parent": "qwikifyQrl_component_zH94hIe0Ick",
@@ -151,7 +151,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-rea
   ]
 }
 */
-============================= ../node_modules/@builder.io/qwik-react/qwikifyqrl_component_zh94hie0ick.mjs (ENTRY POINT)==
+============================= ../node_modules/@builder.io/qwik-react/index.qwik.mjs_qwikifyqrl_component_zh94hie0ick.mjs (ENTRY POINT)==
 
 import { Fragment } from "@builder.io/qwik/jsx-runtime";
 import { SkipRerender } from "@builder.io/qwik";
@@ -172,7 +172,7 @@ export const qwikifyQrl_component_zH94hIe0Ick = (props)=>{
     let run;
     if (props['client:visible']) run = 'visible';
     else if (props['client:load'] || props['client:only']) run = 'load';
-    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./qwikifyqrl_component_usewatch_x04jc5xep1u.mjs"), "qwikifyQrl_component_useWatch_x04JC5xeP1U", [
+    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./index.qwik.mjs_qwikifyqrl_component_usewatch_x04jc5xep1u.mjs"), "qwikifyQrl_component_useWatch_x04JC5xeP1U", [
         hostElement,
         props,
         reactCmpQrl,
@@ -209,9 +209,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-rea
   "origin": "../node_modules/@builder.io/qwik-react/index.qwik.mjs",
   "name": "qwikifyQrl_component_zH94hIe0Ick",
   "entry": null,
-  "displayName": "qwikifyQrl_component",
+  "displayName": "index.qwik.mjs_qwikifyQrl_component",
   "hash": "zH94hIe0Ick",
-  "canonicalFilename": "qwikifyqrl_component_zh94hie0ick",
+  "canonicalFilename": "index.qwik.mjs_qwikifyqrl_component_zh94hie0ick",
   "path": "../node_modules/@builder.io/qwik-react",
   "extension": "mjs",
   "parent": null,
@@ -229,7 +229,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-rea
 import { qrl } from "@builder.io/qwik";
 import { componentQrl, implicit$FirstArg } from '@builder.io/qwik';
 function qwikifyQrl(reactCmpQrl) {
-    return /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./qwikifyqrl_component_zh94hie0ick.mjs"), "qwikifyQrl_component_zH94hIe0Ick", [
+    return /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./index.qwik.mjs_qwikifyqrl_component_zh94hie0ick.mjs"), "qwikifyQrl_component_zH94hIe0Ick", [
         reactCmpQrl
     ]), {
         tagName: 'qwik-wrap'

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_qwik_sdk_inline.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_qwik_sdk_inline.snap
@@ -1079,7 +1079,7 @@ export {
   zodQrl,
 };
 
-============================= ../node_modules/@builder.io/qwik-city/routeroutlet_component_useondocument_event_knne9el0qfc.mjs (ENTRY POINT)==
+============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_routeroutlet_component_useondocument_event_knne9el0qfc.mjs (ENTRY POINT)==
 
 export const RouterOutlet_component_useOnDocument_event_KnNE9eL0qfc = ()=>{
     const POPSTATE_FALLBACK_INITIALIZED = '_qCityPopstateFallback';
@@ -1101,9 +1101,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   "origin": "../node_modules/@builder.io/qwik-city/index.qwik.mjs",
   "name": "RouterOutlet_component_useOnDocument_event_KnNE9eL0qfc",
   "entry": null,
-  "displayName": "RouterOutlet_component_useOnDocument_event",
+  "displayName": "index.qwik.mjs_RouterOutlet_component_useOnDocument_event",
   "hash": "KnNE9eL0qfc",
-  "canonicalFilename": "routeroutlet_component_useondocument_event_knne9el0qfc",
+  "canonicalFilename": "index.qwik.mjs_routeroutlet_component_useondocument_event_knne9el0qfc",
   "path": "../node_modules/@builder.io/qwik-city",
   "extension": "mjs",
   "parent": "RouterOutlet_component_AKetNByE5TM",
@@ -1116,7 +1116,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   ]
 }
 */
-============================= ../node_modules/@builder.io/qwik-city/routeroutlet_component_aketnbye5tm.mjs ==
+============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_routeroutlet_component_aketnbye5tm.mjs ==
 
 import { _auto_ContentInternalContext as ContentInternalContext } from "./index.qwik.mjs";
 import { SkipRender } from "@builder.io/qwik";
@@ -1128,7 +1128,7 @@ import { useContext } from "@builder.io/qwik";
 import { useOnDocument } from "@builder.io/qwik";
 export const RouterOutlet_component_AKetNByE5TM = ()=>{
     _jsxBranch();
-    useOnDocument('qinit', eventQrl(/*#__PURE__*/ qrl(()=>import("./routeroutlet_component_useondocument_event_knne9el0qfc.mjs"), "RouterOutlet_component_useOnDocument_event_KnNE9eL0qfc")));
+    useOnDocument('qinit', eventQrl(/*#__PURE__*/ qrl(()=>import("./index.qwik.mjs_routeroutlet_component_useondocument_event_knne9el0qfc.mjs"), "RouterOutlet_component_useOnDocument_event_KnNE9eL0qfc")));
     const context = useContext(ContentInternalContext);
     if (context.value && context.value.length > 0) {
         const contentsLen = context.value.length;
@@ -1148,9 +1148,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   "origin": "../node_modules/@builder.io/qwik-city/index.qwik.mjs",
   "name": "RouterOutlet_component_AKetNByE5TM",
   "entry": "../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_RouterOutlet",
-  "displayName": "RouterOutlet_component",
+  "displayName": "index.qwik.mjs_RouterOutlet_component",
   "hash": "AKetNByE5TM",
-  "canonicalFilename": "routeroutlet_component_aketnbye5tm",
+  "canonicalFilename": "index.qwik.mjs_routeroutlet_component_aketnbye5tm",
   "path": "../node_modules/@builder.io/qwik-city",
   "extension": "mjs",
   "parent": null,
@@ -1163,7 +1163,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   ]
 }
 */
-============================= ../node_modules/@builder.io/qwik-city/qwikcityprovider_component_usestyles_rpdjaz33wla.mjs ==
+============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_qwikcityprovider_component_usestyles_rpdjaz33wla.mjs ==
 
 export const QwikCityProvider_component_useStyles_RPDJAz33WLA = `:root{view-transition-name: none}`;
 
@@ -1174,9 +1174,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   "origin": "../node_modules/@builder.io/qwik-city/index.qwik.mjs",
   "name": "QwikCityProvider_component_useStyles_RPDJAz33WLA",
   "entry": "../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_QwikCityProvider",
-  "displayName": "QwikCityProvider_component_useStyles",
+  "displayName": "index.qwik.mjs_QwikCityProvider_component_useStyles",
   "hash": "RPDJAz33WLA",
-  "canonicalFilename": "qwikcityprovider_component_usestyles_rpdjaz33wla",
+  "canonicalFilename": "index.qwik.mjs_qwikcityprovider_component_usestyles_rpdjaz33wla",
   "path": "../node_modules/@builder.io/qwik-city",
   "extension": "mjs",
   "parent": "QwikCityProvider_component_TxCFOy819ag",
@@ -1189,7 +1189,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   ]
 }
 */
-============================= ../node_modules/@builder.io/qwik-city/qwikcityprovider_component_goto_event_cbcjroynrvg.mjs ==
+============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_qwikcityprovider_component_goto_event_cbcjroynrvg.mjs ==
 
 import { _getContextElement } from "@builder.io/qwik";
 import { isBrowser } from "@builder.io/qwik/build";
@@ -1223,9 +1223,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   "origin": "../node_modules/@builder.io/qwik-city/index.qwik.mjs",
   "name": "QwikCityProvider_component_goto_event_cBcjROynRVg",
   "entry": "../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_QwikCityProvider",
-  "displayName": "QwikCityProvider_component_goto_event",
+  "displayName": "index.qwik.mjs_QwikCityProvider_component_goto_event",
   "hash": "cBcjROynRVg",
-  "canonicalFilename": "qwikcityprovider_component_goto_event_cbcjroynrvg",
+  "canonicalFilename": "index.qwik.mjs_qwikcityprovider_component_goto_event_cbcjroynrvg",
   "path": "../node_modules/@builder.io/qwik-city",
   "extension": "mjs",
   "parent": "QwikCityProvider_component_TxCFOy819ag",
@@ -1238,7 +1238,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   ]
 }
 */
-============================= ../node_modules/@builder.io/qwik-city/qwikcityprovider_component_usetask_02wmimzeabk.mjs ==
+============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_qwikcityprovider_component_usetask_02wmimzeabk.mjs ==
 
 import { _auto_CLIENT_DATA_CACHE as CLIENT_DATA_CACHE } from "./index.qwik.mjs";
 import { _getContextElement } from "@builder.io/qwik";
@@ -1330,9 +1330,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   "origin": "../node_modules/@builder.io/qwik-city/index.qwik.mjs",
   "name": "QwikCityProvider_component_useTask_02wMImzEAbk",
   "entry": "../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_QwikCityProvider",
-  "displayName": "QwikCityProvider_component_useTask",
+  "displayName": "index.qwik.mjs_QwikCityProvider_component_useTask",
   "hash": "02wMImzEAbk",
-  "canonicalFilename": "qwikcityprovider_component_usetask_02wmimzeabk",
+  "canonicalFilename": "index.qwik.mjs_qwikcityprovider_component_usetask_02wmimzeabk",
   "path": "../node_modules/@builder.io/qwik-city",
   "extension": "mjs",
   "parent": "QwikCityProvider_component_TxCFOy819ag",
@@ -1345,7 +1345,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   ]
 }
 */
-============================= ../node_modules/@builder.io/qwik-city/qwikcityprovider_component_txcfoy819ag.mjs ==
+============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_qwikcityprovider_component_txcfoy819ag.mjs ==
 
 import { _auto_ContentContext as ContentContext } from "./index.qwik.mjs";
 import { _auto_ContentInternalContext as ContentInternalContext } from "./index.qwik.mjs";
@@ -1369,7 +1369,7 @@ import { useStore } from "@builder.io/qwik";
 import { useStylesQrl } from "@builder.io/qwik";
 import { useTaskQrl } from "@builder.io/qwik";
 export const QwikCityProvider_component_TxCFOy819ag = (props)=>{
-    useStylesQrl(/*#__PURE__*/ qrl(()=>import("./qwikcityprovider_component_usestyles_rpdjaz33wla.mjs"), "QwikCityProvider_component_useStyles_RPDJAz33WLA"));
+    useStylesQrl(/*#__PURE__*/ qrl(()=>import("./index.qwik.mjs_qwikcityprovider_component_usestyles_rpdjaz33wla.mjs"), "QwikCityProvider_component_useStyles_RPDJAz33WLA"));
     const env = useQwikCityEnv();
     if (!env?.params) throw new Error(`Missing Qwik City Env Data`);
     const urlEnv = useServerData('url');
@@ -1402,7 +1402,7 @@ export const QwikCityProvider_component_TxCFOy819ag = (props)=>{
             status: env.response.status
         }
     } : void 0);
-    const goto = eventQrl(/*#__PURE__*/ qrl(()=>import("./qwikcityprovider_component_goto_event_cbcjroynrvg.mjs"), "QwikCityProvider_component_goto_event_cBcjROynRVg", [
+    const goto = eventQrl(/*#__PURE__*/ qrl(()=>import("./index.qwik.mjs_qwikcityprovider_component_goto_event_cbcjroynrvg.mjs"), "QwikCityProvider_component_goto_event_cBcjROynRVg", [
         actionState,
         navPath,
         routeLocation
@@ -1414,7 +1414,7 @@ export const QwikCityProvider_component_TxCFOy819ag = (props)=>{
     useContextProvider(RouteNavigateContext, goto);
     useContextProvider(RouteStateContext, loaderState);
     useContextProvider(RouteActionContext, actionState);
-    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./qwikcityprovider_component_usetask_02wmimzeabk.mjs"), "QwikCityProvider_component_useTask_02wMImzEAbk", [
+    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./index.qwik.mjs_qwikcityprovider_component_usetask_02wmimzeabk.mjs"), "QwikCityProvider_component_useTask_02wMImzEAbk", [
         actionState,
         content,
         contentInternal,
@@ -1436,9 +1436,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   "origin": "../node_modules/@builder.io/qwik-city/index.qwik.mjs",
   "name": "QwikCityProvider_component_TxCFOy819ag",
   "entry": "../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_QwikCityProvider",
-  "displayName": "QwikCityProvider_component",
+  "displayName": "index.qwik.mjs_QwikCityProvider_component",
   "hash": "TxCFOy819ag",
-  "canonicalFilename": "qwikcityprovider_component_txcfoy819ag",
+  "canonicalFilename": "index.qwik.mjs_qwikcityprovider_component_txcfoy819ag",
   "path": "../node_modules/@builder.io/qwik-city",
   "extension": "mjs",
   "parent": null,
@@ -1451,7 +1451,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   ]
 }
 */
-============================= ../node_modules/@builder.io/qwik-city/qwikcitymockprovider_component_goto_bubtvtyvvre.mjs ==
+============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_qwikcitymockprovider_component_goto_bubtvtyvvre.mjs ==
 
 export const QwikCityMockProvider_component_goto_BUbtvTyvVRE = async (path)=>{
     throw new Error('Not implemented');
@@ -1464,9 +1464,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   "origin": "../node_modules/@builder.io/qwik-city/index.qwik.mjs",
   "name": "QwikCityMockProvider_component_goto_BUbtvTyvVRE",
   "entry": "../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_QwikCityMockProvider",
-  "displayName": "QwikCityMockProvider_component_goto",
+  "displayName": "index.qwik.mjs_QwikCityMockProvider_component_goto",
   "hash": "BUbtvTyvVRE",
-  "canonicalFilename": "qwikcitymockprovider_component_goto_bubtvtyvvre",
+  "canonicalFilename": "index.qwik.mjs_qwikcitymockprovider_component_goto_bubtvtyvvre",
   "path": "../node_modules/@builder.io/qwik-city",
   "extension": "mjs",
   "parent": "QwikCityMockProvider_component_WmYC5H00wtI",
@@ -1479,7 +1479,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   ]
 }
 */
-============================= ../node_modules/@builder.io/qwik-city/qwikcitymockprovider_component_wmyc5h00wti.mjs ==
+============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_qwikcitymockprovider_component_wmyc5h00wti.mjs ==
 
 import { _auto_ContentContext as ContentContext } from "./index.qwik.mjs";
 import { _auto_ContentInternalContext as ContentInternalContext } from "./index.qwik.mjs";
@@ -1505,7 +1505,7 @@ export const QwikCityMockProvider_component_WmYC5H00wtI = (props)=>{
         deep: false
     });
     const loaderState = useSignal({});
-    const goto = /*#__PURE__*/ qrl(()=>import("./qwikcitymockprovider_component_goto_bubtvtyvvre.mjs"), "QwikCityMockProvider_component_goto_BUbtvTyvVRE");
+    const goto = /*#__PURE__*/ qrl(()=>import("./index.qwik.mjs_qwikcitymockprovider_component_goto_bubtvtyvvre.mjs"), "QwikCityMockProvider_component_goto_BUbtvTyvVRE");
     const documentHead = useStore(createDocumentHead, {
         deep: false
     });
@@ -1532,9 +1532,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   "origin": "../node_modules/@builder.io/qwik-city/index.qwik.mjs",
   "name": "QwikCityMockProvider_component_WmYC5H00wtI",
   "entry": "../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_QwikCityMockProvider",
-  "displayName": "QwikCityMockProvider_component",
+  "displayName": "index.qwik.mjs_QwikCityMockProvider_component",
   "hash": "WmYC5H00wtI",
-  "canonicalFilename": "qwikcitymockprovider_component_wmyc5h00wti",
+  "canonicalFilename": "index.qwik.mjs_qwikcitymockprovider_component_wmyc5h00wti",
   "path": "../node_modules/@builder.io/qwik-city",
   "extension": "mjs",
   "parent": null,
@@ -1547,7 +1547,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   ]
 }
 */
-============================= ../node_modules/@builder.io/qwik-city/link_component_event_event_5g4b0gd1wck.mjs (ENTRY POINT)==
+============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_link_component_event_event_5g4b0gd1wck.mjs (ENTRY POINT)==
 
 import { _auto_prefetchLinkResources as prefetchLinkResources } from "./index.qwik.mjs";
 export const Link_component_event_event_5g4B0Gd1Wck = (ev, elm)=>prefetchLinkResources(elm, ev.type === 'qvisible');
@@ -1559,9 +1559,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   "origin": "../node_modules/@builder.io/qwik-city/index.qwik.mjs",
   "name": "Link_component_event_event_5g4B0Gd1Wck",
   "entry": null,
-  "displayName": "Link_component_event_event",
+  "displayName": "index.qwik.mjs_Link_component_event_event",
   "hash": "5g4B0Gd1Wck",
-  "canonicalFilename": "link_component_event_event_5g4b0gd1wck",
+  "canonicalFilename": "index.qwik.mjs_link_component_event_event_5g4b0gd1wck",
   "path": "../node_modules/@builder.io/qwik-city",
   "extension": "mjs",
   "parent": "Link_component_8gdLBszqbaM",
@@ -1574,7 +1574,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   ]
 }
 */
-============================= ../node_modules/@builder.io/qwik-city/link_component_a_onclick_kzjavhdi3l0.mjs ==
+============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_link_component_a_onclick_kzjavhdi3l0.mjs ==
 
 import { useLexicalScope } from "@builder.io/qwik";
 export const Link_component_a_onClick_kzjavhDI3L0 = (_, elm)=>{
@@ -1589,9 +1589,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   "origin": "../node_modules/@builder.io/qwik-city/index.qwik.mjs",
   "name": "Link_component_a_onClick_kzjavhDI3L0",
   "entry": "../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_Link",
-  "displayName": "Link_component_a_onClick",
+  "displayName": "index.qwik.mjs_Link_component_a_onClick",
   "hash": "kzjavhDI3L0",
-  "canonicalFilename": "link_component_a_onclick_kzjavhdi3l0",
+  "canonicalFilename": "index.qwik.mjs_link_component_a_onclick_kzjavhdi3l0",
   "path": "../node_modules/@builder.io/qwik-city",
   "extension": "mjs",
   "parent": "Link_component_8gdLBszqbaM",
@@ -1604,7 +1604,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   ]
 }
 */
-============================= ../node_modules/@builder.io/qwik-city/link_component_8gdlbszqbam.mjs ==
+============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_link_component_8gdlbszqbam.mjs ==
 
 import { Slot } from "@builder.io/qwik";
 import { _jsxC } from "@builder.io/qwik";
@@ -1627,12 +1627,12 @@ export const Link_component_8gdLBszqbaM = (props)=>{
     const reload = !!linkProps.reload;
     linkProps['preventdefault:click'] = !!clientNavPath;
     linkProps.href = clientNavPath || props.href;
-    const event = eventQrl(/*#__PURE__*/ qrl(()=>import("./link_component_event_event_5g4b0gd1wck.mjs"), "Link_component_event_event_5g4B0Gd1Wck"));
+    const event = eventQrl(/*#__PURE__*/ qrl(()=>import("./index.qwik.mjs_link_component_event_event_5g4b0gd1wck.mjs"), "Link_component_event_event_5g4B0Gd1Wck"));
     return /* @__PURE__ */ _jsxS('a', {
         ...linkProps,
         'data-prefetch': prefetchDataset,
         children: /* @__PURE__ */ _jsxC(Slot, null, 3, 'AD_0'),
-        onClick$: /*#__PURE__*/ qrl(()=>import("./link_component_a_onclick_kzjavhdi3l0.mjs"), "Link_component_a_onClick_kzjavhDI3L0", [
+        onClick$: /*#__PURE__*/ qrl(()=>import("./index.qwik.mjs_link_component_a_onclick_kzjavhdi3l0.mjs"), "Link_component_a_onClick_kzjavhDI3L0", [
             nav,
             reload
         ]),
@@ -1649,9 +1649,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   "origin": "../node_modules/@builder.io/qwik-city/index.qwik.mjs",
   "name": "Link_component_8gdLBszqbaM",
   "entry": "../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_Link",
-  "displayName": "Link_component",
+  "displayName": "index.qwik.mjs_Link_component",
   "hash": "8gdLBszqbaM",
-  "canonicalFilename": "link_component_8gdlbszqbam",
+  "canonicalFilename": "index.qwik.mjs_link_component_8gdlbszqbam",
   "path": "../node_modules/@builder.io/qwik-city",
   "extension": "mjs",
   "parent": null,
@@ -1664,7 +1664,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   ]
 }
 */
-============================= ../node_modules/@builder.io/qwik-city/routeactionqrl_action_submit_a5bzc7wo00a.mjs ==
+============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_routeactionqrl_action_submit_a5bzc7wo00a.mjs ==
 
 import { isServer } from "@builder.io/qwik/build";
 import { noSerialize } from "@builder.io/qwik";
@@ -1722,9 +1722,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   "origin": "../node_modules/@builder.io/qwik-city/index.qwik.mjs",
   "name": "routeActionQrl_action_submit_A5bZC7WO00A",
   "entry": "../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_routeActionQrl",
-  "displayName": "routeActionQrl_action_submit",
+  "displayName": "index.qwik.mjs_routeActionQrl_action_submit",
   "hash": "A5bZC7WO00A",
-  "canonicalFilename": "routeactionqrl_action_submit_a5bzc7wo00a",
+  "canonicalFilename": "index.qwik.mjs_routeactionqrl_action_submit_a5bzc7wo00a",
   "path": "../node_modules/@builder.io/qwik-city",
   "extension": "mjs",
   "parent": null,
@@ -1737,7 +1737,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   ]
 }
 */
-============================= ../node_modules/@builder.io/qwik-city/serverqrl_stuff_woipfiq04l4.mjs ==
+============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_serverqrl_stuff_woipfiq04l4.mjs ==
 
 import { _deserializeData } from "@builder.io/qwik";
 import { _getContextElement } from "@builder.io/qwik";
@@ -1795,9 +1795,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   "origin": "../node_modules/@builder.io/qwik-city/index.qwik.mjs",
   "name": "serverQrl_stuff_wOIPfiQ04l4",
   "entry": "../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_serverQrl",
-  "displayName": "serverQrl_stuff",
+  "displayName": "index.qwik.mjs_serverQrl_stuff",
   "hash": "wOIPfiQ04l4",
-  "canonicalFilename": "serverqrl_stuff_woipfiq04l4",
+  "canonicalFilename": "index.qwik.mjs_serverqrl_stuff_woipfiq04l4",
   "path": "../node_modules/@builder.io/qwik-city",
   "extension": "mjs",
   "parent": null,
@@ -1810,7 +1810,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   ]
 }
 */
-============================= ../node_modules/@builder.io/qwik-city/getform_component_form_onsubmit_p9msze0ojs4.mjs ==
+============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_getform_component_form_onsubmit_p9msze0ojs4.mjs ==
 
 import { useLexicalScope } from "@builder.io/qwik";
 export const GetForm_component_form_onSubmit_p9MSze0ojs4 = async (_, form)=>{
@@ -1840,9 +1840,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   "origin": "../node_modules/@builder.io/qwik-city/index.qwik.mjs",
   "name": "GetForm_component_form_onSubmit_p9MSze0ojs4",
   "entry": "../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_GetForm",
-  "displayName": "GetForm_component_form_onSubmit",
+  "displayName": "index.qwik.mjs_GetForm_component_form_onSubmit",
   "hash": "p9MSze0ojs4",
-  "canonicalFilename": "getform_component_form_onsubmit_p9msze0ojs4",
+  "canonicalFilename": "index.qwik.mjs_getform_component_form_onsubmit_p9msze0ojs4",
   "path": "../node_modules/@builder.io/qwik-city",
   "extension": "mjs",
   "parent": "GetForm_component_Nk9PlpjQm9Y",
@@ -1855,7 +1855,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   ]
 }
 */
-============================= ../node_modules/@builder.io/qwik-city/getform_component_nk9plpjqm9y.mjs ==
+============================= ../node_modules/@builder.io/qwik-city/index.qwik.mjs_getform_component_nk9plpjqm9y.mjs ==
 
 import { Slot } from "@builder.io/qwik";
 import { _fnSignal } from "@builder.io/qwik";
@@ -1875,7 +1875,7 @@ export const GetForm_component_Nk9PlpjQm9Y = (props)=>{
     return /* @__PURE__ */ _jsxS('form', {
         ...rest,
         children: /* @__PURE__ */ _jsxC(Slot, null, 3, 'BC_0'),
-        onSubmit$: /*#__PURE__*/ qrl(()=>import("./getform_component_form_onsubmit_p9msze0ojs4.mjs"), "GetForm_component_form_onSubmit_p9MSze0ojs4", [
+        onSubmit$: /*#__PURE__*/ qrl(()=>import("./index.qwik.mjs_getform_component_form_onsubmit_p9msze0ojs4.mjs"), "GetForm_component_form_onSubmit_p9MSze0ojs4", [
             nav
         ])
     }, {
@@ -1896,9 +1896,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/node_modules/@builder.io/qwik-cit
   "origin": "../node_modules/@builder.io/qwik-city/index.qwik.mjs",
   "name": "GetForm_component_Nk9PlpjQm9Y",
   "entry": "../node_modules/@builder.io/qwik-city/index.qwik.mjs_entry_GetForm",
-  "displayName": "GetForm_component",
+  "displayName": "index.qwik.mjs_GetForm_component",
   "hash": "Nk9PlpjQm9Y",
-  "canonicalFilename": "getform_component_nk9plpjqm9y",
+  "canonicalFilename": "index.qwik.mjs_getform_component_nk9plpjqm9y",
   "path": "../node_modules/@builder.io/qwik-city",
   "extension": "mjs",
   "parent": null,
@@ -1926,7 +1926,7 @@ const DocumentHeadContext = /* @__PURE__ */ createContextId('qc-h');
 const RouteLocationContext = /* @__PURE__ */ createContextId('qc-l');
 const RouteNavigateContext = /* @__PURE__ */ createContextId('qc-n');
 const RouteActionContext = /* @__PURE__ */ createContextId('qc-a');
-const RouterOutlet = /* @__PURE__ */ componentQrl(/*#__PURE__*/ qrl(()=>import("./routeroutlet_component_aketnbye5tm.mjs"), "RouterOutlet_component_AKetNByE5TM"));
+const RouterOutlet = /* @__PURE__ */ componentQrl(/*#__PURE__*/ qrl(()=>import("./index.qwik.mjs_routeroutlet_component_aketnbye5tm.mjs"), "RouterOutlet_component_AKetNByE5TM"));
 const MODULE_CACHE = /* @__PURE__ */ new WeakMap();
 const CLIENT_DATA_CACHE = /* @__PURE__ */ new Map();
 const QACTION_KEY = 'qaction';
@@ -2193,9 +2193,9 @@ const useLocation = ()=>useContext(RouteLocationContext);
 const useNavigate = ()=>useContext(RouteNavigateContext);
 const useAction = ()=>useContext(RouteActionContext);
 const useQwikCityEnv = ()=>noSerialize(useServerData('qwikcity'));
-const QwikCityProvider = /* @__PURE__ */ componentQrl(/*#__PURE__*/ qrl(()=>import("./qwikcityprovider_component_txcfoy819ag.mjs"), "QwikCityProvider_component_TxCFOy819ag"));
-const QwikCityMockProvider = /* @__PURE__ */ componentQrl(/*#__PURE__*/ qrl(()=>import("./qwikcitymockprovider_component_wmyc5h00wti.mjs"), "QwikCityMockProvider_component_WmYC5H00wtI"));
-const Link = /* @__PURE__ */ componentQrl(/*#__PURE__*/ qrl(()=>import("./link_component_8gdlbszqbam.mjs"), "Link_component_8gdLBszqbaM"));
+const QwikCityProvider = /* @__PURE__ */ componentQrl(/*#__PURE__*/ qrl(()=>import("./index.qwik.mjs_qwikcityprovider_component_txcfoy819ag.mjs"), "QwikCityProvider_component_TxCFOy819ag"));
+const QwikCityMockProvider = /* @__PURE__ */ componentQrl(/*#__PURE__*/ qrl(()=>import("./index.qwik.mjs_qwikcitymockprovider_component_wmyc5h00wti.mjs"), "QwikCityMockProvider_component_WmYC5H00wtI"));
+const Link = /* @__PURE__ */ componentQrl(/*#__PURE__*/ qrl(()=>import("./index.qwik.mjs_link_component_8gdlbszqbam.mjs"), "Link_component_8gdLBszqbaM"));
 const prefetchLinkResources = (elm, isOnVisible)=>{
     if (elm && elm.href && elm.hasAttribute('data-prefetch')) {
         if (!windowInnerWidth) windowInnerWidth = innerWidth;
@@ -2233,7 +2233,7 @@ const routeActionQrl = (actionQrl, ...rest)=>{
             }
             return initialState;
         });
-        const submit = /*#__PURE__*/ qrl(()=>import("./routeactionqrl_action_submit_a5bzc7wo00a.mjs"), "routeActionQrl_action_submit_A5bZC7WO00A", [
+        const submit = /*#__PURE__*/ qrl(()=>import("./index.qwik.mjs_routeactionqrl_action_submit_a5bzc7wo00a.mjs"), "routeActionQrl_action_submit_A5bZC7WO00A", [
             currentAction,
             id,
             loc,
@@ -2316,7 +2316,7 @@ const serverQrl = (qrl1)=>{
         if (captured && captured.length > 0 && !_getContextElement()) throw new Error('For security reasons, we cannot serialize QRLs that capture lexical scope.');
     }
     function stuff() {
-        return /*#__PURE__*/ qrl(()=>import("./serverqrl_stuff_woipfiq04l4.mjs"), "serverQrl_stuff_wOIPfiQ04l4", [
+        return /*#__PURE__*/ qrl(()=>import("./index.qwik.mjs_serverqrl_stuff_woipfiq04l4.mjs"), "serverQrl_stuff_wOIPfiQ04l4", [
             qrl1
         ]);
     }
@@ -2416,7 +2416,7 @@ const Form = ({ action, spaReset, reloadDocument, onSubmit$, ...rest }, key)=>{
         ...rest
     }, 0, key);
 };
-const GetForm = /* @__PURE__ */ componentQrl(/*#__PURE__*/ qrl(()=>import("./getform_component_nk9plpjqm9y.mjs"), "GetForm_component_Nk9PlpjQm9Y"));
+const GetForm = /* @__PURE__ */ componentQrl(/*#__PURE__*/ qrl(()=>import("./index.qwik.mjs_getform_component_nk9plpjqm9y.mjs"), "GetForm_component_Nk9PlpjQm9Y"));
 export { Form, Link, QwikCityMockProvider, QwikCityProvider, RouterOutlet, ServiceWorkerRegister, globalAction$, globalActionQrl, routeAction$, routeActionQrl, routeLoader$, routeLoaderQrl, server$, serverQrl, useContent, useDocumentHead, useLocation, useNavigate, validator$, validatorQrl, z2 as z, zod$, zodQrl };
 export { CLIENT_DATA_CACHE as _auto_CLIENT_DATA_CACHE };
 export { ContentContext as _auto_ContentContext };

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_renamed_exports.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_renamed_exports.snap
@@ -20,11 +20,11 @@ export const App = Component((props) => {
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_nuxfthrjvxe"), "App_Component_NuXFTHRjvXE"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_nuxfthrjvxe"), "App_Component_NuXFTHRjvXE"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,wGAMhB\"}")
-============================= app_component_1_a08txhb9pek.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,iHAMhB\"}")
+============================= test.tsx_app_component_1_a08txhb9pek.js (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
 import { _fnSignal } from "@builder.io/qwik";
@@ -44,9 +44,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_Component_1_A08tXHb9pEk",
   "entry": null,
-  "displayName": "App_Component_1",
+  "displayName": "test.tsx_App_Component_1",
   "hash": "A08tXHb9pEk",
-  "canonicalFilename": "app_component_1_a08txhb9pek",
+  "canonicalFilename": "test.tsx_app_component_1_a08txhb9pek",
   "path": "",
   "extension": "js",
   "parent": "App_Component_NuXFTHRjvXE",
@@ -59,7 +59,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_nuxfthrjvxe.js (ENTRY POINT)==
+============================= test.tsx_app_component_nuxfthrjvxe.js (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 import { useStore } from "@builder.io/qwik";
@@ -67,7 +67,7 @@ export const App_Component_NuXFTHRjvXE = (props)=>{
     const state = useStore({
         thing: 0
     });
-    return /*#__PURE__*/ qrl(()=>import("./app_component_1_a08txhb9pek"), "App_Component_1_A08tXHb9pEk", [
+    return /*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_1_a08txhb9pek"), "App_Component_1_A08tXHb9pEk", [
         state
     ]);
 };
@@ -79,9 +79,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_Component_NuXFTHRjvXE",
   "entry": null,
-  "displayName": "App_Component",
+  "displayName": "test.tsx_App_Component",
   "hash": "NuXFTHRjvXE",
-  "canonicalFilename": "app_component_nuxfthrjvxe",
+  "canonicalFilename": "test.tsx_app_component_nuxfthrjvxe",
   "path": "",
   "extension": "js",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_server_auth.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_server_auth.snap
@@ -50,12 +50,12 @@ export const { onRequest, logout, getSession, signup } = auth$({
 import { serverAuthQrl } from "@auth/qwik";
 import { qrl } from "@builder.io/qwik";
 import { authQrl } from "@auth/qwik";
-export const { onRequest, logout, getSession, signup } = serverAuthQrl(/*#__PURE__*/ qrl(()=>import("./serverauth_qvqpx2a0p9y"), "serverAuth_qVqpX2a0p9Y"));
-export const { onRequest, logout, getSession, signup } = authQrl(/*#__PURE__*/ qrl(()=>import("./auth_gu0ay5qcety"), "auth_GU0aY5QCETY"));
+export const { onRequest, logout, getSession, signup } = serverAuthQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_serverauth_qvqpx2a0p9y"), "serverAuth_qVqpX2a0p9Y"));
+export const { onRequest, logout, getSession, signup } = authQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_auth_gu0ay5qcety"), "auth_GU0aY5QCETY"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;AAMA,OAAO,MAAM,EAAE,SAAS,EAAE,MAAM,EAAE,UAAU,EAAE,MAAM,EAAE,GAAG,mGAetD;AAEH,OAAO,MAAM,EAAE,SAAS,EAAE,MAAM,EAAE,UAAU,EAAE,MAAM,EAAE,GAAG,iFAetD\"}")
-============================= auth_gu0ay5qcety.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;AAMA,OAAO,MAAM,EAAE,SAAS,EAAE,MAAM,EAAE,UAAU,EAAE,MAAM,EAAE,GAAG,4GAetD;AAEH,OAAO,MAAM,EAAE,SAAS,EAAE,MAAM,EAAE,UAAU,EAAE,MAAM,EAAE,GAAG,0FAetD\"}")
+============================= test.tsx_auth_gu0ay5qcety.js (ENTRY POINT)==
 
 import Facebook from "next-auth/providers/facebook";
 import GitHub from "@auth/core/providers/github";
@@ -84,9 +84,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "auth_GU0aY5QCETY",
   "entry": null,
-  "displayName": "auth",
+  "displayName": "test.tsx_auth",
   "hash": "GU0aY5QCETY",
-  "canonicalFilename": "auth_gu0ay5qcety",
+  "canonicalFilename": "test.tsx_auth_gu0ay5qcety",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -99,7 +99,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= serverauth_qvqpx2a0p9y.js (ENTRY POINT)==
+============================= test.tsx_serverauth_qvqpx2a0p9y.js (ENTRY POINT)==
 
 import Facebook from "next-auth/providers/facebook";
 import GitHub from "@auth/core/providers/github";
@@ -128,9 +128,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "serverAuth_qVqpX2a0p9Y",
   "entry": null,
-  "displayName": "serverAuth",
+  "displayName": "test.tsx_serverAuth",
   "hash": "qVqpX2a0p9Y",
-  "canonicalFilename": "serverauth_qvqpx2a0p9y",
+  "canonicalFilename": "test.tsx_serverauth_qvqpx2a0p9y",
   "path": "",
   "extension": "js",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_spread_jsx.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_spread_jsx.snap
@@ -44,11 +44,11 @@ import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
 /**
  * The RouterHead component is placed inside of the document `<head>` element.
- */ export const RouterHead = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./routerhead_component_dpa76mgiou0"), "RouterHead_component_DPA76mgIou0"));
+ */ export const RouterHead = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_routerhead_component_dpa76mgiou0"), "RouterHead_component_DPA76mgIou0"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAIA;;CAEC,GACD,OAAO,MAAM,2BAAa,sHAyBvB\"}")
-============================= routerhead_component_dpa76mgiou0.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAIA;;CAEC,GACD,OAAO,MAAM,2BAAa,+HAyBvB\"}")
+============================= test.tsx_routerhead_component_dpa76mgiou0.js (ENTRY POINT)==
 
 import { Fragment as _Fragment } from "@builder.io/qwik/jsx-runtime";
 import { createElement as _createElement } from "@builder.io/qwik";
@@ -102,9 +102,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "RouterHead_component_DPA76mgIou0",
   "entry": null,
-  "displayName": "RouterHead_component",
+  "displayName": "test.tsx_RouterHead_component",
   "hash": "DPA76mgIou0",
-  "canonicalFilename": "routerhead_component_dpa76mgiou0",
+  "canonicalFilename": "test.tsx_routerhead_component_dpa76mgiou0",
   "path": "",
   "extension": "js",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_strip_exports_unused.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_strip_exports_unused.snap
@@ -29,11 +29,11 @@ import { qrl } from "@builder.io/qwik";
 export const onGet = ()=>{
     throw "Symbol removed by Qwik Optimizer, it can not be called from current platform";
 };
-export default /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test_component_luxexe0dqrg"), "test_component_LUXeXe0DQrg"));
+export default /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_test_component_luxexe0dqrg"), "test_component_LUXeXe0DQrg"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;aAIa;;;AASb,6BAAe,0GAEZ\"}")
-============================= test_component_luxexe0dqrg.tsx (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;aAIa;;;AASb,6BAAe,mHAEZ\"}")
+============================= test.tsx_test_component_luxexe0dqrg.tsx (ENTRY POINT)==
 
 export const test_component_LUXeXe0DQrg = ()=>{
     return <div>cmp</div>;
@@ -46,9 +46,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "test_component_LUXeXe0DQrg",
   "entry": null,
-  "displayName": "test_component",
+  "displayName": "test.tsx_test_component",
   "hash": "LUXeXe0DQrg",
-  "canonicalFilename": "test_component_luxexe0dqrg",
+  "canonicalFilename": "test.tsx_test_component_luxexe0dqrg",
   "path": "",
   "extension": "tsx",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_strip_exports_used.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_strip_exports_used.snap
@@ -25,7 +25,7 @@ export default component$(()=> {
     return <div>cmp</div>
 });
 
-============================= test_component_useresource_4a8wvy7wh38.tsx (ENTRY POINT)==
+============================= test.tsx_test_component_useresource_4a8wvy7wh38.tsx (ENTRY POINT)==
 
 import { onGet } from "./test";
 export const test_component_useResource_4a8wVY7wh38 = ()=>{
@@ -39,9 +39,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "test_component_useResource_4a8wVY7wh38",
   "entry": null,
-  "displayName": "test_component_useResource",
+  "displayName": "test.tsx_test_component_useResource",
   "hash": "4a8wVY7wh38",
-  "canonicalFilename": "test_component_useresource_4a8wvy7wh38",
+  "canonicalFilename": "test.tsx_test_component_useresource_4a8wvy7wh38",
   "path": "",
   "extension": "tsx",
   "parent": "test_component_LUXeXe0DQrg",
@@ -61,16 +61,16 @@ import { qrl } from "@builder.io/qwik";
 export const onGet = ()=>{
     throw "Symbol removed by Qwik Optimizer, it can not be called from current platform";
 };
-export default /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test_component_luxexe0dqrg"), "test_component_LUXeXe0DQrg"));
+export default /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_test_component_luxexe0dqrg"), "test_component_LUXeXe0DQrg"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;aAIa;;;AASb,6BAAe,0GAKZ\"}")
-============================= test_component_luxexe0dqrg.tsx (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;aAIa;;;AASb,6BAAe,mHAKZ\"}")
+============================= test.tsx_test_component_luxexe0dqrg.tsx (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 import { useResourceQrl } from "@builder.io/qwik";
 export const test_component_LUXeXe0DQrg = ()=>{
-    useResourceQrl(/*#__PURE__*/ qrl(()=>import("./test_component_useresource_4a8wvy7wh38"), "test_component_useResource_4a8wVY7wh38"));
+    useResourceQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_test_component_useresource_4a8wvy7wh38"), "test_component_useResource_4a8wVY7wh38"));
     return <div>cmp</div>;
 };
 
@@ -81,9 +81,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "test_component_LUXeXe0DQrg",
   "entry": null,
-  "displayName": "test_component",
+  "displayName": "test.tsx_test_component",
   "hash": "LUXeXe0DQrg",
-  "canonicalFilename": "test_component_luxexe0dqrg",
+  "canonicalFilename": "test.tsx_test_component_luxexe0dqrg",
   "path": "",
   "extension": "tsx",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_strip_server_code.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_strip_server_code.snap
@@ -48,7 +48,7 @@ export const Parent = component$(() => {
     );
 });
 
-============================= parent_component_usetask_gdh1etuwqbu.js (ENTRY POINT)==
+============================= test.tsx_parent_component_usetask_gdh1etuwqbu.js (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
 import { isServer } from "@builder.io/qwik/build";
@@ -69,9 +69,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Parent_component_useTask_gDH1EtUWqBU",
   "entry": null,
-  "displayName": "Parent_component_useTask",
+  "displayName": "test.tsx_Parent_component_useTask",
   "hash": "gDH1EtUWqBU",
-  "canonicalFilename": "parent_component_usetask_gdh1etuwqbu",
+  "canonicalFilename": "test.tsx_parent_component_usetask_gdh1etuwqbu",
   "path": "",
   "extension": "js",
   "parent": "Parent_component_0TaiDayHrlo",
@@ -88,11 +88,11 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Parent = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./parent_component_0taidayhrlo"), "Parent_component_0TaiDayHrlo"));
+export const Parent = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_parent_component_0taidayhrlo"), "Parent_component_0TaiDayHrlo"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAOA,OAAO,MAAM,uBAAS,8GAkCnB\"}")
-============================= parent_component_serverstuff_a_2ca3hldc7yc.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAOA,OAAO,MAAM,uBAAS,uHAkCnB\"}")
+============================= test.tsx_parent_component_serverstuff_a_2ca3hldc7yc.js (ENTRY POINT)==
 
 export const Parent_component_serverStuff_a_2ca3HLDC7yc = ()=>{
 // from $(), should not be removed
@@ -106,9 +106,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Parent_component_serverStuff_a_2ca3HLDC7yc",
   "entry": null,
-  "displayName": "Parent_component_serverStuff_a",
+  "displayName": "test.tsx_Parent_component_serverStuff_a",
   "hash": "2ca3HLDC7yc",
-  "canonicalFilename": "parent_component_serverstuff_a_2ca3hldc7yc",
+  "canonicalFilename": "test.tsx_parent_component_serverstuff_a_2ca3hldc7yc",
   "path": "",
   "extension": "js",
   "parent": "Parent_component_serverStuff_r1qAHX7Opp0",
@@ -121,7 +121,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= parent_component_serverstuff_b_client_v9qawr2inkk.js (ENTRY POINT)==
+============================= test.tsx_parent_component_serverstuff_b_client_v9qawr2inkk.js (ENTRY POINT)==
 
 export const Parent_component_serverStuff_b_client_v9qawr2Inkk = ()=>{
 // from clien$(), should not be removed
@@ -134,9 +134,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Parent_component_serverStuff_b_client_v9qawr2Inkk",
   "entry": null,
-  "displayName": "Parent_component_serverStuff_b_client",
+  "displayName": "test.tsx_Parent_component_serverStuff_b_client",
   "hash": "v9qawr2Inkk",
-  "canonicalFilename": "parent_component_serverstuff_b_client_v9qawr2inkk",
+  "canonicalFilename": "test.tsx_parent_component_serverstuff_b_client_v9qawr2inkk",
   "path": "",
   "extension": "js",
   "parent": "Parent_component_serverStuff_r1qAHX7Opp0",
@@ -149,7 +149,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= parent_component_0taidayhrlo.js (ENTRY POINT)==
+============================= test.tsx_parent_component_0taidayhrlo.js (ENTRY POINT)==
 
 import { _fnSignal } from "@builder.io/qwik";
 import { _jsxQ } from "@builder.io/qwik";
@@ -164,14 +164,14 @@ export const Parent_component_0TaiDayHrlo = ()=>{
         text: ''
     });
     // Double count watch
-    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./parent_component_usetask_gdh1etuwqbu"), "Parent_component_useTask_gDH1EtUWqBU", [
+    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_parent_component_usetask_gdh1etuwqbu"), "Parent_component_useTask_gDH1EtUWqBU", [
         state
     ]));
     serverStuffQrl(/*#__PURE__*/ _noopQrl("Parent_component_serverStuff_r1qAHX7Opp0"));
     serverLoaderQrl(/*#__PURE__*/ _noopQrl("Parent_component_serverLoader_k1L0DiPQV1I"));
-    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./parent_component_usetask_1_p8orqhhsurk"), "Parent_component_useTask_1_P8oRQhHsurk"));
+    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_parent_component_usetask_1_p8orqhhsurk"), "Parent_component_useTask_1_P8oRQhHsurk"));
     return /*#__PURE__*/ _jsxQ("div", null, {
-        onClick$: /*#__PURE__*/ qrl(()=>import("./parent_component_div_onclick_c5xe49nqd3a"), "Parent_component_div_onClick_C5XE49Nqd3A")
+        onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_parent_component_div_onclick_c5xe49nqd3a"), "Parent_component_div_onClick_C5XE49Nqd3A")
     }, _fnSignal((p0)=>p0.text, [
         state
     ], "p0.text"), 3, "u6_0");
@@ -184,9 +184,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Parent_component_0TaiDayHrlo",
   "entry": null,
-  "displayName": "Parent_component",
+  "displayName": "test.tsx_Parent_component",
   "hash": "0TaiDayHrlo",
-  "canonicalFilename": "parent_component_0taidayhrlo",
+  "canonicalFilename": "test.tsx_parent_component_0taidayhrlo",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -199,7 +199,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= parent_component_div_onclick_c5xe49nqd3a.js (ENTRY POINT)==
+============================= test.tsx_parent_component_div_onclick_c5xe49nqd3a.js (ENTRY POINT)==
 
 export const Parent_component_div_onClick_C5XE49Nqd3A = ()=>console.log('parent');
 
@@ -210,9 +210,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Parent_component_div_onClick_C5XE49Nqd3A",
   "entry": null,
-  "displayName": "Parent_component_div_onClick",
+  "displayName": "test.tsx_Parent_component_div_onClick",
   "hash": "C5XE49Nqd3A",
-  "canonicalFilename": "parent_component_div_onclick_c5xe49nqd3a",
+  "canonicalFilename": "test.tsx_parent_component_div_onclick_c5xe49nqd3a",
   "path": "",
   "extension": "js",
   "parent": "Parent_component_0TaiDayHrlo",
@@ -225,7 +225,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= parent_component_usetask_1_p8orqhhsurk.js (ENTRY POINT)==
+============================= test.tsx_parent_component_usetask_1_p8orqhhsurk.js (ENTRY POINT)==
 
 export const Parent_component_useTask_1_P8oRQhHsurk = ()=>{
 // Code
@@ -239,9 +239,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Parent_component_useTask_1_P8oRQhHsurk",
   "entry": null,
-  "displayName": "Parent_component_useTask_1",
+  "displayName": "test.tsx_Parent_component_useTask_1",
   "hash": "P8oRQhHsurk",
-  "canonicalFilename": "parent_component_usetask_1_p8orqhhsurk",
+  "canonicalFilename": "test.tsx_parent_component_usetask_1_p8orqhhsurk",
   "path": "",
   "extension": "js",
   "parent": "Parent_component_0TaiDayHrlo",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_transpile_jsx_only.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_transpile_jsx_only.snap
@@ -16,7 +16,7 @@ export const App = component$((props) => {
     );
 });
 
-============================= app_component_ckepmxzlub0.ts (ENTRY POINT)==
+============================= test.tsx_app_component_ckepmxzlub0.ts (ENTRY POINT)==
 
 import { _jsxC } from "@builder.io/qwik";
 import { _jsxQ } from "@builder.io/qwik";
@@ -25,7 +25,7 @@ export const App_component_ckEPmXZlub0 = (props)=>{
     return /*#__PURE__*/ _jsxC(Cmp, {
         children: /*#__PURE__*/ _jsxQ("p", null, {
             class: "stuff",
-            onClick$: /*#__PURE__*/ qrl(()=>import("./app_component_cmp_p_onclick_vuxzfutkpto.ts"), "App_component_Cmp_p_onClick_vuXzfUTkpto")
+            onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_cmp_p_onclick_vuxzfutkpto.ts"), "App_component_Cmp_p_onClick_vuXzfUTkpto")
         }, "Hello Qwik", 3, null)
     }, 3, "u6_0");
 };
@@ -37,9 +37,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "ts",
   "parent": null,
@@ -52,7 +52,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= app_component_cmp_p_onclick_vuxzfutkpto.ts (ENTRY POINT)==
+============================= test.tsx_app_component_cmp_p_onclick_vuxzfutkpto.ts (ENTRY POINT)==
 
 export const App_component_Cmp_p_onClick_vuXzfUTkpto = ()=>console.log('warn');
 
@@ -63,9 +63,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_Cmp_p_onClick_vuXzfUTkpto",
   "entry": null,
-  "displayName": "App_component_Cmp_p_onClick",
+  "displayName": "test.tsx_App_component_Cmp_p_onClick",
   "hash": "vuXzfUTkpto",
-  "canonicalFilename": "app_component_cmp_p_onclick_vuxzfutkpto",
+  "canonicalFilename": "test.tsx_app_component_cmp_p_onclick_vuxzfutkpto",
   "path": "",
   "extension": "ts",
   "parent": "App_component_ckEPmXZlub0",
@@ -82,10 +82,10 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_ckepmxzlub0.ts"), "App_component_ckEPmXZlub0"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0.ts"), "App_component_ckEPmXZlub0"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,2GAMhB\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,oHAMhB\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_ts_enums.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_ts_enums.snap
@@ -31,11 +31,11 @@ export let Thing;
     Thing[Thing["A"] = 0] = "A";
     Thing[Thing["B"] = 1] = "B";
 })(Thing || (Thing = {}));
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;UAGY;;;GAAA,UAAA;AAKZ,OAAO,MAAM,oBAAM,wGAOhB\"}")
-============================= app_component_ckepmxzlub0.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;UAGY;;;GAAA,UAAA;AAKZ,OAAO,MAAM,oBAAM,iHAOhB\"}")
+============================= test.tsx_app_component_ckepmxzlub0.js (ENTRY POINT)==
 
 import { Fragment as _Fragment } from "@builder.io/qwik/jsx-runtime";
 import { _jsxC } from "@builder.io/qwik";
@@ -56,9 +56,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "js",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_ts_enums_issue_1341.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_ts_enums_issue_1341.snap
@@ -31,11 +31,11 @@ let Thing;
     Thing[Thing["A"] = 0] = "A";
     Thing[Thing["B"] = 1] = "B";
 })(Thing || (Thing = {}));
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;UAGK;;;GAAA,UAAA;AAKL,OAAO,MAAM,oBAAM,wGAOhB\"}")
-============================= app_component_ckepmxzlub0.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;UAGK;;;GAAA,UAAA;AAKL,OAAO,MAAM,oBAAM,iHAOhB\"}")
+============================= test.tsx_app_component_ckepmxzlub0.js (ENTRY POINT)==
 
 import { Fragment as _Fragment } from "@builder.io/qwik/jsx-runtime";
 import { _jsxC } from "@builder.io/qwik";
@@ -56,9 +56,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "js",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_ts_enums_no_transpile.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_ts_enums_no_transpile.snap
@@ -30,11 +30,11 @@ export enum Thing {
     A,
     B
 }
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,YAAY;IACR;IACA;;AAGJ,OAAO,MAAM,oBAAM,wGAOhB\"}")
-============================= app_component_ckepmxzlub0.tsx (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,YAAY;IACR;IACA;;AAGJ,OAAO,MAAM,oBAAM,iHAOhB\"}")
+============================= test.tsx_app_component_ckepmxzlub0.tsx (ENTRY POINT)==
 
 import { Thing } from "./test";
 export const App_component_ckEPmXZlub0 = ()=>{
@@ -51,9 +51,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "tsx",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_use_client_effect.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_use_client_effect.snap
@@ -31,7 +31,7 @@ export const Child = component$(() => {
 });
 
 
-============================= child_component_usebrowservisibletask_0igfpoyjmqa.js (ENTRY POINT)==
+============================= test.tsx_child_component_usebrowservisibletask_0igfpoyjmqa.js (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
 export const Child_component_useBrowserVisibleTask_0IGFPOyJmQA = ()=>{
@@ -52,9 +52,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Child_component_useBrowserVisibleTask_0IGFPOyJmQA",
   "entry": null,
-  "displayName": "Child_component_useBrowserVisibleTask",
+  "displayName": "test.tsx_Child_component_useBrowserVisibleTask",
   "hash": "0IGFPOyJmQA",
-  "canonicalFilename": "child_component_usebrowservisibletask_0igfpoyjmqa",
+  "canonicalFilename": "test.tsx_child_component_usebrowservisibletask_0igfpoyjmqa",
   "path": "",
   "extension": "js",
   "parent": "Child_component_9GyF01GDKqw",
@@ -71,11 +71,11 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Child = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./child_component_9gyf01gdkqw"), "Child_component_9GyF01GDKqw"));
+export const Child = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_child_component_9gyf01gdkqw"), "Child_component_9GyF01GDKqw"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,sBAAQ,4GAoBlB\"}")
-============================= child_component_9gyf01gdkqw.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,sBAAQ,qHAoBlB\"}")
+============================= test.tsx_child_component_9gyf01gdkqw.js (ENTRY POINT)==
 
 import { _fnSignal } from "@builder.io/qwik";
 import { _jsxQ } from "@builder.io/qwik";
@@ -87,7 +87,7 @@ export const Child_component_9GyF01GDKqw = ()=>{
         count: 0
     });
     // Double count watch
-    useBrowserVisibleTaskQrl(/*#__PURE__*/ qrl(()=>import("./child_component_usebrowservisibletask_0igfpoyjmqa"), "Child_component_useBrowserVisibleTask_0IGFPOyJmQA", [
+    useBrowserVisibleTaskQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_child_component_usebrowservisibletask_0igfpoyjmqa"), "Child_component_useBrowserVisibleTask_0IGFPOyJmQA", [
         state
     ]));
     return /*#__PURE__*/ _jsxQ("div", null, null, _fnSignal((p0)=>p0.count, [
@@ -102,9 +102,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Child_component_9GyF01GDKqw",
   "entry": null,
-  "displayName": "Child_component",
+  "displayName": "test.tsx_Child_component",
   "hash": "9GyF01GDKqw",
-  "canonicalFilename": "child_component_9gyf01gdkqw",
+  "canonicalFilename": "test.tsx_child_component_9gyf01gdkqw",
   "path": "",
   "extension": "js",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_use_server_mount.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_use_server_mount.snap
@@ -45,7 +45,7 @@ export const Child = component$(() => {
     );
 });
 
-============================= parent_component_usetask_gdh1etuwqbu.js ==
+============================= test.tsx_parent_component_usetask_gdh1etuwqbu.js ==
 
 import { useLexicalScope } from "@builder.io/qwik";
 import mongo from "mongodb";
@@ -64,9 +64,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Parent_component_useTask_gDH1EtUWqBU",
   "entry": "test.tsx_entry_Parent",
-  "displayName": "Parent_component_useTask",
+  "displayName": "test.tsx_Parent_component_useTask",
   "hash": "gDH1EtUWqBU",
-  "canonicalFilename": "parent_component_usetask_gdh1etuwqbu",
+  "canonicalFilename": "test.tsx_parent_component_usetask_gdh1etuwqbu",
   "path": "",
   "extension": "js",
   "parent": "Parent_component_0TaiDayHrlo",
@@ -83,12 +83,12 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Parent = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./parent_component_0taidayhrlo"), "Parent_component_0TaiDayHrlo"));
-export const Child = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./child_component_9gyf01gdkqw"), "Child_component_9GyF01GDKqw"));
+export const Parent = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_parent_component_0taidayhrlo"), "Parent_component_0TaiDayHrlo"));
+export const Child = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_child_component_9gyf01gdkqw"), "Child_component_9GyF01GDKqw"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAKA,OAAO,MAAM,uBAAS,8GAgBnB;AAEH,OAAO,MAAM,sBAAQ,4GAelB\"}")
-============================= child_component_usetask_oh4n7zeqjku.js ==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAKA,OAAO,MAAM,uBAAS,uHAgBnB;AAEH,OAAO,MAAM,sBAAQ,qHAelB\"}")
+============================= test.tsx_child_component_usetask_oh4n7zeqjku.js ==
 
 import { useLexicalScope } from "@builder.io/qwik";
 import mongo from "mongodb";
@@ -105,9 +105,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Child_component_useTask_Oh4n7ZeqJkU",
   "entry": "test.tsx_entry_Child",
-  "displayName": "Child_component_useTask",
+  "displayName": "test.tsx_Child_component_useTask",
   "hash": "Oh4n7ZeqJkU",
-  "canonicalFilename": "child_component_usetask_oh4n7zeqjku",
+  "canonicalFilename": "test.tsx_child_component_usetask_oh4n7zeqjku",
   "path": "",
   "extension": "js",
   "parent": "Child_component_9GyF01GDKqw",
@@ -120,7 +120,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= parent_component_0taidayhrlo.js ==
+============================= test.tsx_parent_component_0taidayhrlo.js ==
 
 import { _fnSignal } from "@builder.io/qwik";
 import { _jsxQ } from "@builder.io/qwik";
@@ -132,11 +132,11 @@ export const Parent_component_0TaiDayHrlo = ()=>{
         text: ''
     });
     // Double count watch
-    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./parent_component_usetask_gdh1etuwqbu"), "Parent_component_useTask_gDH1EtUWqBU", [
+    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_parent_component_usetask_gdh1etuwqbu"), "Parent_component_useTask_gDH1EtUWqBU", [
         state
     ]));
     return /*#__PURE__*/ _jsxQ("div", null, {
-        onClick$: /*#__PURE__*/ qrl(()=>import("./parent_component_div_onclick_c5xe49nqd3a"), "Parent_component_div_onClick_C5XE49Nqd3A")
+        onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_parent_component_div_onclick_c5xe49nqd3a"), "Parent_component_div_onClick_C5XE49Nqd3A")
     }, _fnSignal((p0)=>p0.text, [
         state
     ], "p0.text"), 3, "u6_0");
@@ -149,9 +149,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Parent_component_0TaiDayHrlo",
   "entry": "test.tsx_entry_Parent",
-  "displayName": "Parent_component",
+  "displayName": "test.tsx_Parent_component",
   "hash": "0TaiDayHrlo",
-  "canonicalFilename": "parent_component_0taidayhrlo",
+  "canonicalFilename": "test.tsx_parent_component_0taidayhrlo",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -164,7 +164,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= parent_component_div_onclick_c5xe49nqd3a.js (ENTRY POINT)==
+============================= test.tsx_parent_component_div_onclick_c5xe49nqd3a.js (ENTRY POINT)==
 
 export const Parent_component_div_onClick_C5XE49Nqd3A = ()=>console.log('parent');
 
@@ -175,9 +175,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Parent_component_div_onClick_C5XE49Nqd3A",
   "entry": null,
-  "displayName": "Parent_component_div_onClick",
+  "displayName": "test.tsx_Parent_component_div_onClick",
   "hash": "C5XE49Nqd3A",
-  "canonicalFilename": "parent_component_div_onclick_c5xe49nqd3a",
+  "canonicalFilename": "test.tsx_parent_component_div_onclick_c5xe49nqd3a",
   "path": "",
   "extension": "js",
   "parent": "Parent_component_0TaiDayHrlo",
@@ -190,7 +190,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= child_component_9gyf01gdkqw.js ==
+============================= test.tsx_child_component_9gyf01gdkqw.js ==
 
 import { _fnSignal } from "@builder.io/qwik";
 import { _jsxQ } from "@builder.io/qwik";
@@ -202,11 +202,11 @@ export const Child_component_9GyF01GDKqw = ()=>{
         text: ''
     });
     // Double count watch
-    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./child_component_usetask_oh4n7zeqjku"), "Child_component_useTask_Oh4n7ZeqJkU", [
+    useTaskQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_child_component_usetask_oh4n7zeqjku"), "Child_component_useTask_Oh4n7ZeqJkU", [
         state
     ]));
     return /*#__PURE__*/ _jsxQ("div", null, {
-        onClick$: /*#__PURE__*/ qrl(()=>import("./child_component_div_onclick_ellivsnaioq"), "Child_component_div_onClick_elliVSnAiOQ")
+        onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_child_component_div_onclick_ellivsnaioq"), "Child_component_div_onClick_elliVSnAiOQ")
     }, _fnSignal((p0)=>p0.text, [
         state
     ], "p0.text"), 3, "u6_1");
@@ -219,9 +219,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Child_component_9GyF01GDKqw",
   "entry": "test.tsx_entry_Child",
-  "displayName": "Child_component",
+  "displayName": "test.tsx_Child_component",
   "hash": "9GyF01GDKqw",
-  "canonicalFilename": "child_component_9gyf01gdkqw",
+  "canonicalFilename": "test.tsx_child_component_9gyf01gdkqw",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -234,7 +234,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= child_component_div_onclick_ellivsnaioq.js (ENTRY POINT)==
+============================= test.tsx_child_component_div_onclick_ellivsnaioq.js (ENTRY POINT)==
 
 export const Child_component_div_onClick_elliVSnAiOQ = ()=>console.log('child');
 
@@ -245,9 +245,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Child_component_div_onClick_elliVSnAiOQ",
   "entry": null,
-  "displayName": "Child_component_div_onClick",
+  "displayName": "test.tsx_Child_component_div_onClick",
   "hash": "elliVSnAiOQ",
-  "canonicalFilename": "child_component_div_onclick_ellivsnaioq",
+  "canonicalFilename": "test.tsx_child_component_div_onclick_ellivsnaioq",
   "path": "",
   "extension": "js",
   "parent": "Child_component_9GyF01GDKqw",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_with_style.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_with_style.snap
@@ -17,7 +17,7 @@ export const Foo = component$(() => {
     tagName: "my-foo",
 });
 
-============================= foo_component_usestyles_pv9tscbihw8.tsx (ENTRY POINT)==
+============================= test.tsx_foo_component_usestyles_pv9tscbihw8.tsx (ENTRY POINT)==
 
 export const Foo_component_useStyles_pV9TSCBIhw8 = '.class {}';
 
@@ -28,9 +28,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_useStyles_pV9TSCBIhw8",
   "entry": null,
-  "displayName": "Foo_component_useStyles",
+  "displayName": "test.tsx_Foo_component_useStyles",
   "hash": "pV9TSCBIhw8",
-  "canonicalFilename": "foo_component_usestyles_pv9tscbihw8",
+  "canonicalFilename": "test.tsx_foo_component_usestyles_pv9tscbihw8",
   "path": "",
   "extension": "tsx",
   "parent": "Foo_component_HTDRsvUbLiE",
@@ -43,12 +43,12 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= foo_component_htdrsvublie.tsx (ENTRY POINT)==
+============================= test.tsx_foo_component_htdrsvublie.tsx (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 import { useStylesQrl } from "@builder.io/qwik";
 export const Foo_component_HTDRsvUbLiE = ()=>{
-    useStylesQrl(/*#__PURE__*/ qrl(()=>import("./foo_component_usestyles_pv9tscbihw8"), "Foo_component_useStyles_pV9TSCBIhw8"));
+    useStylesQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_usestyles_pv9tscbihw8"), "Foo_component_useStyles_pV9TSCBIhw8"));
     return <div class="class"/>;
 };
 
@@ -59,9 +59,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_HTDRsvUbLiE",
   "entry": null,
-  "displayName": "Foo_component",
+  "displayName": "test.tsx_Foo_component",
   "hash": "HTDRsvUbLiE",
-  "canonicalFilename": "foo_component_htdrsvublie",
+  "canonicalFilename": "test.tsx_foo_component_htdrsvublie",
   "path": "",
   "extension": "tsx",
   "parent": null,
@@ -78,12 +78,12 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Foo = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./foo_component_htdrsvublie"), "Foo_component_HTDRsvUbLiE"), {
+export const Foo = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_htdrsvublie"), "Foo_component_HTDRsvUbLiE"), {
     tagName: "my-foo"
 });
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,wGAKhB;IACC,SAAS;AACb,GAAG\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,iHAKhB;IACC,SAAS;AACb,GAAG\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_with_tagname.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_with_tagname.snap
@@ -19,11 +19,11 @@ export const Foo = component$(() => {
     tagName: "my-foo",
 });
 
-============================= foo_component_htdrsvublie.tsx (ENTRY POINT)==
+============================= test.tsx_foo_component_htdrsvublie.tsx (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 export const Foo_component_HTDRsvUbLiE = ()=>{
-    return /*#__PURE__*/ qrl(()=>import("./foo_component_1_dvu6fitwgly"), "Foo_component_1_DvU6FitWglY");
+    return /*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_1_dvu6fitwgly"), "Foo_component_1_DvU6FitWglY");
 };
 
 
@@ -33,9 +33,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_HTDRsvUbLiE",
   "entry": null,
-  "displayName": "Foo_component",
+  "displayName": "test.tsx_Foo_component",
   "hash": "HTDRsvUbLiE",
-  "canonicalFilename": "foo_component_htdrsvublie",
+  "canonicalFilename": "test.tsx_foo_component_htdrsvublie",
   "path": "",
   "extension": "tsx",
   "parent": null,
@@ -48,7 +48,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= foo_component_1_dvu6fitwgly.tsx (ENTRY POINT)==
+============================= test.tsx_foo_component_1_dvu6fitwgly.tsx (ENTRY POINT)==
 
 export const Foo_component_1_DvU6FitWglY = ()=>{
     return <div>
@@ -63,9 +63,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Foo_component_1_DvU6FitWglY",
   "entry": null,
-  "displayName": "Foo_component_1",
+  "displayName": "test.tsx_Foo_component_1",
   "hash": "DvU6FitWglY",
-  "canonicalFilename": "foo_component_1_dvu6fitwgly",
+  "canonicalFilename": "test.tsx_foo_component_1_dvu6fitwgly",
   "path": "",
   "extension": "tsx",
   "parent": "Foo_component_HTDRsvUbLiE",
@@ -82,12 +82,12 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Foo = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./foo_component_htdrsvublie"), "Foo_component_HTDRsvUbLiE"), {
+export const Foo = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_foo_component_htdrsvublie"), "Foo_component_HTDRsvUbLiE"), {
     tagName: "my-foo"
 });
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,wGAOhB;IACC,SAAS;AACb,GAAG\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,iHAOhB;IACC,SAAS;AACb,GAAG\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__issue_150.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__issue_150.snap
@@ -30,12 +30,12 @@ const d = $(()=>console.log('thing'));
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Greeter = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./greeter_component_n7hug2hhu0q"), "Greeter_component_n7HuG2hhU0Q"));
-/*#__PURE__*/ qrl(()=>import("./d_wknfjeiqvua"), "d_wKNFJEIQVUA");
+export const Greeter = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_greeter_component_n7hug2hhu0q"), "Greeter_component_n7HuG2hhU0Q"));
+/*#__PURE__*/ qrl(()=>import("./test.tsx_d_wknfjeiqvua"), "d_wKNFJEIQVUA");
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAIA,OAAO,MAAM,wBAAU,gHAapB\"}")
-============================= d_wknfjeiqvua.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAIA,OAAO,MAAM,wBAAU,yHAapB\"}")
+============================= test.tsx_d_wknfjeiqvua.js (ENTRY POINT)==
 
 export const d_wKNFJEIQVUA = ()=>console.log('thing');
 export { _hW } from "@builder.io/qwik";
@@ -47,9 +47,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "d_wKNFJEIQVUA",
   "entry": null,
-  "displayName": "d",
+  "displayName": "test.tsx_d",
   "hash": "wKNFJEIQVUA",
-  "canonicalFilename": "d_wknfjeiqvua",
+  "canonicalFilename": "test.tsx_d_wknfjeiqvua",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -62,7 +62,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= greeter_component_1_krcndswhx4u.js (ENTRY POINT)==
+============================= test.tsx_greeter_component_1_krcndswhx4u.js (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
 import { _jsxQ } from "@builder.io/qwik";
@@ -86,9 +86,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Greeter_component_1_krCndSwhX4U",
   "entry": null,
-  "displayName": "Greeter_component_1",
+  "displayName": "test.tsx_Greeter_component_1",
   "hash": "krCndSwhX4U",
-  "canonicalFilename": "greeter_component_1_krcndswhx4u",
+  "canonicalFilename": "test.tsx_greeter_component_1_krcndswhx4u",
   "path": "",
   "extension": "js",
   "parent": "Greeter_component_n7HuG2hhU0Q",
@@ -101,12 +101,12 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= greeter_component_n7hug2hhu0q.js (ENTRY POINT)==
+============================= test.tsx_greeter_component_n7hug2hhu0q.js (ENTRY POINT)==
 
 import { qrl } from "@builder.io/qwik";
 export const Greeter_component_n7HuG2hhU0Q = ()=>{
     const stuff = useStore();
-    return /*#__PURE__*/ qrl(()=>import("./greeter_component_1_krcndswhx4u"), "Greeter_component_1_krCndSwhX4U", [
+    return /*#__PURE__*/ qrl(()=>import("./test.tsx_greeter_component_1_krcndswhx4u"), "Greeter_component_1_krCndSwhX4U", [
         stuff
     ]);
 };
@@ -118,9 +118,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Greeter_component_n7HuG2hhU0Q",
   "entry": null,
-  "displayName": "Greeter_component",
+  "displayName": "test.tsx_Greeter_component",
   "hash": "n7HuG2hhU0Q",
-  "canonicalFilename": "greeter_component_n7hug2hhu0q",
+  "canonicalFilename": "test.tsx_greeter_component_n7hug2hhu0q",
   "path": "",
   "extension": "js",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__issue_5008.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__issue_5008.snap
@@ -27,11 +27,11 @@ expression: output
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export default /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test_component_luxexe0dqrg"), "test_component_LUXeXe0DQrg"));
+export default /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_test_component_luxexe0dqrg"), "test_component_LUXeXe0DQrg"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGQ,6BAAe,0GAaZ\"}")
-============================= test_component_luxexe0dqrg.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGQ,6BAAe,mHAaZ\"}")
+============================= test.tsx_test_component_luxexe0dqrg.js (ENTRY POINT)==
 
 import { Fragment as _Fragment } from "@builder.io/qwik/jsx-runtime";
 import { _jsxC } from "@builder.io/qwik";
@@ -48,7 +48,7 @@ export const test_component_LUXeXe0DQrg = ()=>{
     return /*#__PURE__*/ _jsxC(_Fragment, {
         children: [
             /*#__PURE__*/ _jsxQ("button", null, {
-                onClick$: /*#__PURE__*/ qrl(()=>import("./test_component_fragment_button_onclick_ef3qezgqwcy"), "test_component_Fragment_button_onClick_eF3QEzgQWcY", [
+                onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_test_component_fragment_button_onclick_ef3qezgqwcy"), "test_component_Fragment_button_onClick_eF3QEzgQWcY", [
                     store
                 ])
             }, "+1", 3, null),
@@ -73,9 +73,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "test_component_LUXeXe0DQrg",
   "entry": null,
-  "displayName": "test_component",
+  "displayName": "test.tsx_test_component",
   "hash": "LUXeXe0DQrg",
-  "canonicalFilename": "test_component_luxexe0dqrg",
+  "canonicalFilename": "test.tsx_test_component_luxexe0dqrg",
   "path": "",
   "extension": "js",
   "parent": null,
@@ -88,7 +88,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= test_component_fragment_button_onclick_ef3qezgqwcy.js (ENTRY POINT)==
+============================= test.tsx_test_component_fragment_button_onclick_ef3qezgqwcy.js (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
 export const test_component_Fragment_button_onClick_eF3QEzgQWcY = ()=>{
@@ -103,9 +103,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "test_component_Fragment_button_onClick_eF3QEzgQWcY",
   "entry": null,
-  "displayName": "test_component_Fragment_button_onClick",
+  "displayName": "test.tsx_test_component_Fragment_button_onClick",
   "hash": "eF3QEzgQWcY",
-  "canonicalFilename": "test_component_fragment_button_onclick_ef3qezgqwcy",
+  "canonicalFilename": "test.tsx_test_component_fragment_button_onclick_ef3qezgqwcy",
   "path": "",
   "extension": "js",
   "parent": "test_component_LUXeXe0DQrg",

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__issue_964.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__issue_964.snap
@@ -20,11 +20,11 @@ export const App = component$(() => {
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,wGAMhB\"}")
-============================= app_component_ckepmxzlub0.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,iHAMhB\"}")
+============================= test.tsx_app_component_ckepmxzlub0.js (ENTRY POINT)==
 
 import { _jsxQ } from "@builder.io/qwik";
 export const App_component_ckEPmXZlub0 = ()=>{
@@ -41,9 +41,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "App_component_ckEPmXZlub0",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "test.tsx_App_component",
   "hash": "ckEPmXZlub0",
-  "canonicalFilename": "app_component_ckepmxzlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
   "path": "",
   "extension": "js",
   "parent": null,

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__lib_mode_fn_signal.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__lib_mode_fn_signal.snap
@@ -20,7 +20,7 @@ export const Counter = component$(() => {
   );
 });
 
-============================= counter_component_ztmrhll09gg.ts (ENTRY POINT)==
+============================= test.tsx_counter_component_ztmrhll09gg.ts (ENTRY POINT)==
 
 import { _fnSignal } from "@builder.io/qwik";
 import { _jsxQ } from "@builder.io/qwik";
@@ -35,7 +35,7 @@ export const Counter_component_zTmRHlL09Gg = ()=>{
             ], "p0.value")
         ], 3, null),
         /*#__PURE__*/ _jsxQ("p", null, null, /*#__PURE__*/ _jsxQ("button", null, {
-            onClick$: /*#__PURE__*/ qrl(()=>import("./counter_component_div_p_button_onclick_kqq00u8qaim"), "Counter_component_div_p_button_onClick_Kqq00U8qaIM", [
+            onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_counter_component_div_p_button_onclick_kqq00u8qaim"), "Counter_component_div_p_button_onClick_Kqq00U8qaIM", [
                 count
             ])
         }, "Increment", 3, null), 3, null)
@@ -49,9 +49,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Counter_component_zTmRHlL09Gg",
   "entry": null,
-  "displayName": "Counter_component",
+  "displayName": "test.tsx_Counter_component",
   "hash": "zTmRHlL09Gg",
-  "canonicalFilename": "counter_component_ztmrhll09gg",
+  "canonicalFilename": "test.tsx_counter_component_ztmrhll09gg",
   "path": "",
   "extension": "ts",
   "parent": null,
@@ -64,7 +64,7 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= counter_component_div_p_button_onclick_kqq00u8qaim.ts (ENTRY POINT)==
+============================= test.tsx_counter_component_div_p_button_onclick_kqq00u8qaim.ts (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
 export const Counter_component_div_p_button_onClick_Kqq00U8qaIM = ()=>{
@@ -79,9 +79,9 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "origin": "test.tsx",
   "name": "Counter_component_div_p_button_onClick_Kqq00U8qaIM",
   "entry": null,
-  "displayName": "Counter_component_div_p_button_onClick",
+  "displayName": "test.tsx_Counter_component_div_p_button_onClick",
   "hash": "Kqq00U8qaIM",
-  "canonicalFilename": "counter_component_div_p_button_onclick_kqq00u8qaim",
+  "canonicalFilename": "test.tsx_counter_component_div_p_button_onclick_kqq00u8qaim",
   "path": "",
   "extension": "ts",
   "parent": "Counter_component_zTmRHlL09Gg",
@@ -98,10 +98,10 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Counter = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./counter_component_ztmrhll09gg"), "Counter_component_zTmRHlL09Gg"));
+export const Counter = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_counter_component_ztmrhll09gg"), "Counter_component_zTmRHlL09Gg"));
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAEA,OAAO,MAAM,wBAAU,gHAWpB\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAEA,OAAO,MAAM,wBAAU,yHAWpB\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__relative_paths.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__relative_paths.snap
@@ -3,7 +3,7 @@ source: packages/qwik/src/optimizer/core/src/test.rs
 assertion_line: 3302
 expression: output
 ---
-============================= ../../node_modules/dep/dist/app_component_div_p_button_onclick_8dwua0cjar4.js (ENTRY POINT)==
+============================= ../../node_modules/dep/dist/lib.mjs_app_component_div_p_button_onclick_8dwua0cjar4.js (ENTRY POINT)==
 
 import { useLexicalScope } from "@builder.io/qwik";
 export const App_component_div_p_button_onClick_8dWUa0cJAr4 = ()=>{
@@ -18,9 +18,9 @@ Some("{\"version\":3,\"sources\":[\"node_modules/dep/dist/lib.mjs\"],\"sourceRoo
   "origin": "../../node_modules/dep/dist/lib.mjs",
   "name": "App_component_div_p_button_onClick_8dWUa0cJAr4",
   "entry": null,
-  "displayName": "App_component_div_p_button_onClick",
+  "displayName": "lib.mjs_App_component_div_p_button_onClick",
   "hash": "8dWUa0cJAr4",
-  "canonicalFilename": "app_component_div_p_button_onclick_8dwua0cjar4",
+  "canonicalFilename": "lib.mjs_app_component_div_p_button_onclick_8dwua0cjar4",
   "path": "../../node_modules/dep/dist",
   "extension": "js",
   "parent": "App_component_AkbU84a8zes",
@@ -33,7 +33,7 @@ Some("{\"version\":3,\"sources\":[\"node_modules/dep/dist/lib.mjs\"],\"sourceRoo
   ]
 }
 */
-============================= ../../node_modules/dep/dist/app_component_akbu84a8zes.js (ENTRY POINT)==
+============================= ../../node_modules/dep/dist/lib.mjs_app_component_akbu84a8zes.js (ENTRY POINT)==
 
 import { _fnSignal } from "@builder.io/qwik";
 import { _jsxQ } from "@builder.io/qwik";
@@ -49,7 +49,7 @@ export const App_component_AkbU84a8zes = ()=>{
             ], "p0.count")
         ], 3, null),
         /*#__PURE__*/ _jsxQ("p", null, null, /*#__PURE__*/ _jsxQ("button", {
-            onClick$: /*#__PURE__*/ qrl(()=>import("./app_component_div_p_button_onclick_8dwua0cjar4.js"), "App_component_div_p_button_onClick_8dWUa0cJAr4", [
+            onClick$: /*#__PURE__*/ qrl(()=>import("./lib.mjs_app_component_div_p_button_onclick_8dwua0cjar4.js"), "App_component_div_p_button_onClick_8dWUa0cJAr4", [
                 store
             ])
         }, null, "Click", 2, null), 1, null)
@@ -63,9 +63,9 @@ Some("{\"version\":3,\"sources\":[\"node_modules/dep/dist/lib.mjs\"],\"sourceRoo
   "origin": "../../node_modules/dep/dist/lib.mjs",
   "name": "App_component_AkbU84a8zes",
   "entry": null,
-  "displayName": "App_component",
+  "displayName": "lib.mjs_App_component",
   "hash": "AkbU84a8zes",
-  "canonicalFilename": "app_component_akbu84a8zes",
+  "canonicalFilename": "lib.mjs_app_component_akbu84a8zes",
   "path": "../../node_modules/dep/dist",
   "extension": "js",
   "parent": null,
@@ -87,12 +87,12 @@ const useData = ()=>{
         count: 0
     });
 };
-export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./app_component_akbu84a8zes.js"), "App_component_AkbU84a8zes"));
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./lib.mjs_app_component_akbu84a8zes.js"), "App_component_AkbU84a8zes"));
 export { useData as _auto_useData };
 
 
-Some("{\"version\":3,\"sources\":[\"node_modules/dep/dist/lib.mjs\"],\"sourceRoot\":\"/path/to/app/\",\"names\":[],\"mappings\":\";AACA,SAAS,YAAY,EAAc,QAAQ,QAAyB,mBAAmB;AAIvF,MAAM,UAAU;IACZ,OAAO,SAAS;QACZ,OAAO;IACX;AACJ;AAEA,OAAO,MAAM,MAAM,WAAW,GAAG,2GAuBA\"}")
-============================= components/local_component_jj0v28bs0p8.js (ENTRY POINT)==
+Some("{\"version\":3,\"sources\":[\"node_modules/dep/dist/lib.mjs\"],\"sourceRoot\":\"/path/to/app/\",\"names\":[],\"mappings\":\";AACA,SAAS,YAAY,EAAc,QAAQ,QAAyB,mBAAmB;AAIvF,MAAM,UAAU;IACZ,OAAO,SAAS;QACZ,OAAO;IACX;AACJ;AAEA,OAAO,MAAM,MAAM,WAAW,GAAG,mHAuBA\"}")
+============================= components/main.tsx_local_component_jj0v28bs0p8.js (ENTRY POINT)==
 
 import { _jsxQ } from "@builder.io/qwik";
 import { state } from "./sibling";
@@ -107,9 +107,9 @@ Some("{\"version\":3,\"sources\":[\"src/thing/components/main.tsx\"],\"sourceRoo
   "origin": "components/main.tsx",
   "name": "Local_component_jJ0v28bs0p8",
   "entry": null,
-  "displayName": "Local_component",
+  "displayName": "main.tsx_Local_component",
   "hash": "jJ0v28bs0p8",
-  "canonicalFilename": "local_component_jj0v28bs0p8",
+  "canonicalFilename": "main.tsx_local_component_jj0v28bs0p8",
   "path": "components",
   "extension": "js",
   "parent": null,
@@ -126,10 +126,10 @@ Some("{\"version\":3,\"sources\":[\"src/thing/components/main.tsx\"],\"sourceRoo
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Local = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./local_component_jj0v28bs0p8.js"), "Local_component_jJ0v28bs0p8"));
+export const Local = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./main.tsx_local_component_jj0v28bs0p8.js"), "Local_component_jJ0v28bs0p8"));
 
 
-Some("{\"version\":3,\"sources\":[\"src/thing/components/main.tsx\"],\"sourceRoot\":\"/path/to/app/\",\"names\":[],\"mappings\":\";;AAIA,OAAO,MAAM,sBAAQ,+GAIlB\"}")
+Some("{\"version\":3,\"sources\":[\"src/thing/components/main.tsx\"],\"sourceRoot\":\"/path/to/app/\",\"names\":[],\"mappings\":\";;AAIA,OAAO,MAAM,sBAAQ,wHAIlB\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__support_windows_paths.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__support_windows_paths.snap
@@ -9,7 +9,7 @@ expression: output
 import { component$ } from '@builder.io/qwik';
 export const Greeter = component$(() => <div/>)
 
-============================= components/apps/greeter_component_0jjovx068y0.ts (ENTRY POINT)==
+============================= components/apps/apps.tsx_greeter_component_0jjovx068y0.ts (ENTRY POINT)==
 
 import { _jsxQ } from "@builder.io/qwik";
 export const Greeter_component_0jjOvx068y0 = ()=>/*#__PURE__*/ _jsxQ("div", null, null, null, 3, "KD_0");
@@ -21,9 +21,9 @@ Some("{\"version\":3,\"sources\":[\"C:\\\\users\\\\apps/components/apps/apps.tsx
   "origin": "components/apps/apps.tsx",
   "name": "Greeter_component_0jjOvx068y0",
   "entry": null,
-  "displayName": "Greeter_component",
+  "displayName": "apps.tsx_Greeter_component",
   "hash": "0jjOvx068y0",
-  "canonicalFilename": "greeter_component_0jjovx068y0",
+  "canonicalFilename": "apps.tsx_greeter_component_0jjovx068y0",
   "path": "components/apps",
   "extension": "ts",
   "parent": null,
@@ -40,10 +40,10 @@ Some("{\"version\":3,\"sources\":[\"C:\\\\users\\\\apps/components/apps/apps.tsx
 
 import { componentQrl } from "@builder.io/qwik";
 import { qrl } from "@builder.io/qwik";
-export const Greeter = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./greeter_component_0jjovx068y0"), "Greeter_component_0jjOvx068y0"));
+export const Greeter = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./apps.tsx_greeter_component_0jjovx068y0"), "Greeter_component_0jjOvx068y0"));
 
 
-Some("{\"version\":3,\"sources\":[\"C:\\\\users\\\\apps/components/apps/apps.tsx\"],\"names\":[],\"mappings\":\";;AAEA,OAAO,MAAM,wBAAU,gHAAwB\"}")
+Some("{\"version\":3,\"sources\":[\"C:\\\\users\\\\apps/components/apps/apps.tsx\"],\"names\":[],\"mappings\":\";;AAEA,OAAO,MAAM,wBAAU,yHAAwB\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/qwik/src/optimizer/core/src/transform.rs
+++ b/packages/qwik/src/optimizer/core/src/transform.rs
@@ -340,6 +340,7 @@ impl<'a> QwikTransform<'a> {
 		} else {
 			format!("s_{}", hash64)
 		};
+		display_name = format!("{}_{}", &self.options.path_data.file_name, display_name);
 		(
 			JsWord::from(symbol_name),
 			JsWord::from(display_name),
@@ -348,6 +349,7 @@ impl<'a> QwikTransform<'a> {
 		)
 	}
 
+	/** Parse inlinedQrl() (from library code) */
 	fn handle_inlined_qsegment(&mut self, mut node: ast::CallExpr) -> ast::CallExpr {
 		node.args.reverse();
 
@@ -387,6 +389,7 @@ impl<'a> QwikTransform<'a> {
 			parse_symbol_name(
 				symbol_name,
 				matches!(self.options.mode, EmitMode::Dev | EmitMode::Test),
+				&self.options.path_data.file_name,
 			)
 		};
 
@@ -742,7 +745,7 @@ impl<'a> QwikTransform<'a> {
 		span: Span,
 		segment_hash: u64,
 	) -> ast::CallExpr {
-		let canonical_filename = get_canonical_filename(&symbol_name);
+		let canonical_filename = get_canonical_filename(&segment_data.display_name, &symbol_name);
 
 		// We import from the segment file directly but store the entry for later chunking by the bundler
 		let entry = self.options.entry_policy.get_entry_for_sym(
@@ -994,7 +997,10 @@ impl<'a> QwikTransform<'a> {
 			self.segments.push(Segment {
 				entry: None,
 				span,
-				canonical_filename: get_canonical_filename(&symbol_name),
+				canonical_filename: get_canonical_filename(
+					&segment_data.display_name,
+					&symbol_name,
+				),
 				name: symbol_name.clone(),
 				data: segment_data.clone(),
 				expr: Box::new(expr),
@@ -2303,16 +2309,21 @@ fn compute_scoped_idents(all_idents: &[Id], all_decl: &[IdPlusType]) -> (Vec<Id>
 	(output, immutable)
 }
 
-fn get_canonical_filename(symbol_name: &JsWord) -> JsWord {
-	JsWord::from(symbol_name.as_ref().to_ascii_lowercase())
+fn get_canonical_filename(display_name: &JsWord, symbol_name: &JsWord) -> JsWord {
+	let hash = symbol_name.split('_').last().unwrap();
+	JsWord::from(format!("{}_{}", display_name, hash).to_ascii_lowercase())
 }
 
-fn parse_symbol_name(symbol_name: JsWord, dev: bool) -> (JsWord, JsWord, JsWord) {
+fn parse_symbol_name(
+	symbol_name: JsWord,
+	dev: bool,
+	file_name: &String,
+) -> (JsWord, JsWord, JsWord) {
 	let mut splitter = symbol_name.rsplitn(2, '_');
 	let hash = splitter
 		.next()
 		.expect("symbol_name always need to have a segment");
-	let display_name = splitter.next().unwrap_or(hash);
+	let display_name = format!("{}_{}", file_name, splitter.next().unwrap_or(hash));
 
 	let s_n = if dev {
 		symbol_name.clone()

--- a/packages/qwik/src/optimizer/src/plugins/vite-dev-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-dev-server.ts
@@ -73,7 +73,7 @@ function createSymbolMapper(
     const qrlPath = parentPath.startsWith(opts.rootDir)
       ? normalizePath(path.relative(opts.rootDir, parentPath))
       : `@fs${maybeSlash}${parentPath}`;
-    const qrlFile = `${encode(qrlPath)}/${symbolName.toLowerCase()}.js?_qrl_parent=${encode(parentFile)}`;
+    const qrlFile = `${encode(qrlPath)}/${parentFile.toLowerCase()}_${symbolName.toLowerCase()}.js?_qrl_parent=${encode(parentFile)}`;
     return [symbolName, `${base}${qrlFile}`];
   };
 }


### PR DESCRIPTION
This allows nicer debugging because you can easily see which segment file belongs to which original file

![image](https://github.com/user-attachments/assets/a7b54fcb-b9d5-433b-96ae-e309903147d3)

This also uses the full displayname in production qrl segments for nicer debugging (doesn't impact  bundling)
