### PR TITLE
fix: mark event listeners inside loops as var props

### DIFF
--- a/packages/qwik/src/core/tests/use-lexical-scope.spec.tsx
+++ b/packages/qwik/src/core/tests/use-lexical-scope.spec.tsx
@@ -1,0 +1,144 @@
+import { domRender, ssrRenderToDom, trigger } from '@qwik.dev/core/testing';
+import { describe, expect, it } from 'vitest';
+import {
+  component$,
+  useStore,
+  useSignal,
+  Fragment as Component,
+  Fragment as Signal,
+} from '@qwik.dev/core';
+
+const debug = false; //true;
+Error.stackTraceLimit = 100;
+
+describe.each([
+  { render: ssrRenderToDom }, //
+  { render: domRender }, //
+])('$render.name: useLexicalScope', ({ render }) => {
+  it('should update const prop event value', async () => {
+    type Cart = string[];
+
+    const Parent = component$(() => {
+      const cart = useStore<Cart>([]);
+      const results = useSignal(['foo']);
+
+      return (
+        <div>
+          <button id="first" onClick$={() => (results.value = ['item'])}></button>
+
+          {results.value.map((item) => (
+            <button
+              id="second"
+              onClick$={() => {
+                cart.push(item);
+              }}
+            >
+              {item}
+            </button>
+          ))}
+          <ul>
+            {cart.map((item) => (
+              <li>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      );
+    });
+
+    const { vNode, document } = await render(<Parent />, { debug });
+
+    expect(vNode).toMatchVDOM(
+      <Component>
+        <div>
+          <button id="first"></button>
+          <button id="second">foo</button>
+          <ul></ul>
+        </div>
+      </Component>
+    );
+
+    await trigger(document.body, 'button#first', 'click');
+
+    expect(vNode).toMatchVDOM(
+      <Component>
+        <div>
+          <button id="first"></button>
+          <button id="second">item</button>
+          <ul></ul>
+        </div>
+      </Component>
+    );
+
+    await trigger(document.body, 'button#second', 'click');
+
+    expect(vNode).toMatchVDOM(
+      <Component>
+        <div>
+          <button id="first"></button>
+          <button id="second">item</button>
+          <ul>
+            <li>
+              <span>item</span>
+            </li>
+          </ul>
+        </div>
+      </Component>
+    );
+  });
+
+  describe('regression', () => {
+    it('#5662 - should update value in the list', async () => {
+      /**
+       * ROOT CAUSE ANALYSIS: This is a bug in Optimizer. The optimizer incorrectly marks the
+       * `onClick` listener as 'const'/'immutable'. Because it is const, the QRL associated with the
+       * click handler always points to the original object, and it is not updated.
+       */
+      const Cmp = component$(() => {
+        const store = useStore<{ users: { name: string }[] }>({ users: [{ name: 'Giorgio' }] });
+
+        return (
+          <div>
+            {store.users.map((user, key) => (
+              <span
+                key={key}
+                onClick$={() => {
+                  store.users = store.users.map(({ name }: { name: string }) => ({
+                    name: name === user.name ? name + '!' : name,
+                  }));
+                }}
+              >
+                {user.name}
+              </span>
+            ))}
+          </div>
+        );
+      });
+      const { vNode, container } = await render(<Cmp />, { debug });
+      expect(vNode).toMatchVDOM(
+        <Component>
+          <div>
+            <span key="0">
+              <Signal ssr-required>{'Giorgio'}</Signal>
+            </span>
+          </div>
+        </Component>
+      );
+      await trigger(container.element, 'span', 'click');
+      await trigger(container.element, 'span', 'click');
+      await trigger(container.element, 'span', 'click');
+      await trigger(container.element, 'span', 'click');
+      await trigger(container.element, 'span', 'click');
+      expect(vNode).toMatchVDOM(
+        <Component>
+          <div>
+            <span key="0">
+              <Signal ssr-required>{'Giorgio!!!!!'}</Signal>
+            </span>
+          </div>
+        </Component>
+      );
+    });
+  });
+});

--- a/packages/qwik/src/core/tests/use-store.spec.tsx
+++ b/packages/qwik/src/core/tests/use-store.spec.tsx
@@ -882,58 +882,6 @@ describe.each([
       vi.useRealTimers();
     });
 
-    it.skip('#5662 - should update value in the list', async () => {
-      /**
-       * ROOT CAUSE ANALYSIS: This is a bug in Optimizer. The optimizer incorrectly marks the
-       * `onClick` listener as 'const'/'immutable'. Because it is const, the QRL associated with the
-       * click handler always points to the original object, and it is not updated.
-       */
-      const Cmp = component$(() => {
-        const store = useStore<{ users: { name: string }[] }>({ users: [{ name: 'Giorgio' }] });
-
-        return (
-          <div>
-            {store.users.map((user, key) => (
-              <span
-                key={key}
-                onClick$={() => {
-                  store.users = store.users.map(({ name }: { name: string }) => ({
-                    name: name === user.name ? name + '!' : name,
-                  }));
-                }}
-              >
-                {user.name}
-              </span>
-            ))}
-          </div>
-        );
-      });
-      const { vNode, container } = await render(<Cmp />, { debug });
-      expect(vNode).toMatchVDOM(
-        <Component>
-          <div>
-            <span key="0">
-              <Signal>{'Giorgio'}</Signal>
-            </span>
-          </div>
-        </Component>
-      );
-      await trigger(container.element, 'span', 'click');
-      await trigger(container.element, 'span', 'click');
-      await trigger(container.element, 'span', 'click');
-      await trigger(container.element, 'span', 'click');
-      await trigger(container.element, 'span', 'click');
-      expect(vNode).toMatchVDOM(
-        <Component>
-          <div>
-            <span key="0">
-              <Signal>{'Giorgio!!!!!'}</Signal>
-            </span>
-          </div>
-        </Component>
-      );
-    });
-
     it('#5017 - should update child nodes for direct array', async () => {
       const Child = component$<{ columns: string }>(({ columns }) => {
         return <div>Child: {columns}</div>;

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_component_with_event_listeners_inside_loop.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_component_with_event_listeners_inside_loop.snap
@@ -1,0 +1,419 @@
+---
+source: packages/qwik/src/optimizer/core/src/test.rs
+assertion_line: 3850
+expression: output
+---
+==INPUT==
+
+
+import { $, component$, useStore, useSignal } from '@qwik.dev/core';
+
+export const App = component$(() => {
+      const cart = useStore<string[]>([]);
+      const results = useSignal(['foo']);
+
+      function loopArrowFn(results: string[]) {
+        return results.map((item) => (
+          <span
+            onClick$={() => {
+              cart.push(item);
+            }}
+          >
+            {item}
+          </span>
+        ));
+      }
+
+      function loopForI(results: string[]) {
+        const items = [];
+        for (let i = 0; i < results.length; i++) {
+          items.push(
+            <span
+              onClick$={() => {
+                cart.push(results[i]);
+              }}
+            >
+              {results[i]}
+            </span>
+          );
+        }
+        return items;
+      }
+
+      function loopForOf(results: string[]) {
+        const items = [];
+        for (const item of results) {
+          items.push(
+            <span
+              onClick$={() => {
+                cart.push(item);
+              }}
+            >
+              {item}
+            </span>
+          );
+        }
+        return items;
+      }
+
+      function loopForIn(results: string[]) {
+        const items = [];
+        for (const key in results) {
+          items.push(
+            <span
+              onClick$={() => {
+                cart.push(results[key]);
+              }}
+            >
+              {results[key]}
+            </span>
+          );
+        }
+        return items;
+      }
+
+      function loopWhile(results: string[]) {
+        const items = [];
+        let i = 0;
+        while (i < results.length) {
+          items.push(
+            <span
+              onClick$={() => {
+                cart.push(results[i]);
+              }}
+            >
+              {results[i]}
+            </span>
+          );
+          i++;
+        }
+        return items;
+      }
+
+      return (
+        <div>
+          {results.value.map((item) => (
+            <button
+              id="second"
+              onClick$={() => {
+                cart.push(item);
+              }}
+            >
+              {item}
+            </button>
+          ))}
+          {loopArrowFn(results.value)}
+          {loopForI(results.value)}
+          {loopForOf(results.value)}
+          {loopForIn(results.value)}
+          {loopWhile(results.value)}
+        </div>
+      );
+    });
+
+============================= test.js ==
+
+import { componentQrl } from "@qwik.dev/core";
+import { qrl } from "@qwik.dev/core";
+export const App = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_App_component_ckEPmXZlub0"), "App_component_ckEPmXZlub0"));
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAGA,OAAO,MAAM,oBAAM,iHAqGZ\"}")
+============================= test.tsx_App_component_loopWhile_span_onClick_ycCPdh6iazg.js (ENTRY POINT)==
+
+import { useLexicalScope } from "@qwik.dev/core";
+export const App_component_loopWhile_span_onClick_ycCPdh6iazg = ()=>{
+    const [cart, i, results] = useLexicalScope();
+    cart.push(results[i]);
+};
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";gEAyEwB;;IACR,KAAK,IAAI,CAAC,OAAO,CAAC,EAAE\"}")
+/*
+{
+  "origin": "test.tsx",
+  "name": "App_component_loopWhile_span_onClick_ycCPdh6iazg",
+  "entry": null,
+  "displayName": "test.tsx_App_component_loopWhile_span_onClick",
+  "hash": "ycCPdh6iazg",
+  "canonicalFilename": "test.tsx_App_component_loopWhile_span_onClick_ycCPdh6iazg",
+  "path": "",
+  "extension": "js",
+  "parent": "App_component_ckEPmXZlub0",
+  "ctxKind": "eventHandler",
+  "ctxName": "onClick$",
+  "captures": true,
+  "loc": [
+    1699,
+    1761
+  ]
+}
+*/
+============================= test.tsx_App_component_loopArrowFn_span_onClick_xyQUo7XwaEM.js (ENTRY POINT)==
+
+import { useLexicalScope } from "@qwik.dev/core";
+export const App_component_loopArrowFn_span_onClick_xyQUo7XwaEM = ()=>{
+    const [cart, item] = useLexicalScope();
+    cart.push(item);
+};
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";kEAUsB;;IACR,KAAK,IAAI,CAAC\"}")
+/*
+{
+  "origin": "test.tsx",
+  "name": "App_component_loopArrowFn_span_onClick_xyQUo7XwaEM",
+  "entry": null,
+  "displayName": "test.tsx_App_component_loopArrowFn_span_onClick",
+  "hash": "xyQUo7XwaEM",
+  "canonicalFilename": "test.tsx_App_component_loopArrowFn_span_onClick_xyQUo7XwaEM",
+  "path": "",
+  "extension": "js",
+  "parent": "App_component_ckEPmXZlub0",
+  "ctxKind": "eventHandler",
+  "ctxName": "onClick$",
+  "captures": true,
+  "loc": [
+    321,
+    373
+  ]
+}
+*/
+============================= test.tsx_App_component_loopForIn_span_onClick_1mDJD4xhUZ8.js (ENTRY POINT)==
+
+import { useLexicalScope } from "@qwik.dev/core";
+export const App_component_loopForIn_span_onClick_1mDJD4xhUZ8 = ()=>{
+    const [cart, key, results] = useLexicalScope();
+    cart.push(results[key]);
+};
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";gEAwDwB;;IACR,KAAK,IAAI,CAAC,OAAO,CAAC,IAAI\"}")
+/*
+{
+  "origin": "test.tsx",
+  "name": "App_component_loopForIn_span_onClick_1mDJD4xhUZ8",
+  "entry": null,
+  "displayName": "test.tsx_App_component_loopForIn_span_onClick",
+  "hash": "1mDJD4xhUZ8",
+  "canonicalFilename": "test.tsx_App_component_loopForIn_span_onClick_1mDJD4xhUZ8",
+  "path": "",
+  "extension": "js",
+  "parent": "App_component_ckEPmXZlub0",
+  "ctxKind": "eventHandler",
+  "ctxName": "onClick$",
+  "captures": true,
+  "loc": [
+    1324,
+    1388
+  ]
+}
+*/
+============================= test.tsx_App_component_loopForOf_span_onClick_AjlGKUbcCKY.js (ENTRY POINT)==
+
+import { useLexicalScope } from "@qwik.dev/core";
+export const App_component_loopForOf_span_onClick_AjlGKUbcCKY = ()=>{
+    const [cart, item] = useLexicalScope();
+    cart.push(item);
+};
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";gEAwCwB;;IACR,KAAK,IAAI,CAAC\"}")
+/*
+{
+  "origin": "test.tsx",
+  "name": "App_component_loopForOf_span_onClick_AjlGKUbcCKY",
+  "entry": null,
+  "displayName": "test.tsx_App_component_loopForOf_span_onClick",
+  "hash": "AjlGKUbcCKY",
+  "canonicalFilename": "test.tsx_App_component_loopForOf_span_onClick_AjlGKUbcCKY",
+  "path": "",
+  "extension": "js",
+  "parent": "App_component_ckEPmXZlub0",
+  "ctxKind": "eventHandler",
+  "ctxName": "onClick$",
+  "captures": true,
+  "loc": [
+    984,
+    1040
+  ]
+}
+*/
+============================= test.tsx_App_component_div_button_onClick_f5NwW9e63a4.js (ENTRY POINT)==
+
+import { useLexicalScope } from "@qwik.dev/core";
+export const App_component_div_button_onClick_f5NwW9e63a4 = ()=>{
+    const [cart, item] = useLexicalScope();
+    cart.push(item);
+};
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";4DA0FwB;;IACR,KAAK,IAAI,CAAC\"}")
+/*
+{
+  "origin": "test.tsx",
+  "name": "App_component_div_button_onClick_f5NwW9e63a4",
+  "entry": null,
+  "displayName": "test.tsx_App_component_div_button_onClick",
+  "hash": "f5NwW9e63a4",
+  "canonicalFilename": "test.tsx_App_component_div_button_onClick_f5NwW9e63a4",
+  "path": "",
+  "extension": "js",
+  "parent": "App_component_ckEPmXZlub0",
+  "ctxKind": "eventHandler",
+  "ctxName": "onClick$",
+  "captures": true,
+  "loc": [
+    2033,
+    2089
+  ]
+}
+*/
+============================= test.tsx_App_component_ckEPmXZlub0.js (ENTRY POINT)==
+
+import { _fnSignal } from "@qwik.dev/core";
+import { _jsxSorted } from "@qwik.dev/core";
+import { qrl } from "@qwik.dev/core";
+import { useSignal } from "@qwik.dev/core";
+import { useStore } from "@qwik.dev/core";
+export const App_component_ckEPmXZlub0 = ()=>{
+    const cart = useStore([]);
+    const results = useSignal([
+        'foo'
+    ]);
+    function loopArrowFn(results) {
+        return results.map((item)=>/*#__PURE__*/ _jsxSorted("span", {
+                onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_App_component_loopArrowFn_span_onClick_xyQUo7XwaEM"), "App_component_loopArrowFn_span_onClick_xyQUo7XwaEM", [
+                    cart,
+                    item
+                ])
+            }, null, item, 3, "u6_0"));
+    }
+    function loopForI(results) {
+        const items = [];
+        for(let i = 0; i < results.length; i++)items.push(/*#__PURE__*/ _jsxSorted("span", {
+            onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_App_component_loopForI_span_onClick_MXjGbUTgkco"), "App_component_loopForI_span_onClick_MXjGbUTgkco", [
+                cart,
+                i,
+                results
+            ])
+        }, null, _fnSignal((p0, p1)=>p1[p0], [
+            i,
+            results
+        ], "p1[p0]"), 3, "u6_1"));
+        return items;
+    }
+    function loopForOf(results) {
+        const items = [];
+        for (const item of results)items.push(/*#__PURE__*/ _jsxSorted("span", {
+            onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_App_component_loopForOf_span_onClick_AjlGKUbcCKY"), "App_component_loopForOf_span_onClick_AjlGKUbcCKY", [
+                cart,
+                item
+            ])
+        }, null, item, 3, "u6_2"));
+        return items;
+    }
+    function loopForIn(results) {
+        const items = [];
+        for(const key in results)items.push(/*#__PURE__*/ _jsxSorted("span", {
+            onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_App_component_loopForIn_span_onClick_1mDJD4xhUZ8"), "App_component_loopForIn_span_onClick_1mDJD4xhUZ8", [
+                cart,
+                key,
+                results
+            ])
+        }, null, _fnSignal((p0, p1)=>p1[p0], [
+            key,
+            results
+        ], "p1[p0]"), 3, "u6_3"));
+        return items;
+    }
+    function loopWhile(results) {
+        const items = [];
+        let i = 0;
+        while(i < results.length){
+            items.push(/*#__PURE__*/ _jsxSorted("span", {
+                onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_App_component_loopWhile_span_onClick_ycCPdh6iazg"), "App_component_loopWhile_span_onClick_ycCPdh6iazg", [
+                    cart,
+                    i,
+                    results
+                ])
+            }, null, _fnSignal((p0, p1)=>p1[p0], [
+                i,
+                results
+            ], "p1[p0]"), 3, "u6_4"));
+            i++;
+        }
+        return items;
+    }
+    return /*#__PURE__*/ _jsxSorted("div", null, null, [
+        results.value.map((item)=>/*#__PURE__*/ _jsxSorted("button", {
+                onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_App_component_div_button_onClick_f5NwW9e63a4"), "App_component_div_button_onClick_f5NwW9e63a4", [
+                    cart,
+                    item
+                ])
+            }, {
+                id: "second"
+            }, item, 3, "u6_5")),
+        loopArrowFn(results.value),
+        loopForI(results.value),
+        loopForOf(results.value),
+        loopForIn(results.value),
+        loopWhile(results.value)
+    ], 1, "u6_6");
+};
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;yCAG8B;IACxB,MAAM,OAAO,SAAmB,EAAE;IAClC,MAAM,UAAU,UAAU;QAAC;KAAM;IAEjC,SAAS,YAAY,OAAiB;QACpC,OAAO,QAAQ,GAAG,CAAC,CAAC,qBAClB,WAAC;gBACC,QAAQ;;;;qBAIP;IAGP;IAEA,SAAS,SAAS,OAAiB;QACjC,MAAM,QAAQ,EAAE;QAChB,IAAK,IAAI,IAAI,GAAG,IAAI,QAAQ,MAAM,EAAE,IAClC,MAAM,IAAI,eACR,WAAC;YACC,QAAQ;;;;;qCAIP,EAAO,IAAG;;;;QAIjB,OAAO;IACT;IAEA,SAAS,UAAU,OAAiB;QAClC,MAAM,QAAQ,EAAE;QAChB,KAAK,MAAM,QAAQ,QACjB,MAAM,IAAI,eACR,WAAC;YACC,QAAQ;;;;iBAIP;QAIP,OAAO;IACT;IAEA,SAAS,UAAU,OAAiB;QAClC,MAAM,QAAQ,EAAE;QAChB,IAAK,MAAM,OAAO,QAChB,MAAM,IAAI,eACR,WAAC;YACC,QAAQ;;;;;qCAIP,EAAO,IAAK;;;;QAInB,OAAO;IACT;IAEA,SAAS,UAAU,OAAiB;QAClC,MAAM,QAAQ,EAAE;QAChB,IAAI,IAAI;QACR,MAAO,IAAI,QAAQ,MAAM,CAAE;YACzB,MAAM,IAAI,eACR,WAAC;gBACC,QAAQ;;;;;yCAIP,EAAO,IAAG;;;;YAGf;QACF;QACA,OAAO;IACT;IAEA,qBACE,WAAC;QACE,QAAQ,KAAK,CAAC,GAAG,CAAC,CAAC,qBAClB,WAAC;gBAEC,QAAQ;;;;;gBADR,IAAG;eAKF;QAGJ,YAAY,QAAQ,KAAK;QACzB,SAAS,QAAQ,KAAK;QACtB,UAAU,QAAQ,KAAK;QACvB,UAAU,QAAQ,KAAK;QACvB,UAAU,QAAQ,KAAK;;AAG9B\"}")
+/*
+{
+  "origin": "test.tsx",
+  "name": "App_component_ckEPmXZlub0",
+  "entry": null,
+  "displayName": "test.tsx_App_component",
+  "hash": "ckEPmXZlub0",
+  "canonicalFilename": "test.tsx_App_component_ckEPmXZlub0",
+  "path": "",
+  "extension": "js",
+  "parent": null,
+  "ctxKind": "function",
+  "ctxName": "component$",
+  "captures": false,
+  "loc": [
+    102,
+    2377
+  ]
+}
+*/
+============================= test.tsx_App_component_loopForI_span_onClick_MXjGbUTgkco.js (ENTRY POINT)==
+
+import { useLexicalScope } from "@qwik.dev/core";
+export const App_component_loopForI_span_onClick_MXjGbUTgkco = ()=>{
+    const [cart, i, results] = useLexicalScope();
+    cart.push(results[i]);
+};
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";+DAwBwB;;IACR,KAAK,IAAI,CAAC,OAAO,CAAC,EAAE\"}")
+/*
+{
+  "origin": "test.tsx",
+  "name": "App_component_loopForI_span_onClick_MXjGbUTgkco",
+  "entry": null,
+  "displayName": "test.tsx_App_component_loopForI_span_onClick",
+  "hash": "MXjGbUTgkco",
+  "canonicalFilename": "test.tsx_App_component_loopForI_span_onClick_MXjGbUTgkco",
+  "path": "",
+  "extension": "js",
+  "parent": "App_component_ckEPmXZlub0",
+  "ctxKind": "eventHandler",
+  "ctxName": "onClick$",
+  "captures": true,
+  "loc": [
+    631,
+    693
+  ]
+}
+*/
+== DIAGNOSTICS ==
+
+[]

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_functional_component_2.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__example_functional_component_2.snap
@@ -1,6 +1,6 @@
 ---
 source: packages/qwik/src/optimizer/core/src/test.rs
