### PR TITLE
fix(insights): minify ping script and externalize zod

### DIFF
--- a/packages/insights/.gitignore
+++ b/packages/insights/.gitignore
@@ -14,6 +14,7 @@ node_modules
 .rollup.cache
 tsconfig.tsbuildinfo
 tmp
+q-insights.json
 
 # Logs
 logs

--- a/packages/insights/package.json
+++ b/packages/insights/package.json
@@ -37,7 +37,8 @@
     "undici": "*",
     "vite": "5.3.5",
     "vite-tsconfig-paths": "4.3.2",
-    "vitest": "2.0.5"
+    "vitest": "2.0.5",
+    "zod": "3.22.4"
   },
   "engines": {
     "node": ">=16.8.0 <18.0.0 || >=18.11"

--- a/packages/insights/src/db/query-helpers.ts
+++ b/packages/insights/src/db/query-helpers.ts
@@ -76,7 +76,7 @@ export function createEdgeRow({
 }: {
   publicApiKey: string;
   manifestHash: string;
-  from: string | null;
+  from?: string | null;
   to: string;
   interaction: boolean;
   delayBucket: number;

--- a/packages/insights/src/db/query.ts
+++ b/packages/insights/src/db/query.ts
@@ -180,7 +180,7 @@ export async function updateEdge(
   edge: {
     publicApiKey: string;
     manifestHash: string;
-    from: string | null;
+    from?: string | null;
     to: string;
     interaction: boolean;
     delayBucket: number;
@@ -202,7 +202,7 @@ export async function updateEdge(
       and(
         eq(edgeTable.manifestHash, edge.manifestHash),
         eq(edgeTable.publicApiKey, edge.publicApiKey),
-        edge.from === null ? isNull(edgeTable.from) : eq(edgeTable.from, edge.from),
+        edge.from == null ? isNull(edgeTable.from) : eq(edgeTable.from, edge.from),
         eq(edgeTable.to, edge.to)
       )
     )

--- a/packages/insights/src/routes/api/v1/[publicApiKey]/post/index.tsx
+++ b/packages/insights/src/routes/api/v1/[publicApiKey]/post/index.tsx
@@ -45,10 +45,10 @@ export const onPost: RequestHandler = async ({ exit, json, request, params }) =>
   }
 };
 
-function cleanupSymbolName(symbolName: string | null): string | null {
-  if (!symbolName) return null;
+function cleanupSymbolName(symbolName?: string | null) {
+  if (!symbolName) return;
   const shortName = symbolName.substring(symbolName.lastIndexOf('_') + 1 || 0);
-  if (shortName == 'hW') return null;
+  if (shortName == 'hW') return;
   return shortName;
 }
 function migrate1(payloadJson: any) {

--- a/packages/qwik-labs/package.json
+++ b/packages/qwik-labs/package.json
@@ -14,7 +14,11 @@
     "prettier": "3.3.3",
     "typescript": "5.4.5",
     "undici": "*",
-    "vite": "5.3.5"
+    "vite": "5.3.5",
+    "zod": "3.22.4"
+  },
+  "peerDependencies": {
+    "zod": "3.22.4"
   },
   "engines": {
     "node": ">=16.8.0 <18.0.0 || >=18.11"

--- a/packages/qwik-labs/vite.config.mts
+++ b/packages/qwik-labs/vite.config.mts
@@ -11,6 +11,9 @@ export default defineConfig(() => {
         formats: ['es', 'cjs'],
         fileName: (format) => `index.qwik.${format === 'es' ? 'mjs' : 'cjs'}`,
       },
+      rollupOptions: {
+        external: ['zod'],
+      },
     },
     plugins: [qwikVite(), dtsPlugin()],
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -549,6 +549,9 @@ importers:
       vitest:
         specifier: 2.0.5
         version: 2.0.5(@types/node@20.14.11)(terser@5.31.3)
+      zod:
+        specifier: 3.22.4
+        version: 3.22.4
 
   packages/qwik:
     dependencies:
@@ -743,6 +746,9 @@ importers:
       vite:
         specifier: 5.3.5
         version: 5.3.5(@types/node@20.14.11)(terser@5.31.3)
+      zod:
+        specifier: 3.22.4
+        version: 3.22.4
 
   packages/qwik-react:
     devDependencies:


### PR DESCRIPTION
zod was being built into the library, and the script wasn't minified and was actually broken because fn.toString() didn't include a helper that rollup injected
