### PR TITLE
fix: validate prefetch-sw messages

### DIFF
--- a/packages/qwik/src/optimizer/src/qwik-binding-map.ts
+++ b/packages/qwik/src/optimizer/src/qwik-binding-map.ts
@@ -30,15 +30,5 @@ export const QWIK_BINDING_MAP = {
         "platformArchABI": "qwik.win32-x64-msvc.node"
       }
     ]
-  },
-  "linux": {
-    "x64": [
-      {
-        "platform": "linux",
-        "arch": "x64",
-        "abi": "gnu",
-        "platformArchABI": "qwik.linux-x64-gnu.node"
-      }
-    ]
   }
 };

--- a/packages/qwik/src/prefetch-service-worker/process-message.ts
+++ b/packages/qwik/src/prefetch-service-worker/process-message.ts
@@ -77,8 +77,6 @@ export const processMessage = async (state: SWState, msg: SWMessages) => {
   } else if (type === 'verbose') {
     // eslint-disable-next-line no-console
     (state.$log$ = log)('mode: verbose');
-  } else {
-    console.error('UNKNOWN MESSAGE:', msg);
   }
 };
 


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.
-->

# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests / types / typos
- [ ] Infra

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

fixes: https://github.com/QwikDev/qwik/issues/6921

If an unknown message is sent to the SW which isn't an array, Qwik throws an error attempting to slice the array. If it is an array type, Qwik will log an error. This PR will check if messages are Qwik messages before queuing them and ignore unknown messages.

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have ran `pnpm change` and documented my changes
- [ ] I have made corresponding changes to the Qwik docs
- [ ] Added new tests to cover the fix / functionality
