### PR TITLE
fix(core): rename old packages during transform

### DIFF
--- a/packages/qwik/src/optimizer/core/src/lib.rs
+++ b/packages/qwik/src/optimizer/core/src/lib.rs
@@ -21,6 +21,7 @@ mod is_const;
 mod package_json;
 mod parse;
 mod props_destructuring;
+mod rename_imports;
 mod transform;
 mod utils;
 mod words;

--- a/packages/qwik/src/optimizer/core/src/parse.rs
+++ b/packages/qwik/src/optimizer/core/src/parse.rs
@@ -13,6 +13,7 @@ use crate::const_replace::ConstReplacerVisitor;
 use crate::entry_strategy::EntryPolicy;
 use crate::filter_exports::StripExportsVisitor;
 use crate::props_destructuring::transform_props_destructuring;
+use crate::rename_imports::RenameTransform;
 use crate::transform::{QwikTransform, QwikTransformOptions, Segment, SegmentKind};
 use crate::utils::{Diagnostic, DiagnosticCategory, DiagnosticScope, SourceLocation};
 use crate::EntryStrategy;
@@ -285,6 +286,9 @@ pub fn transform_code(config: TransformCodeOptions) -> Result<TransformOutput, a
 							unresolved_mark,
 						));
 					}
+
+					// rename old imports to new imports
+					program.visit_mut_with(&mut RenameTransform);
 
 					// Resolve with mark
 					program.visit_mut_with(&mut resolver(

--- a/packages/qwik/src/optimizer/core/src/rename_imports.rs
+++ b/packages/qwik/src/optimizer/core/src/rename_imports.rs
@@ -1,0 +1,17 @@
+/// Rename imports from @builder.io to @qwik.dev
+use swc_ecmascript::ast;
+use swc_ecmascript::visit::VisitMut;
+
+pub struct RenameTransform;
+
+impl VisitMut for RenameTransform {
+	fn visit_mut_import_decl(&mut self, node: &mut ast::ImportDecl) {
+		if node.src.value.starts_with("@builder.io/qwik-city") {
+			node.src.value = ("@qwik.dev/router".to_string() + &node.src.value[21..]).into();
+		} else if node.src.value.starts_with("@builder.io/qwik-react") {
+			node.src.value = ("@qwik.dev/react".to_string() + &node.src.value[22..]).into();
+		} else if node.src.value.starts_with("@builder.io/qwik") {
+			node.src.value = ("@qwik.dev/core".to_string() + &node.src.value[16..]).into();
+		}
+	}
+}

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__rename_builder_io.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__rename_builder_io.snap
@@ -1,0 +1,131 @@
+---
+source: packages/qwik/src/optimizer/core/src/test.rs
+assertion_line: 3811
+expression: output
+---
+==INPUT==
+
+
+		import { $, component$ } from "@builder.io/qwik";
+		import { isDev } from "@builder.io/qwik/build";
+		import { stuff } from "@builder.io/qwik-city";
+		import { moreStuff } from "@builder.io/qwik-city/more/here";
+		import { qwikify$ } from "@builder.io/qwik-react";
+		import sdk from "@builder.io/sdk";
+		
+		export const Foo = qwikify$(MyReactComponent);
+		
+		export const Bar = $("a thing");
+
+		export const App = component$(() => {
+			sdk.hello();
+			if (isDev) {
+				stuff()
+			} else {
+				moreStuff()
+			}
+			return "hi";
+		});
+		
+============================= test.tsx_bar_gxxnvutursw.ts (ENTRY POINT)==
+
+export const Bar_GXXnVUtURSw = "a thing";
+export { _hW } from "@qwik.dev/core";
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"+BAUuB\"}")
+/*
+{
+  "origin": "test.tsx",
+  "name": "Bar_GXXnVUtURSw",
+  "entry": null,
+  "displayName": "test.tsx_Bar",
+  "hash": "GXXnVUtURSw",
+  "canonicalFilename": "test.tsx_bar_gxxnvutursw",
+  "path": "",
+  "extension": "ts",
+  "parent": null,
+  "ctxKind": "function",
+  "ctxName": "$",
+  "captures": false,
+  "loc": [
+    384,
+    393
+  ]
+}
+*/
+============================= test.tsx_foo_qwikify_0yoy9qa0sc0.ts (ENTRY POINT)==
+
+export const Foo_qwikify_0Yoy9qA0SC0 = MyReactComponent;
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"uCAQ8B\"}")
+/*
+{
+  "origin": "test.tsx",
+  "name": "Foo_qwikify_0Yoy9qA0SC0",
+  "entry": null,
+  "displayName": "test.tsx_Foo_qwikify",
+  "hash": "0Yoy9qA0SC0",
+  "canonicalFilename": "test.tsx_foo_qwikify_0yoy9qa0sc0",
+  "path": "",
+  "extension": "ts",
+  "parent": null,
+  "ctxKind": "function",
+  "ctxName": "qwikify$",
+  "captures": false,
+  "loc": [
+    339,
+    355
+  ]
+}
+*/
+============================= test.tsx_app_component_ckepmxzlub0.ts (ENTRY POINT)==
+
+import { isDev } from "@qwik.dev/core/build";
+import { moreStuff } from "@qwik.dev/router/more/here";
+import sdk from "@builder.io/sdk";
+import { stuff } from "@qwik.dev/router";
+export const App_component_ckEPmXZlub0 = ()=>{
+    sdk.hello();
+    if (isDev) stuff();
+    else moreStuff();
+    return "hi";
+};
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;yCAYgC;IAC7B,IAAI,KAAK;IACT,IAAI,OACH;SAEA;IAED,OAAO;AACR\"}")
+/*
+{
+  "origin": "test.tsx",
+  "name": "App_component_ckEPmXZlub0",
+  "entry": null,
+  "displayName": "test.tsx_App_component",
+  "hash": "ckEPmXZlub0",
+  "canonicalFilename": "test.tsx_app_component_ckepmxzlub0",
+  "path": "",
+  "extension": "ts",
+  "parent": null,
+  "ctxKind": "function",
+  "ctxName": "component$",
+  "captures": false,
+  "loc": [
+    429,
+    533
+  ]
+}
+*/
+============================= test.ts ==
+
+import { qwikifyQrl } from "@qwik.dev/react";
+import { qrl } from "@qwik.dev/core";
+import { componentQrl } from "@qwik.dev/core";
+export const Foo = qwikifyQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_foo_qwikify_0yoy9qa0sc0"), "Foo_qwikify_0Yoy9qA0SC0"));
+export const Bar = /*#__PURE__*/ qrl(()=>import("./test.tsx_bar_gxxnvutursw"), "Bar_GXXnVUtURSw");
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_app_component_ckepmxzlub0"), "App_component_ckEPmXZlub0"));
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;AAQE,OAAO,MAAM,MAAM,2GAA2B;AAE9C,OAAO,MAAM,qFAAmB;AAEhC,OAAO,MAAM,oBAAM,iHAQhB\"}")
+== DIAGNOSTICS ==
+
+[]

