### PR TITLE
docs: clarify wording

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/concepts/think-qwik/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/concepts/think-qwik/index.mdx
@@ -56,7 +56,7 @@ The solution to the above problem is both obvious and hard: Ship less JavaScript
 
 The obvious part is that sites with less JavaScript will perform better.
 
-The hard part is our tools don't help us to get there. The majority of  Qwik's tools solve problems in a way that makes shipping less JavaScript hard. These tools are designed to solve a specific problem without thinking about the amount of JavaScript they generate.
+The hard part is that our tools don't help us achieve this. Most of them solve problems in a way that makes shipping less JavaScript hard. These tools are designed to address specific issues without considering how much JavaScript they produce.
 
 Do you need to solve rendering, styling, animation, A/B testing, analytics, etc.? There is a tool for that. Just import or add a `<script>` tag, and these tools will solve your problems, but at the expense of making the initial bundle bigger.
 


### PR DESCRIPTION
# What is it?

- Docs

# Description

The original text wrongly implied that Qwik's tools increase JavaScript, which goes against what Qwik is all about. I reworded it to clarify that the issue applies to general tools, not Qwik's.
