### PR TITLE
added vite as peer to qwik-react and qwik-labs

### DIFF
--- a/.changeset/ninety-planets-search.md
+++ b/.changeset/ninety-planets-search.md
@@ -3,4 +3,4 @@
 '@builder.io/qwik': patch
 ---
 
-FIX: `vite` is now a peer dependency of `qwik` and `qwik-city`, so that there can be no duplicate imports. This should not have consequences, since all apps also directly depend on `vite`.
+FIX: `vite` is now a peer dependency of `qwik`, `qwik-city`, `qwik-react` and `qwik-labs`, so that there can be no duplicate imports. This should not have consequences, since all apps also directly depend on `vite`.

--- a/packages/qwik-labs/package.json
+++ b/packages/qwik-labs/package.json
@@ -38,7 +38,8 @@
   ],
   "main": "./lib/index.qwik.mjs",
   "peerDependencies": {
-    "zod": "3.22.4"
+    "zod": "3.22.4",
+    "vite": "^5"
   },
   "private": true,
   "qwik": "./lib/index.qwik.mjs",

--- a/packages/qwik-react/package.json
+++ b/packages/qwik-react/package.json
@@ -39,7 +39,8 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "vite": "^5"
   },
   "qwik": "./lib/index.qwik.mjs",
   "repository": {

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -159,11 +159,6 @@
   "peerDependencies": {
     "vite": "^5"
   },
-  "peerDependenciesMeta": {
-    "vite": {
-      "optional": true
-    }
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/QwikDev/qwik.git",


### PR DESCRIPTION
`vite` is now a peer dependency of `qwik`, `qwik-city`, `qwik-react` and `qwik-labs`, so that there can be no duplicate imports. This should not have consequences, since all apps also directly depend on `vite`.

# What is it?

- Infra

# Description
