### PR TITLE
refactor(v2): reduce subsriptions count, dont use regexp for attribute checking

### DIFF
--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -3,7 +3,13 @@ import { SERIALIZABLE_STATE, type OnRenderFn } from '../shared/component.public'
 import { assertDefined, assertFalse, assertTrue } from '../shared/error/assert';
 import type { QRLInternal } from '../shared/qrl/qrl-class';
 import type { QRL } from '../shared/qrl/qrl.public';
-import { Fragment, JSXNodeImpl, isJSXNode, type Props } from '../shared/jsx/jsx-runtime';
+import {
+  Fragment,
+  JSXNodeImpl,
+  directGetPropsProxyProp,
+  isJSXNode,
+  type Props,
+} from '../shared/jsx/jsx-runtime';
 import { Slot } from '../shared/jsx/slot.public';
 import type { JSXNode, JSXOutput } from '../shared/jsx/types/jsx-node';
 import type { JSXChildren } from '../shared/jsx/types/jsx-qwik-attributes';
@@ -419,7 +425,9 @@ export const vnode_diff = (
       /// STEP 1: Bucketize the children based on the projection name.
       for (let i = 0; i < children.length; i++) {
         const child = children[i];
-        const slotName = String((isJSXNode(child) && child.props[QSlot]) || QDefaultSlot);
+        const slotName = String(
+          (isJSXNode(child) && directGetPropsProxyProp(child, QSlot)) || QDefaultSlot
+        );
         const idx = mapApp_findIndx(projections, slotName, 0);
         let jsxBucket: JSXNodeImpl<typeof Projection>;
         if (idx >= 0) {
@@ -518,7 +526,7 @@ export const vnode_diff = (
         return trackSignal(() => constValue.value, vHost, EffectProperty.COMPONENT, container);
       }
     }
-    return jsxValue.props.name || QDefaultSlot;
+    return directGetPropsProxyProp(jsxValue, 'name') || QDefaultSlot;
   }
 
   function drainAsyncQueue(): ValueOrPromise<void> {

--- a/packages/qwik/src/core/shared/component-execution.ts
+++ b/packages/qwik/src/core/shared/component-execution.ts
@@ -2,7 +2,7 @@ import { isDev } from '@builder.io/qwik/build';
 import { isQwikComponent, type OnRenderFn } from './component.public';
 import { assertDefined } from './error/assert';
 import { isQrl, type QRLInternal } from './qrl/qrl-class';
-import { JSXNodeImpl, isJSXNode } from './jsx/jsx-runtime';
+import { JSXNodeImpl, isJSXNode, type Props } from './jsx/jsx-runtime';
 import type { JSXNode, JSXOutput } from './jsx/types/jsx-node';
 import type { KnownEventNames } from './jsx/types/jsx-qwik-events';
 import { invokeApply, newInvokeContext, untrack } from '../use/use-core';
@@ -50,7 +50,7 @@ export const executeComponent = (
   renderHost: HostElement,
   subscriptionHost: HostElement,
   componentQRL: OnRenderFn<unknown> | QRLInternal<OnRenderFn<unknown>> | null,
-  props: Record<string, unknown> | null
+  props: Props | null
 ): ValueOrPromise<JSXOutput> => {
   const iCtx = newInvokeContext(container.$locale$, subscriptionHost, undefined, RenderEvent);
   iCtx.$effectSubscriber$ = [subscriptionHost, EffectProperty.COMPONENT];
@@ -69,13 +69,13 @@ export const executeComponent = (
     componentFn = componentQRL.getFn(iCtx);
   } else if (isQwikComponent(componentQRL)) {
     const qComponentFn = componentQRL as (
-      props: Record<string, unknown>,
+      props: Props,
       key: string | null,
       flags: number
     ) => JSXNode;
     componentFn = () => invokeApply(iCtx, qComponentFn, [props || EMPTY_OBJ, null, 0]);
   } else {
-    const inlineComponent = componentQRL as (props: Record<string, unknown>) => JSXOutput;
+    const inlineComponent = componentQRL as (props: Props) => JSXOutput;
     componentFn = () => invokeApply(iCtx, inlineComponent, [props || EMPTY_OBJ]);
   }
 

--- a/packages/qwik/src/core/shared/jsx/jsx-runtime.ts
+++ b/packages/qwik/src/core/shared/jsx/jsx-runtime.ts
@@ -430,4 +430,14 @@ class PropsProxyHandler implements ProxyHandler<any> {
   }
 }
 
+/**
+ * Instead of using PropsProxyHandler getter (which could create a component-level subscription).
+ * Use this function to get the props directly from a const or var props.
+ */
+export const directGetPropsProxyProp = <T, JSX>(jsx: JSXNode<JSX>, prop: string): T => {
+  return (
+    jsx.constProps && prop in jsx.constProps ? jsx.constProps[prop] : jsx.varProps[prop]
+  ) as T;
+};
+
 export { jsx as jsxs };

--- a/packages/qwik/src/core/ssr/ssr-render-jsx.ts
+++ b/packages/qwik/src/core/ssr/ssr-render-jsx.ts
@@ -2,7 +2,7 @@ import { isDev } from '@builder.io/qwik/build';
 import { isQwikComponent } from '../shared/component.public';
 import { isQrl } from '../shared/qrl/qrl-class';
 import type { QRL } from '../shared/qrl/qrl.public';
-import { Fragment } from '../shared/jsx/jsx-runtime';
+import { Fragment, directGetPropsProxyProp } from '../shared/jsx/jsx-runtime';
 import { Slot } from '../shared/jsx/slot.public';
 import type { JSXNode, JSXOutput } from '../shared/jsx/types/jsx-node';
 import type { JSXChildren } from '../shared/jsx/types/jsx-qwik-attributes';
@@ -26,7 +26,7 @@ import {
   isJsxPropertyAnEventName,
   isPreventDefault,
 } from '../shared/utils/event-names';
-import { addComponentStylePrefix, hasClassAttr, isClassAttr } from '../shared/utils/scoped-styles';
+import { addComponentStylePrefix, isClassAttr } from '../shared/utils/scoped-styles';
 import { qrlToString, type SerializationContext } from '../shared/shared-serialization';
 import { DEBUG_TYPE, VirtualType } from '../shared/types';
 import { WrappedSignal, EffectProperty, isSignal } from '../signal/signal';
@@ -155,16 +155,7 @@ function processJSXNode(
       const type = jsx.type;
       // Below, JSXChildren allows functions and regexes, but we assume the dev only uses those as appropriate.
       if (typeof type === 'string') {
-        // append class attribute if styleScopedId exists and there is no class attribute
-        const classAttributeExists =
-          hasClassAttr(jsx.varProps) || (jsx.constProps && hasClassAttr(jsx.constProps));
-        if (!classAttributeExists && styleScoped) {
-          if (!jsx.constProps) {
-            jsx.constProps = {};
-          }
-          jsx.constProps['class'] = '';
-        }
-
+        appendClassIfScopedStyleExists(jsx, styleScoped);
         appendQwikInspectorAttribute(jsx);
 
         const innerHTML = ssr.openElement(
@@ -232,7 +223,7 @@ function processJSXNode(
             ssr.closeFragment();
           }
         } else if (type === SSRComment) {
-          ssr.commentNode((jsx.props.data as string) || '');
+          ssr.commentNode(directGetPropsProxyProp(jsx, 'data') || '');
         } else if (type === SSRStream) {
           ssr.commentNode(FLUSH_COMMENT);
           const generator = jsx.children as SSRStreamChildren;
@@ -251,7 +242,7 @@ function processJSXNode(
           enqueue(value as StackValue);
           isPromise(value) && enqueue(Promise);
         } else if (type === SSRRaw) {
-          ssr.htmlNode(jsx.props.data as string);
+          ssr.htmlNode(directGetPropsProxyProp(jsx, 'data'));
         } else if (isQwikComponent(type)) {
           // prod: use new instance of an array for props, we always modify props for a component
           ssr.openComponent(isDev ? [DEBUG_TYPE, VirtualType.Component] : []);
@@ -490,19 +481,27 @@ function getSlotName(host: ISsrNode, jsx: JSXNode, ssr: SSRContainer): string {
       return trackSignal(() => constValue.value, host, EffectProperty.COMPONENT, ssr);
     }
   }
-  return (jsx.props.name as string) || QDefaultSlot;
+  return directGetPropsProxyProp(jsx, 'name') || QDefaultSlot;
 }
 
 function appendQwikInspectorAttribute(jsx: JSXNode) {
   if (isDev && qInspector && jsx.dev && jsx.type !== 'head') {
     const sanitizedFileName = jsx.dev.fileName?.replace(/\\/g, '/');
     const qwikInspectorAttr = 'data-qwik-inspector';
-    if (sanitizedFileName && !(qwikInspectorAttr in jsx.props)) {
-      if (!jsx.constProps) {
-        jsx.constProps = {};
-      }
-      jsx.constProps[qwikInspectorAttr] =
+    if (sanitizedFileName && (!jsx.constProps || !(qwikInspectorAttr in jsx.constProps))) {
+      (jsx.constProps ||= {})[qwikInspectorAttr] =
         `${sanitizedFileName}:${jsx.dev.lineNumber}:${jsx.dev.columnNumber}`;
     }
+  }
+}
+
+// append class attribute if styleScopedId exists and there is no class attribute
+function appendClassIfScopedStyleExists(jsx: JSXNode, styleScoped: string | null) {
+  const classAttributeExists = directGetPropsProxyProp(jsx, 'class') != null;
+  if (!classAttributeExists && styleScoped) {
+    if (!jsx.constProps) {
+      jsx.constProps = {};
+    }
+    jsx.constProps['class'] = '';
   }
 }

--- a/packages/qwik/src/server/ssr-container.ts
+++ b/packages/qwik/src/server/ssr-container.ts
@@ -1131,9 +1131,24 @@ function hasDestroy(obj: any): obj is { $destroy$(): void } {
 }
 
 // https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
-const unsafeAttrCharRE = /[>/="'\u0009\u000a\u000c\u0020]/; // eslint-disable-line no-control-regex
 function isSSRUnsafeAttr(name: string): boolean {
-  return unsafeAttrCharRE.test(name);
+  for (let idx = 0; idx < name.length; idx++) {
+    const ch = name.charCodeAt(idx);
+    if (
+      ch === 62 /* > */ ||
+      ch === 47 /* / */ ||
+      ch === 61 /* = */ ||
+      ch === 34 /* " */ ||
+      ch === 39 /* ' */ ||
+      ch === 9 /* \t */ ||
+      ch === 10 /* \n */ ||
+      ch === 12 /* \f */ ||
+      ch === 32 /* space */
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function hash() {


### PR DESCRIPTION
- do not use `.props` during rendering - this  creates component-level subscription
- don't use regexp for checking attribute name during ssr