### PR TITLE
fix(jsx): textarea type should accept text children

### DIFF
--- a/.changeset/gentle-adults-compare.md
+++ b/.changeset/gentle-adults-compare.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': patch
+---
+
+FIX: the type for `<textarea>` now accepts text children, as per spec.

--- a/packages/qwik/src/core/render/jsx/types/jsx-generated.ts
+++ b/packages/qwik/src/core/render/jsx/types/jsx-generated.ts
@@ -711,7 +711,7 @@ type SpecialAttrs = {
     form?: string | undefined;
     value?: string | ReadonlyArray<string> | number | undefined;
     'bind:value'?: Signal<string | undefined>;
-    children?: undefined;
+    children?: string;
   };
   track: {
     children?: undefined;


### PR DESCRIPTION
fixes #7012