### PR TITLE
fix(computed): retry qrl execution on throwing promise

### DIFF
--- a/packages/qwik/src/core/shared/shared-serialization.ts
+++ b/packages/qwik/src/core/shared/shared-serialization.ts
@@ -283,15 +283,21 @@ const inflate = (container: DeserializeContainer, target: any, typeId: TypeIds, 
       computed.$untrackedValue$ = d[1];
       computed.$invalid$ = d[2];
       computed.$effects$ = d.slice(3);
-      /**
-       * If we try to compute value and the qrl is not resolved, then system throws an error with
-       * qrl promise. To prevent that we should early resolve computed qrl while computed
-       * deserialization. This also prevents anything from firing while computed qrls load, because
-       * of scheduler
-       */
-      // try to download qrl in this tick
-      computed.$computeQrl$.resolve();
-      (container as DomContainer).$scheduler$?.(ChoreType.QRL_RESOLVE, null, computed.$computeQrl$);
+      if (computed.$invalid$) {
+        /**
+         * If we try to compute value and the qrl is not resolved, then system throws an error with
+         * qrl promise. To prevent that we should early resolve computed qrl while computed
+         * deserialization. This also prevents anything from firing while computed qrls load,
+         * because of scheduler
+         */
+        // try to download qrl in this tick
+        computed.$computeQrl$.resolve();
+        (container as DomContainer).$scheduler$?.(
+          ChoreType.QRL_RESOLVE,
+          null,
+          computed.$computeQrl$
+        );
+      }
       break;
     }
     case TypeIds.Error: {

--- a/starters/apps/e2e/src/components/computed/computed.tsx
+++ b/starters/apps/e2e/src/components/computed/computed.tsx
@@ -19,6 +19,7 @@ export const ComputedRoot = component$(() => {
       <Issue3488 />
       <Issue5738 />
       <ShouldResolveComputedQrlEarly />
+      <ShouldRetryWhenThereIsNoQRL />
     </div>
   );
 });
@@ -135,5 +136,23 @@ export const ShouldResolveComputedQrlEarly = component$(() => {
         Click me! {repro.value}
       </button>
     </>
+  );
+});
+
+export const ShouldRetryWhenThereIsNoQRL = component$(() => {
+  const counter = useSignal(0);
+
+  const someComputed = useComputed$(() => {});
+
+  return (
+    <button
+      id="retry-no-qrl"
+      onClick$={() => {
+        someComputed.value;
+        counter.value++;
+      }}
+    >
+      {counter.value}
+    </button>
   );
 });

--- a/starters/e2e/e2e.computed.e2e.ts
+++ b/starters/e2e/e2e.computed.e2e.ts
@@ -44,6 +44,15 @@ test.describe("computed", () => {
       await expect(button).toContainText("Click me! 5");
     });
 
+    test("should retry when there is no qrl", async ({ page }) => {
+      const button = page.locator("#retry-no-qrl");
+      await expect(button).toContainText("0");
+
+      await button.click();
+
+      await expect(button).toContainText("1");
+    });
+
     test("issue 3482", async ({ page }) => {
       const button = page.locator("#issue-3482-button");
       const div = page.locator("#issue-3482-div");


### PR DESCRIPTION
When we are executing the `computedIfNeeded` function we can throw a promise (a qrl) if the qrl is not resolved, then we should retry execution of it.

This is a workaround until a complex fix will be implemented.