### PR TITLE
fix(v2): warning instead of error for tag nesting

### DIFF
--- a/packages/qwik/src/server/qwik-copy.ts
+++ b/packages/qwik/src/server/qwik-copy.ts
@@ -56,3 +56,4 @@ export { VNodeDataChar } from '../core/shared/vnode-data-types';
 export { VNodeDataSeparator } from '../core/shared/vnode-data-types';
 export { escapeHTML } from '../core/shared/utils/character-escaping';
 export { getValidManifest } from '../optimizer/src/manifest';
+export { logWarn } from '../core/shared/utils/log';

--- a/packages/qwik/src/server/ssr-container.ts
+++ b/packages/qwik/src/server/ssr-container.ts
@@ -49,6 +49,7 @@ import {
   QInstanceAttr,
   escapeHTML,
   Q_PROPS_SEPARATOR,
+  logWarn,
 } from './qwik-copy';
 import {
   type ContextId,
@@ -989,7 +990,7 @@ class SSRContainer extends _SharedContainer implements ISSRContainer {
               allowedContent(previousTagNesting)[0]
             }.`
           );
-          throw newTagError(text.join('\n'));
+          logWarn('SsrError(tag): ' + text.join('\n'));
         }
       }
     }
@@ -1119,10 +1120,6 @@ const isQwikStyleElement = (tag: string, attrs: SsrAttrs | null | undefined) => 
   }
   return false;
 };
-
-function newTagError(text: string) {
-  return new Error('SsrError(tag): ' + text);
-}
 
 function hasDestroy(obj: any): obj is { $destroy$(): void } {
   return obj && typeof obj === 'object' && typeof obj.$destroy$ === 'function';


### PR DESCRIPTION
Print a warning instead of throwing an error for tag nesting