### PR TITLE
feat: minify scroll restoration shim

### DIFF
--- a/.changeset/nervous-ants-swim.md
+++ b/.changeset/nervous-ants-swim.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik-city': patch
+---
+
+feat: scroll restoration shim code is minified in production

--- a/packages/qwik-city/src/runtime/src/spa-shim.ts
+++ b/packages/qwik-city/src/runtime/src/spa-shim.ts
@@ -6,7 +6,7 @@ import { getPlatform } from '@builder.io/qwik';
 
 import init from './spa-init';
 
-const SPA_SHIM_MINIFIED = `(t,e,l)=>{((r,c,o)=>{if(!r._qcs&&"manual"===c.scrollRestoration){r._qcs=!0;let s=c.state?._qCityScroll;s&&r.scrollTo(s.x,s.y);let n=o.currentScript;if(n){let i=n.closest("[q\\\\:container]"),a=new URL(e,new URL(t,o.baseURI));import(a.href).then(t=>t[l](i))}}})(window,history,document)};`;
+const SPA_SHIM_MINIFIED = `(t,e,l)=>{((r,c,o,s,i)=>{if(!r._qcs&&"manual"===c.scrollRestoration){r._qcs=!0;s=c.state?._qCityScroll;s&&r.scrollTo(s.x,s.y);s=o.currentScript;if(s){i=s.closest("[q\\\\:container]"),s=new URL(e,new URL(t,o.baseURI));import(s.href).then(t=>t[l](i))}}})(window,history,document)};`;
 
 export default (base: string) => {
   if (isServer) {

--- a/packages/qwik-city/src/runtime/src/spa-shim.ts
+++ b/packages/qwik-city/src/runtime/src/spa-shim.ts
@@ -40,14 +40,7 @@ export const shim = async (base: string, path: string, symbol: string) => {
       const container = script!.closest('[q\\:container]')!;
       const url = new URL(path, new URL(base, document.baseURI));
 
-      if (isDev) {
-        // Bypass dev import hijack. (not going to work here)
-        // eslint-disable-next-line no-new-func
-        const imp = new Function('url', 'return import(url)');
-        (await imp(url.href))[symbol](container);
-      } else {
-        (await import(url.href))[symbol](container);
-      }
+      (await import(url.href))[symbol](container);
     }
   }
 };

