### PR TITLE
fix: solve issue with Cache-Control header deletion

### DIFF
--- a/.changeset/moaning-master-chief.md
+++ b/.changeset/moaning-master-chief.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik-city': patch
+---
+
+fix: Redirect, error, and fail request events no longer forcefully delete user-defined Cache-Control HTTP header value.

--- a/packages/qwik-city/src/middleware/request-handler/request-event.ts
+++ b/packages/qwik-city/src/middleware/request-handler/request-event.ts
@@ -207,6 +207,10 @@ export function createRequestEvent(
         }
         headers.set('Location', fixedURL);
       }
+      // Fallback to 'no-store' when end user is not managing Cache-Control header
+      if (statusCode > 301 && !headers.get('Cache-Control')) {
+        headers.set('Cache-Control', 'no-store');
+      }
       exit();
       return new RedirectMessage();
     },

--- a/packages/qwik-city/src/middleware/request-handler/request-event.ts
+++ b/packages/qwik-city/src/middleware/request-handler/request-event.ts
@@ -194,7 +194,6 @@ export function createRequestEvent(
 
     error: (statusCode: number, message: string) => {
       status = statusCode;
-      headers.delete('Cache-Control');
       return new ErrorResponse(statusCode, message);
     },
 
@@ -208,10 +207,6 @@ export function createRequestEvent(
         }
         headers.set('Location', fixedURL);
       }
-      headers.delete('Cache-Control');
-      if (statusCode > 301) {
-        headers.set('Cache-Control', 'no-store');
-      }
       exit();
       return new RedirectMessage();
     },
@@ -223,7 +218,6 @@ export function createRequestEvent(
     fail: <T extends Record<string, any>>(statusCode: number, data: T): FailReturn<T> => {
       check();
       status = statusCode;
-      headers.delete('Cache-Control');
       return {
         failed: true,
         ...data,


### PR DESCRIPTION
# What is it?

<!-- pick one and remove the others -->

- Bug (kinda)

# Description
Currently, it is impossible to define a Cache-Control header using the `request.cacheControl` on any method that takes a request event other than success (HTTP 200). Looks like qwik-city, internally, deletes whatever is defined.

I am not entirely sure about the `error()` and `fail()` handlers, which are also forcing the removal of the header. I'd say that engineers could potentially decide to cache 404s, for example, and the framework should not enforce this kind of rules. However, I am not sure about this premise for 4xx or 5xx.

Redirects (HTTP 301, HTTP 302, HTTP 307, HTTP 308, at least) should be totally configurable by software engineers.

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [X] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [X] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
