### PR TITLE
docs: fix server$ example

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/advanced/eslint/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/advanced/eslint/index.mdx
@@ -972,7 +972,7 @@ export const ColorList = component$(() => {
 <div class="code-wrapper">
 <span class="badge good">✓</span>
 ```tsx {4,12} /serverGreeter/#a
-import { component$ } from '@builder.io/qwik';
+import { $, component$ } from '@builder.io/qwik';
 import { server$ } from '@builder.io/qwik-city';
  
 const serverGreeter = server$((firstName: string, lastName: string) => {

--- a/packages/docs/src/routes/docs/(qwik)/advanced/eslint/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/advanced/eslint/index.mdx
@@ -982,10 +982,10 @@ const serverGreeter = server$((firstName: string, lastName: string) => {
  
 export default component$(() => (
     <button
-      onClick$={async () => {
+      onClick$={$(async () => {
         const greeting = await serverGreeter('John', 'Doe');
         alert(greeting);
-      }}
+      })}
     >
       greet
     </button>

--- a/packages/docs/src/routes/docs/(qwikcity)/server$/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/server$/index.mdx
@@ -31,7 +31,7 @@ Your new function will have the following signature:
 > Please note that depending on your server runtime, the function on the server may not terminate immediately. It depends on how client disconnections are handled by the runtime.
 
 ```tsx
-import { component$, useSignal } from '@builder.io/qwik';
+import { component$, useSignal, $ } from '@builder.io/qwik';
 import { server$ } from '@builder.io/qwik-city';
 
 // By wrapping a function with `server$()` we mark it to always
@@ -176,7 +176,7 @@ export const handleRequest = server$(
 Terminating the generator on the client side (e.g., by calling `.return()` on the generator or by breaking out from your async for-of loop) will terminate the connection. Similar to `AbortSignal`, how the generator terminates on the server side depends on the server runtime and how client disconnects are handled.
 
 ```tsx
-import { component$, useSignal } from '@builder.io/qwik';
+import { component$, useSignal, $ } from '@builder.io/qwik';
 import { server$ } from '@builder.io/qwik-city';
 
 export const streamFromServer = server$(
@@ -203,7 +203,7 @@ export default component$(() => {
     <div>
       <button
         onClick$={
-          async () => {
+          $(async () => {
             // call the async stream function and wait for the response
             const response = await streamFromServer(); 
             // use a for-await-of loop to asynchronously iterate over the response
@@ -212,7 +212,7 @@ export default component$(() => {
               message.value += ` ${value}`;
             }
             // do anything else
-          }
+          })
         }
       >
         start

--- a/packages/docs/src/routes/docs/(qwikcity)/server$/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/server$/index.mdx
@@ -55,10 +55,10 @@ export default component$(() => {
 
       <button
         onClick$={
-          async () => {
+          $(async () => {
             const greeting = await serverGreeter(firstName.value, lastName.value);
             alert(greeting);
-          }
+          })
         }
       >
         greet


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.
-->

# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests / types / typos
- [ ] Infra

# Description

Fixes https://qwik.dev/docs/server$/#server  and  https://qwik.dev/docs/advanced/eslint/#unused-server

as described in the documentation:
When defining and calling `server$()` inside an `onClick$¡, be aware that this can lead to potential errors. To avoid them, make sure the handlers have `$¡ wrapped around them.
Don't do this
`onClick$={() => server$(() => // some server code!)}`
Do this
`onClick$={$(() => server$(() => // some server code!))}`

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have ran `pnpm change` and documented my changes
- [x] I have made corresponding changes to the Qwik docs
- [x] Added new tests to cover the fix / functionality
