### PR TITLE
add documentation on now to track useStore

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/components/tasks/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/tasks/index.mdx
@@ -19,7 +19,8 @@ contributors:
   - adamdbradley
   - aendel
   - jemsco
-updated_at: '2023-10-18T07:33:22Z'
+  - czuma
+updated_at: '2024-09-18T02:08:00Z'
 created_at: '2023-03-31T02:40:50Z'
 ---
 
@@ -232,6 +233,7 @@ const delay = (time: number) => new Promise((res) => setTimeout(res, time));
 
 > Sometimes it is required to only run code either in the server or in the client. This can be achieved by using the `isServer` and `isBrowser` booleans exported from `@builder.io/qwik/build` as shown above.
 
+> If you want to track `useStore()` objects and execute something when any of their internal values change, use `track(myExampleStore)` directly without the anonymous function. This prevents `track()` from losing the reference to the original reactive object.
 
 ### `track()` as a function
 


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.
-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ x ] Docs / tests / types / typos
- [ ] Infra

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->
this add documentation on a case you want to track useStore and act when some of it's internal values change.  This is added because the anonymous function expresed don't work and you need to provide the track function the object directly. more info here
https://discord.com/channels/842438759945601056/1161720833035743272

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ x ] I have made corresponding changes to the Qwik docs
- [ ] Added new tests to cover the fix / functionality