-assertion_line: 347
+assertion_line: 348
 expression: output
 ---
 ==INPUT==
@@ -131,19 +131,19 @@ export const App_component_ckEPmXZlub0 = (props)=>{
         ])
     }, [
         /*#__PURE__*/ _jsxSorted("span", null, null, _wrapProp(state, "count"), 3, null),
-        buttons.map((btn)=>/*#__PURE__*/ _jsxSorted("button", null, {
+        buttons.map((btn)=>/*#__PURE__*/ _jsxSorted("button", {
                 onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_App_component_div_button_onClick_f5NwW9e63a4"), "App_component_div_button_onClick_f5NwW9e63a4", [
                     btn,
                     props,
                     state,
                     thing
                 ])
-            }, _wrapProp(btn, "name"), 3, "u6_0"))
+            }, null, _wrapProp(btn, "name"), 3, "u6_0"))
     ], 0, "u6_1");
 };
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;yCAQ8B,CAAC;IAC9B,MAAM,QAAQ;IACd,MAAM,QAAQ,SAAS;QAAC,OAAO;IAAC;IAGhC,MAAM,SAAS,MAAM,KAAK,GAAG;IAC7B,qBACC,WAAC;QAAI,QAAQ;;;;;sBACZ,WAAC,8BAAM;QACN,QAAQ,GAAG,CAAC,CAAA,oBACZ,WAAC;gBACA,QAAQ;;;;;;yBAEP;;AAON\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;yCAQ8B,CAAC;IAC9B,MAAM,QAAQ;IACd,MAAM,QAAQ,SAAS;QAAC,OAAO;IAAC;IAGhC,MAAM,SAAS,MAAM,KAAK,GAAG;IAC7B,qBACC,WAAC;QAAI,QAAQ;;;;;sBACZ,WAAC,8BAAM;QACN,QAAQ,GAAG,CAAC,CAAA,oBACZ,WAAC;gBACA,QAAQ;;;;;;+BAEP;;AAON\"}")
 /*
 {
   "origin": "test.tsx",

--- a/packages/qwik/src/optimizer/core/src/test.rs
+++ b/packages/qwik/src/optimizer/core/src/test.rs
@@ -3845,6 +3845,122 @@ fn rename_builder_io() {
 	});
 }
 
+#[test]
+fn example_component_with_event_listeners_inside_loop() {
+	test_input!(TestInput {
+		code: r#"
+import { $, component$, useStore, useSignal } from '@qwik.dev/core';
+
+export const App = component$(() => {
+      const cart = useStore<string[]>([]);
+      const results = useSignal(['foo']);
+
+      function loopArrowFn(results: string[]) {
+        return results.map((item) => (
+          <span
+            onClick$={() => {
+              cart.push(item);
+            }}
+          >
+            {item}
+          </span>
+        ));
+      }
+
+      function loopForI(results: string[]) {
+        const items = [];
+        for (let i = 0; i < results.length; i++) {
+          items.push(
+            <span
+              onClick$={() => {
+                cart.push(results[i]);
+              }}
+            >
+              {results[i]}
+            </span>
+          );
+        }
+        return items;
+      }
+
+      function loopForOf(results: string[]) {
+        const items = [];
+        for (const item of results) {
+          items.push(
+            <span
+              onClick$={() => {
+                cart.push(item);
+              }}
+            >
+              {item}
+            </span>
+          );
+        }
+        return items;
+      }
+
+      function loopForIn(results: string[]) {
+        const items = [];
+        for (const key in results) {
+          items.push(
+            <span
+              onClick$={() => {
+                cart.push(results[key]);
+              }}
+            >
+              {results[key]}
+            </span>
+          );
+        }
+        return items;
+      }
+
+      function loopWhile(results: string[]) {
+        const items = [];
+        let i = 0;
+        while (i < results.length) {
+          items.push(
+            <span
+              onClick$={() => {
+                cart.push(results[i]);
+              }}
+            >
+              {results[i]}
+            </span>
+          );
+          i++;
+        }
+        return items;
+      }
+
+      return (
+        <div>
+          {results.value.map((item) => (
+            <button
+              id="second"
+              onClick$={() => {
+                cart.push(item);
+              }}
+            >
+              {item}
+            </button>
+          ))}
+          {loopArrowFn(results.value)}
+          {loopForI(results.value)}
+          {loopForOf(results.value)}
+          {loopForIn(results.value)}
+          {loopWhile(results.value)}
+        </div>
+      );
+    });
+"#
+		.to_string(),
+		transpile_ts: true,
+		transpile_jsx: true,
+		..TestInput::default()
+	});
+}
+
 // TODO(misko): Make this test work by implementing strict serialization.
 // #[test]
 // fn example_of_synchronous_qrl_that_cant_be_serialized() {


### PR DESCRIPTION
If event handler is changing should be inside var props, because const props are ignored by vnodes. This is a case when we iterate over an items and return a jsx with an event listener.

closes #7032 