### PR TITLE
fix: calling component as a function

### DIFF
--- a/packages/qwik/src/core/shared/component.public.ts
+++ b/packages/qwik/src/core/shared/component.public.ts
@@ -1,5 +1,5 @@
 import { dollar, type QRL } from './qrl/qrl.public';
-import type { JSXOutput } from './jsx/types/jsx-node';
+import type { JSXNode, JSXOutput } from './jsx/types/jsx-node';
 import type {
   ComponentBaseProps,
   EventHandler,
@@ -7,8 +7,12 @@ import type {
   QRLEventHandlerMulti,
 } from './jsx/types/jsx-qwik-attributes';
 import type { FunctionComponent } from './jsx/types/jsx-node';
-import { _CONST_PROPS, _VAR_PROPS, _jsxSorted } from '../internal';
+import { _CONST_PROPS, _VAR_PROPS, _jsxSorted, _jsxSplit } from '../internal';
 import type { QwikIntrinsicElements } from './jsx/types/jsx-qwik-elements';
+import { assertQrl } from './qrl/qrl-class';
+import { assertNumber } from './error/assert';
+import { qTest } from './utils/qdev';
+import { Virtual } from './jsx/jsx-runtime';
 
 // TS way to check for any
 type IsAny<T> = 0 extends T & 1 ? true : false;
@@ -126,7 +130,17 @@ export const componentQrl = <PROPS extends Record<any, any>>(
   componentQrl: QRL<OnRenderFn<PROPS>>
 ): Component<PROPS> => {
   // Return a QComponent Factory function.
-  const QwikComponent = () => {};
+  function QwikComponent(
+    props: PublicProps<PROPS>,
+    key: string | null,
+    flags: number = 0
+  ): JSXNode {
+    assertQrl(componentQrl);
+    assertNumber(flags, 'The Qwik Component was not invoked correctly');
+    const hash = qTest ? 'sX' : componentQrl.$hash$.slice(0, 4);
+    const finalKey = hash + ':' + (key ? key : '');
+    return _jsxSplit(Virtual, props, null, props.children, flags, finalKey);
+  }
   (QwikComponent as any)[SERIALIZABLE_STATE] = [componentQrl];
   return QwikComponent as any;
 };

--- a/packages/qwik/src/core/tests/inline-component.spec.tsx
+++ b/packages/qwik/src/core/tests/inline-component.spec.tsx
@@ -423,23 +423,39 @@ describe.each([
   });
 
   it('should render component$ inside inlined wrapper', async () => {
-    const ComplexWrapper = (props: PublicProps<{}>, key: string | null, flags: number) => {
-      const cmpFn = component$(() => {
-        return <Slot />;
+    interface ComplexWrapperProps {
+      foo: string;
+    }
+
+    const ComplexWrapper = (
+      props: PublicProps<ComplexWrapperProps>,
+      key: string | null,
+      flags: number
+    ) => {
+      const cmpFn = component$<ComplexWrapperProps>(({ foo }) => {
+        return (
+          <div>
+            {foo}: <Slot />
+          </div>
+        );
       });
       return cmpFn(props, key, flags);
     };
 
     const { vNode } = await render(
-      <ComplexWrapper>
-        <div id="1">Test</div>
+      <ComplexWrapper foo="bar">
+        <div>
+          bar: <div id="1">Test</div>
+        </div>
       </ComplexWrapper>,
       { debug }
     );
     expect(vNode).toMatchVDOM(
       <InlineComponent>
         <Component>
-          <div id="1">Test</div>
+          <div>
+            bar: <div id="1">Test</div>
+          </div>
         </Component>
       </InlineComponent>
     );

--- a/packages/qwik/src/core/tests/inline-component.spec.tsx
+++ b/packages/qwik/src/core/tests/inline-component.spec.tsx
@@ -2,9 +2,11 @@ import {
   Fragment as Component,
   Fragment,
   Fragment as InlineComponent,
+  Slot,
   component$,
   useSignal,
   useStore,
+  type PublicProps,
 } from '@qwik.dev/core';
 import { domRender, ssrRenderToDom, trigger } from '@qwik.dev/core/testing';
 import { describe, expect, it } from 'vitest';
@@ -417,6 +419,29 @@ describe.each([
           </InlineComponent>
         </footer>
       </Component>
+    );
+  });
+
+  it('should render component$ inside inlined wrapper', async () => {
+    const ComplexWrapper = (props: PublicProps<{}>, key: string | null, flags: number) => {
+      const cmpFn = component$(() => {
+        return <Slot />;
+      });
+      return cmpFn(props, key, flags);
+    };
+
+    const { vNode } = await render(
+      <ComplexWrapper>
+        <div id="1">Test</div>
+      </ComplexWrapper>,
+      { debug }
+    );
+    expect(vNode).toMatchVDOM(
+      <InlineComponent>
+        <Component>
+          <div id="1">Test</div>
+        </Component>
+      </InlineComponent>
     );
   });
 });


### PR DESCRIPTION
This PR fixes calling a component as a function by returning a jsxSplit with correct props inside component