### PR TITLE
fix(build): always have qwik binary available

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "build.watch": "tsm scripts/index.ts --build  --qwikcity --watch --dev --platform-binding",
     "change": "changeset",
     "cli": "pnpm build.cli && node packages/create-qwik/dist/create-qwik.cjs && tsm scripts/validate-cli.ts --copy-local-qwik-dist",
-    "cli.qwik": "pnpm build.cli && node packages/qwik/dist/qwik-cli.cjs",
+    "cli.qwik": "pnpm build.cli && packages/qwik/qwik-cli.cjs",
     "cli.validate": "tsm scripts/validate-cli.ts",
     "deps": "corepack pnpm upgrade -i -r --latest && syncpack fix-mismatches && corepack pnpm dedupe",
     "docs.dev": "cd packages/docs && pnpm build.repl-sw && pnpm dev",

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -4,7 +4,7 @@
   "version": "1.9.1",
   "annotation": "This package.json is for internal use in the monorepo, the build actually makes a new package.json for the published package via scripts/package-json.ts",
   "bin": {
-    "qwik": "./dist/qwik-cli.cjs"
+    "qwik": "./qwik-cli.cjs"
   },
   "bugs": "https://github.com/QwikDev/qwik/issues",
   "contributors": [
@@ -137,7 +137,8 @@
     "loader.d.ts",
     "optimizer.d.ts",
     "server.d.ts",
-    "testing.d.ts"
+    "testing.d.ts",
+    "qwik-cli.cjs"
   ],
   "homepage": "https://qwik.dev/",
   "keywords": [

--- a/scripts/submodule-cli.ts
+++ b/scripts/submodule-cli.ts
@@ -2,7 +2,7 @@ import { build } from 'esbuild';
 import { existsSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { copyStartersDir } from './create-qwik-cli';
-import { type BuildConfig, copyDir, copyFile, getBanner, nodeTarget } from './util';
+import { type BuildConfig, copyDir, getBanner, nodeTarget } from './util';
 
 /** Builds @builder.io/qwik/cli */
 export async function submoduleCli(config: BuildConfig) {
@@ -41,11 +41,6 @@ export async function submoduleCli(config: BuildConfig) {
       'globalThis.QWIK_VERSION': JSON.stringify(config.distVersion),
     },
   });
-
-  await copyFile(
-    join(config.srcQwikDir, submodule, 'qwik.cjs'),
-    join(config.distQwikPkgDir, 'qwik-cli.cjs')
-  );
 
   await copyStartersDir(config, config.distQwikPkgDir, ['features', 'adapters']);
 


### PR DESCRIPTION
To have the bin `qwik` working during installs, the file it points to from package.json must exist.

We already had a perpetual script in the qwik package but it got ignored at some point.
