### PR TITLE
Changed release from `main` to `upcoming` branch

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
   "fixed": [["@builder.io/qwik", "@builder.io/qwik-city", "eslint-plugin-qwik", "create-qwik"]],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "upcoming",
   "updateInternalDependencies": "minor",
   "ignore": [
     "qwik-docs",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ on:
   push:
     branches:
       - main
+      - upcoming
       - next
       - qwik-labs
       - vercelserverless
@@ -76,7 +77,7 @@ jobs:
       - name: Set Dist Tag
         id: set_dist_tag
         if: |
-          github.ref == 'refs/heads/main' && (
+          github.ref == 'refs/heads/upcoming' && (
             github.event_name == 'push' ||
             github.event_name == 'workflow_dispatch'
           )
@@ -811,12 +812,12 @@ jobs:
       - test-unit
       - test-e2e
     # test-unit runs when any packages changes, so we have to release
-    # on main, we always check if we have something to release
+    # on "upcoming", we always check if we have something to release
     # don't run on forks
     if: |
       always() && 
       github.repository == 'QwikDev/qwik' && (
-        github.ref == 'refs/heads/main' ||
+        github.ref == 'refs/heads/upcoming' ||
         needs.test-unit.result == 'success'
       )
 
@@ -870,7 +871,7 @@ jobs:
       # Do this before other release steps to avoid
       # publishing temporary files
       - name: Create Release Pull Request or Publish to npm
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/upcoming'
         id: changesets
         uses: changesets/action@v1
         with:
@@ -899,7 +900,7 @@ jobs:
   trigger-qwikcity-e2e:
     name: Trigger Qwik City E2E
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/upcoming'
 
     needs:
       - changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,8 @@ If you're interested in helping out with triaging issues, please follow the [Tri
 
 ### Branch Organization
 
-We adopt [trunk-based development](https://trunkbaseddevelopment.com/) therefore all Pull Requests are made against the main branch because we do not use separate branches for development or for the versions we release.
+We adopt [trunk-based development](https://trunkbaseddevelopment.com/) therefore all Pull Requests are made against the main branch.
+Before releasing, we merge `main` into a release branch, for testing purposes.
 
 ### Good first issue
 
@@ -366,7 +367,7 @@ For your convenience, we prepared a video tutorial that covers the process of ad
 Make sure the PR follows all the guidelines in this document. Once you think the PR is good to merge, if the commits are "nice", you can merge the PR. If not, squash the PR.
 
 In case the PR is stuck waiting for the original author to apply a trivial
-change (a typo, capitalisation change, etc.) and the author allowed the members
+change (a typo, capitalization change, etc.) and the author allowed the members
 to modify the PR, consider applying it yourself (or commit the existing review
 suggestion). You should pay extra attention to make sure the addition doesn't go
 against the idea of the original PR and would not be opposed by the author.


### PR DESCRIPTION

# What is it?

<!-- pick one and remove the others -->

- Infra

# Description

We want to make sure that we release only versions that have been tested by our "alpha testers" team.

Currently, releasing from `main` is problematic, because PRs might get merged between the time we got a 👍 from the testers but before we release, meaing bugs can creep in. 

Having a pure `upcoming` release branch, where everything is being tested from allows us to release fully tested and more stable versions. 

The new flow will be: 

1. PRs are merged into `main`

2. `main` is periodically merged into `upcoming`

3. A new `Versions` PR is getting created automatically by changesets against the `upcoming` branch (instead of `main`).

4. When we are ready to cut a release, we ask the alpha testers to test the `pkg.pr.new` version from the `upcoming` branch.

5. After we get the approval that the new version on is checked and verified to be working with multiple projects, we can merge the `Vesions` PR into the `upcoming` branch which will kick off the auto release process.

6. After the release we merge `upcoming` into `main` so it'll have the latest released version numbers.


# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I made corresponding changes to the Qwik docs