--- a/packages/qwik-city/src/runtime/src/spa-shim.ts
+++ b/packages/qwik-city/src/runtime/src/spa-shim.ts
@@ -23,7 +23,7 @@ export default (base: string) => {
 // - If the check here doesn't pass, your page was never SPA. (no SPA pops possible)
 
 // ! DO NOT IMPORT OR USE ANY EXTERNAL REFERENCES IN THIS SCRIPT.
-const shim = async (base: string, path: string, symbol: string) => {
+export const shim = async (base: string, path: string, symbol: string) => {
   if (!(window as ClientSPAWindow)._qcs && history.scrollRestoration === 'manual') {
     // TODO Option to remove this shim especially for MFEs, like loader, for now we only run once.
     (window as ClientSPAWindow)._qcs = true;

--- a/packages/qwik-city/src/runtime/src/spa-shim.ts
+++ b/packages/qwik-city/src/runtime/src/spa-shim.ts
@@ -6,11 +6,13 @@ import { getPlatform } from '@builder.io/qwik';
 
 import init from './spa-init';
 
+const SPA_SHIM_MINFIED = `const shim=async(t,o,n)=>{if(!window._qcs&&"manual"===history.scrollRestoration){window._qcs=!0;const s=history.state?._qCityScroll;s&&window.scrollTo(s.x,s.y);const i=document.currentScript;if(i){const s=i?.closest("[q\\:container]"),c=new URL(o,new URL(t,document.baseURI));if(isDev){const t=new Function("url","return import(url)");(await t(c.href))[n](s)}else(await import(c.href))[n](s)}}};`;
+
 export default (base: string) => {
   if (isServer) {
     const [symbol, bundle] = getPlatform().chunkForSymbol(init.getSymbol(), null, init.dev?.file)!;
     const args = [base, bundle, symbol].map((x) => JSON.stringify(x)).join(',');
-    return `(${shim.toString()})(${args});`;
+    return isDev ? `(${shim.toString()})(${args})` : SPA_SHIM_MINFIED;
   }
 };
 

--- a/packages/qwik-city/src/runtime/src/spa-shim.ts
+++ b/packages/qwik-city/src/runtime/src/spa-shim.ts
@@ -6,13 +6,13 @@ import { getPlatform } from '@builder.io/qwik';
 
 import init from './spa-init';
 
-const SPA_SHIM_MINFIED = `const shim=async(t,o,n)=>{if(!window._qcs&&"manual"===history.scrollRestoration){window._qcs=!0;const s=history.state?._qCityScroll;s&&window.scrollTo(s.x,s.y);const i=document.currentScript;if(i){const s=i?.closest("[q\\:container]"),c=new URL(o,new URL(t,document.baseURI));if(isDev){const t=new Function("url","return import(url)");(await t(c.href))[n](s)}else(await import(c.href))[n](s)}}};`;
+const SPA_SHIM_MINIFIED = `(t,e,l)=>{((r,c,o)=>{if(!r._qcs&&"manual"===c.scrollRestoration){r._qcs=!0;let s=c.state?._qCityScroll;s&&r.scrollTo(s.x,s.y);let n=o.currentScript;if(n){let i=n.closest("[q\\\\:container]"),a=new URL(e,new URL(t,o.baseURI));import(a.href).then(t=>t[l](i))}}})(window,history,document)};`;
 
 export default (base: string) => {
   if (isServer) {
     const [symbol, bundle] = getPlatform().chunkForSymbol(init.getSymbol(), null, init.dev?.file)!;
     const args = [base, bundle, symbol].map((x) => JSON.stringify(x)).join(',');
-    return isDev ? `(${shim.toString()})(${args})` : SPA_SHIM_MINFIED;
+    return isDev ? `(${shim.toString()})(${args})` : `(${SPA_SHIM_MINIFIED})(${args})`;
   }
 };
 

--- a/packages/qwik-city/src/runtime/src/spa-shim.unit.ts
+++ b/packages/qwik-city/src/runtime/src/spa-shim.unit.ts
@@ -1,0 +1,81 @@
+import { assert, test, vi, beforeEach } from 'vitest';
+import { shim } from './spa-shim';
+
+const mockWindow: any = {
+  scrollTo: vi.fn(),
+  _qcs: undefined,
+};
+
+const mockHistory: any = {
+  scrollRestoration: 'manual',
+  state: {
+    _qCityScroll: { x: 100, y: 200 },
+  },
+};
+
+const mockDocument: any = {
+  currentScript: {
+    closest: vi.fn(),
+  },
+  baseURI: 'http://localhost:3000',
+};
+
+vi.mock('URL', () => {
+  return {
+    URL: vi.fn().mockImplementation(() => ({
+      href: 'http://localhost:3000/test-bundle.js',
+    })),
+  };
+});
+
+global.window = mockWindow;
+global.history = mockHistory;
+global.document = mockDocument;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWindow._qcs = undefined;
+});
+
+test('shim function sets _qcs and scrolls to saved position', async () => {
+  const mockContainer = { id: 'mock-container' };
+  mockDocument.currentScript.closest.mockReturnValue(mockContainer);
+
+  const mockSymbol = 'testSymbol';
+  const mockModule = {
+    [mockSymbol]: vi.fn(),
+  };
+
+  vi.mock('http://localhost:3000/test-bundle.js', () => ({
+    default: mockModule,
+  }));
+
+  await shim('/', 'test-bundle.js', mockSymbol);
+
+  assert.equal(mockWindow._qcs, true);
+  assert.equal(mockWindow.scrollTo.mock.calls.length, 1);
+  assert.deepEqual(mockWindow.scrollTo.mock.calls[0], [100, 200]);
+  assert.equal(mockDocument.currentScript.closest.mock.calls.length, 1);
+  assert.equal(mockDocument.currentScript.closest.mock.calls[0][0], '[q\\:container]');
+  assert.equal(mockModule[mockSymbol].mock.calls.length, 1);
+  assert.equal(mockModule[mockSymbol].mock.calls[0][0], mockContainer);
+});
+
+test('shim function does not run if _qcs is already set', async () => {
+  mockWindow._qcs = true;
+
+  await shim('/', 'test-bundle.js', 'testSymbol');
+
+  assert.equal(mockWindow.scrollTo.mock.calls.length, 0);
+  assert.equal(mockDocument.currentScript.closest.mock.calls.length, 0);
+});
+
+test('shim function does not run if scrollRestoration is not manual', async () => {
+  mockHistory.scrollRestoration = 'auto';
+
+  await shim('/', 'test-bundle.js', 'testSymbol');
+
+  assert.equal(mockWindow._qcs, undefined);
+  assert.equal(mockWindow.scrollTo.mock.calls.length, 0);
+  assert.equal(mockDocument.currentScript.closest.mock.calls.length, 0);
+});


### PR DESCRIPTION
Scroll restoration shim code currently isn't minified in production. This PR creates a minified version, and uses the previous version in dev mode.

![image](https://github.com/user-attachments/assets/493ea7e5-cc54-4cbb-bc93-8829e721bb76)

<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.
-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests / types / typos
- [ ] Infra

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have made corresponding changes to the Qwik docs
- [ ] Added new tests to cover the fix / functionality