--- a/packages/qwik/src/optimizer/core/src/test.rs
+++ b/packages/qwik/src/optimizer/core/src/test.rs
@@ -3806,6 +3806,37 @@ fn impure_template_fns() {
 	});
 }
 
+#[test]
+fn rename_builder_io() {
+	test_input!(TestInput {
+		code: r#"
+		import { $, component$ } from "@builder.io/qwik";
+		import { isDev } from "@builder.io/qwik/build";
+		import { stuff } from "@builder.io/qwik-city";
+		import { moreStuff } from "@builder.io/qwik-city/more/here";
+		import { qwikify$ } from "@builder.io/qwik-react";
+		import sdk from "@builder.io/sdk";
+		
+		export const Foo = qwikify$(MyReactComponent);
+		
+		export const Bar = $("a thing");
+
+		export const App = component$(() => {
+			sdk.hello();
+			if (isDev) {
+				stuff()
+			} else {
+				moreStuff()
+			}
+			return "hi";
+		});
+		"#
+		.to_string(),
+		transpile_jsx: true,
+		..TestInput::default()
+	});
+}
+
 // TODO(misko): Make this test work by implementing strict serialization.
 // #[test]
 // fn example_of_synchronous_qrl_that_cant_be_serialized() {


### PR DESCRIPTION
The vite aliases don't help because they happen after the transform, and Qwik needs to know exactly what's importing what.