### PR TITLE
docs: fix up env links in auth.js section

### DIFF
--- a/packages/docs/src/routes/docs/integrations/authjs/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/authjs/index.mdx
@@ -286,7 +286,7 @@ GITHUB_SECRET=
 AUTH_SECRET=
 ```
 
-> *IMPORTANT*: Please read the Qwik documentation about [Environment Variables](/docs/env-variables/) to ensure you are using them safely. Many provider secrets should be kept secure and not exposed to the client/browser.
+> *IMPORTANT*: Please read the Qwik documentation about [Environment Variables](/docs/guides/env-variables/) to ensure you are using them safely. Many provider secrets should be kept secure and not exposed to the client/browser.
 
 4. The application is now ready to implement authentication using Auth.js.
 5. Enjoy!
@@ -331,7 +331,7 @@ export const { onRequest, useSession, useSignIn, useSignOut } = QwikAuth$(
 AUTH_SECRET=
 ```
 
-> *IMPORTANT*: Please read the Qwik documentation about [Environment Variables](/docs/env-variables/) to ensure you are using them safely. Many provider secrets should be kept secure and not exposed to the client/browser.
+> *IMPORTANT*: Please read the Qwik documentation about [Environment Variables](/docs/guides/env-variables/) to ensure you are using them safely. Many provider secrets should be kept secure and not exposed to the client/browser.
 
 3. The application is now ready to implement authentication using Auth.js.
 4. Enjoy!


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos
- [ ] Infra

# Description
I noticed that the links to the environment variables docs in the [documentation](https://qwik.dev/docs/integrations/authjs/) were broken (I think it still linked to an old route). I've gone ahead to update it.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have made corresponding changes to the Qwik docs
- [ ] Added new tests to cover the fix / functionality
