### PR TITLE
fix(sync$): serialize "minified" function

### DIFF
--- a/.changeset/shaggy-apes-kneel.md
+++ b/.changeset/shaggy-apes-kneel.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': patch
+---
+
+sync$ QRLs will now be serialized into the HTML in a shorter form

--- a/.changeset/silver-countries-kiss.md
+++ b/.changeset/silver-countries-kiss.md
@@ -1,5 +1,5 @@
 ---
-'@builder.io/qwik-city': minor
+'@builder.io/qwik-city': patch
 ---
 
 Prevent unexpected caching for q-data.json

--- a/packages/qwik-city/src/runtime/src/router-outlet-component.tsx
+++ b/packages/qwik-city/src/runtime/src/router-outlet-component.tsx
@@ -41,13 +41,16 @@ export const RouterOutlet = component$(() => {
             document:onQCInit$={spaInit}
             document:onQInit$={sync$(() => {
               // Minify window and history
-              ((window: ClientSPAWindow, history: History & { state?: ScrollHistoryState }) => {
-                if (!window._qcs && history.scrollRestoration === 'manual') {
-                  window._qcs = true;
+              // Write this as minified as possible, the optimizer does not really minify this code.
+              ((w: ClientSPAWindow, h: History & { state?: ScrollHistoryState }) => {
+                if (!w._qcs && h.scrollRestoration === 'manual') {
+                  // true
+                  w._qcs = !0;
 
-                  const scrollState = history.state?._qCityScroll;
-                  if (scrollState) {
-                    window.scrollTo(scrollState.x, scrollState.y);
+                  // scrollState
+                  const s = h.state?._qCityScroll;
+                  if (s) {
+                    w.scrollTo(s.x, s.y);
                   }
                   document.dispatchEvent(new Event('qcinit'));
                 }

--- a/packages/qwik/src/core/qrl/qrl.public.ts
+++ b/packages/qwik/src/core/qrl/qrl.public.ts
@@ -332,5 +332,6 @@ export const _qrlSync = function <TYPE extends Function>(
   if (serializedFn === undefined) {
     serializedFn = fn.toString();
   }
+  (fn as any).serialized = serializedFn;
   return createQRL<TYPE>('', SYNC_QRL, fn, null, null, null, null) as any;
 };

--- a/packages/qwik/src/core/qrl/qrl.ts
+++ b/packages/qwik/src/core/qrl/qrl.ts
@@ -199,7 +199,7 @@ export const serializeQRL = (qrl: QRLInternal, opts: QRLSerializeOptions = {}) =
     if (opts.$containerState$) {
       const fn = qrl.resolved as Function;
       const containerState = opts.$containerState$;
-      const fnStrKey = fn.toString();
+      const fnStrKey = ((fn as any).serialized as string) || fn.toString();
       let id = containerState.$inlineFns$.get(fnStrKey);
       if (id === undefined) {
         id = containerState.$inlineFns$.size;


### PR DESCRIPTION
It's not super minified, but it's better than before.

For example, qwik.dev had this in the sync funcs script tag:

```tsx
() => {
    ((window1, history1) => {
      var _a3;
      if (!window1._qcs && history1.scrollRestoration === "manual") {
        window1._qcs = true;
        const scrollState = (_a3 = history1.state) == null ? void 0 : _a3._qCityScroll;
        if (scrollState) window1.scrollTo(scrollState.x, scrollState.y);
        document.dispatchEvent(new Event("qcinit"));
      }
    })(window, history)})
```
which was copied verbatim with spacing.
Now it will be without spaces.
