### PR TITLE
chore: update modulepreload experiment date

### DIFF
--- a/packages/docs/src/entry.ssr.tsx
+++ b/packages/docs/src/entry.ssr.tsx
@@ -14,14 +14,14 @@ export default function (opts: RenderToStreamOptions) {
       lang: 'en',
       ...opts.containerAttributes,
     },
-    // Core Web Vitals experiment until October 9: Do not remove! Reach out to @maiieul first if you believe you have a good reason to change this.
+    // Core Web Vitals experiment until October 23: Do not remove! Reach out to @maiieul first if you believe you have a good reason to change this.
     prefetchStrategy: {
       implementation: {
         linkInsert: 'html-append',
         linkRel: 'modulepreload',
       },
     },
-    // Core Web Vitals experiment until October 9: Do not remove! Reach out to @maiieul first if you believe you have a good reason to change this.
+    // Core Web Vitals experiment until October 23: Do not remove! Reach out to @maiieul first if you believe you have a good reason to change this.
     qwikPrefetchServiceWorker: {
       include: false,
     },

--- a/packages/docs/src/root.tsx
+++ b/packages/docs/src/root.tsx
@@ -71,7 +71,7 @@ export default component$(() => {
         <script dangerouslySetInnerHTML={uwu} />
         <script dangerouslySetInnerHTML={unregisterPrefetchServiceWorkers} />
         <RouterHead />
-        {/* Core Web Vitals experiment until October 9: Do not bring back any SW until then! Reach out to @maiieul first if you believe you have a good reason to change this. */}
+        {/* Core Web Vitals experiment until October 23: Do not bring back any SW until then! Reach out to @maiieul first if you believe you have a good reason to change this. */}
         {/* <ServiceWorkerRegister /> */}
 
         {/* <script dangerouslySetInnerHTML={`(${collectSymbols})()`} /> */}
@@ -85,7 +85,7 @@ export default component$(() => {
       >
         <RouterOutlet />
         <RealMetricsOptimization builderApiKey={BUILDER_PUBLIC_API_KEY} />
-        {/* Core Web Vitals experiment until October 9: Do not bring back any SW until then! Reach out to @maiieul first if you believe you have a good reason to change this. */}
+        {/* Core Web Vitals experiment until October 23: Do not bring back any SW until then! Reach out to @maiieul first if you believe you have a good reason to change this. */}
       </body>
     </QwikCityProvider>
   );


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.
-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos
- [ ] Infra

# Description

The docs site wasn't updated when I made the first modulepreload experiment PR. So we have to run the experiment until October ~20 to be sure we have all the data running on pagespeed for 28 days.

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have made corresponding changes to the Qwik docs
- [ ] Added new tests to cover the fix / functionality
