### PR TITLE
fix: do not serialize methods of objects passed to styles

### DIFF
--- a/.changeset/tender-files-press.md
+++ b/.changeset/tender-files-press.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': patch
+---
+
+Do not allow object methods to be serialized with style prop

--- a/packages/qwik/src/core/error/error.ts
+++ b/packages/qwik/src/core/error/error.ts
@@ -5,7 +5,7 @@ export const codeToText = (code: number, ...parts: any[]): string => {
   if (qDev) {
     // Keep one error, one line to make it easier to search for the error message.
     const MAP = [
-      'Error while serializing class attribute', // 0
+      'Error while serializing class or style attributes', // 0
       'Can not serialize a HTML Node that is not an Element', // 1
       'Runtime but no instance found on element.', // 2
       'Only primitive and object literals can be serialized', // 3

--- a/packages/qwik/src/core/render/execute-component.ts
+++ b/packages/qwik/src/core/render/execute-component.ts
@@ -186,7 +186,7 @@ export const stringifyStyle = (obj: any): string => {
       for (const key in obj) {
         if (Object.prototype.hasOwnProperty.call(obj, key)) {
           const value = obj[key];
-          if (value != null) {
+          if (value != null && typeof value !== 'function') {
             if (key.startsWith('--')) {
               chunks.push(key + ':' + value);
             } else {
@@ -201,7 +201,7 @@ export const stringifyStyle = (obj: any): string => {
   return String(obj);
 };
 
-const setValueForStyle = (styleName: string, value: any) => {
+export const setValueForStyle = (styleName: string, value: any) => {
   if (typeof value === 'number' && value !== 0 && !isUnitlessNumber(styleName)) {
     return value + 'px';
   }

--- a/packages/qwik/src/core/render/execute-component.unit.ts
+++ b/packages/qwik/src/core/render/execute-component.unit.ts
@@ -1,5 +1,10 @@
 import { suite, test, assert } from 'vitest';
-import { serializeClass, serializeClassWithHost } from './execute-component';
+import {
+  serializeClass,
+  serializeClassWithHost,
+  stringifyStyle,
+  setValueForStyle,
+} from './execute-component';
 import type { QContext } from '../state/context';
 
 const obj = {
@@ -175,5 +180,156 @@ suite('serializeClassWithHost', () => {
       serializeClassWithHost(obj, { $scopeIds$: ['foo', 'baz'] } as QContext),
       'foo baz bar bar-baz baz-bar'
     );
+  });
+});
+
+suite('stringifyStyle', () => {
+  test('should stringify null', () => {
+    assert.equal(stringifyStyle(null), '');
+  });
+
+  test('should stringify undefined', () => {
+    assert.equal(stringifyStyle(undefined), '');
+  });
+
+  test('should stringify string', () => {
+    assert.equal(stringifyStyle('color: red;'), 'color: red;');
+  });
+
+  test('should stringify number', () => {
+    assert.equal(stringifyStyle(10), '10');
+  });
+
+  test('should stringify boolean', () => {
+    assert.equal(stringifyStyle(true), 'true');
+    assert.equal(stringifyStyle(false), 'false');
+  });
+
+  suite('object values', () => {
+    test('should throw an error for array', () => {
+      assert.throws(
+        () => stringifyStyle([]),
+        'Code(0): Error while serializing class or style attributes'
+      );
+    });
+
+    suite('regular objects', () => {
+      test('should stringify object with nullish values', () => {
+        assert.equal(stringifyStyle({ color: null, backgroundColor: undefined }), '');
+      });
+
+      test('should stringify empty object', () => {
+        assert.equal(stringifyStyle({}), '');
+      });
+
+      test('should stringify object with single property', () => {
+        assert.equal(stringifyStyle({ color: 'red' }), 'color:red');
+      });
+
+      test('should stringify object with multiple properties', () => {
+        assert.equal(
+          stringifyStyle({ color: 'red', 'background-color': 'blue' }),
+          'color:red;background-color:blue'
+        );
+      });
+
+      test('should stringify object with numeric values', () => {
+        assert.equal(stringifyStyle({ width: 10, height: 20 }), 'width:10px;height:20px');
+      });
+
+      test('should convert camelCase to kebab-case', () => {
+        assert.equal(stringifyStyle({ backgroundColor: 'blue' }), 'background-color:blue');
+      });
+
+      test('should stringify object with unitless properties', () => {
+        assert.equal(stringifyStyle({ lineHeight: 1.5 }), 'line-height:1.5');
+      });
+
+      test('should stringify properties that start with two dashes', () => {
+        assert.equal(stringifyStyle({ '--foo': 'bar' }), '--foo:bar');
+      });
+
+      test('should stringify properties with numeric values that start with two dashes', () => {
+        assert.equal(stringifyStyle({ '--foo': 10 }), '--foo:10');
+      });
+    });
+
+    suite('objects with methods', () => {
+      test('should stringify object with own properties only', () => {
+        const obj = Object.create({ color: 'red' });
+        obj.marginTop = '10em';
+        assert.equal(obj.color, 'red');
+        assert.equal(stringifyStyle(obj), 'margin-top:10em');
+      });
+
+      test('should ignore object methods', () => {
+        const obj = {
+          margin: () => 10,
+          color: 'red',
+          backgroundColor: 'blue',
+        };
+        assert.equal(stringifyStyle(obj), 'color:red;background-color:blue');
+      });
+
+      test('should stringify object with custom hasOwnProperty method', () => {
+        const obj = {
+          hasOwnProperty: () => false,
+          color: 'red',
+          backgroundColor: 'blue',
+        };
+        assert.equal(stringifyStyle(obj), 'color:red;background-color:blue');
+      });
+    });
+  });
+});
+
+suite('setValueForStyle', () => {
+  suite('properties with units', () => {
+    test('should not add "px" to numeric zero value (= 0)', () => {
+      assert.equal(setValueForStyle('margin', 0), '0');
+    });
+
+    test('should add "px" to numeric value that is non-zero (<> 0)', () => {
+      assert.equal(setValueForStyle('margin', 10), '10px');
+    });
+
+    test('should not add "px" to string zero value (= "0")', () => {
+      assert.equal(setValueForStyle('margin', '0'), '0');
+    });
+
+    test('should not add "px" to string zero value ending with "px" (= "0px")', () => {
+      assert.equal(setValueForStyle('margin', '0px'), '0px');
+    });
+
+    test('should not add "px" to string zero value ending with "rem" (= "0rem")', () => {
+      assert.equal(setValueForStyle('margin', '0rem'), '0rem');
+    });
+
+    test('should not add "px" to string value that is word (= "red")', () => {
+      assert.equal(setValueForStyle('color', 'red'), 'red');
+    });
+
+    test('should not add "px" to string value that is non-zero ending with "px" (= "10px")', () => {
+      assert.equal(setValueForStyle('margin', '10px'), '10px');
+    });
+
+    test('should not add "px" to string value that is non-zero ending with "rem" (= "10rem")', () => {
+      assert.equal(setValueForStyle('margin', '10rem'), '10rem');
+    });
+  });
+
+  suite('unitless properties', () => {
+    test('should not add "px" to numeric zero value (= 0)', () => {
+      assert.equal(setValueForStyle('lineHeight', 0), '0');
+    });
+
+    test('should not add "px" to numeric value that is non-zero (<> 0)', () => {
+      assert.equal(setValueForStyle('lineHeight', 10), '10');
+    });
+
+    test('should not add "px" to string value', () => {
+      assert.equal(setValueForStyle('lineHeight', '0'), '0');
+      assert.equal(setValueForStyle('lineHeight', '10'), '10');
+    });
   });
 });


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.
-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug fix
- [ ] Docs / tests / types / typos
- [ ] Infra

# Description

It is completely valid to write a code like this:

```tsx
export const cmp = component$(() => {
  const style = {
    hasOwnProperty: () => false,
    foo: () => {
      return 'bar';
    },
    color: 'red',
  };

  return <a style={style} href="/some-link">Link</a>;
});
```

This gets serialized to DOM like this:

<img width="585" alt="image" src="https://github.com/user-attachments/assets/1ee05d9e-8e72-45cc-9109-73b12a808b41">

To prove this wrong, I added some tests for `stringifyStyle` function that converts whatever it gets from user to a usable string value that later gets stored to DOM. Without this fix, tests `"should ignore object methods"` and `"should stringify object with custom hasOwnProperty method"` would fail.

Side note: since I wanted to add a lot of other tests for `stringifyStyle` (and `setValueForStyle` as well), I noticed that error with code [`QError_stringifyClassOrStyle`](https://github.com/QwikDev/qwik/blob/baed4526582fb3c64f6531eae1dbff2c3d194bcc/packages/qwik/src/core/error/error.ts#L59) does not mention style property, so I updated error message in `packages/qwik/src/core/error/error.ts`. Does that make any problem for public facing APIs? If not, then I'd like it to stay because it mentions `style` as well.


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have ran `pnpm change` and documented my changes
- [ ] I have made corresponding changes to the Qwik docs
- [x] Added new tests to cover the fix / functionality
