### PR TITLE
docs: typo in image path example

### DIFF
--- a/packages/docs/src/routes/docs/integrations/image-optimization/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/image-optimization/index.mdx
@@ -66,7 +66,7 @@ The community and the Qwik team love this API for a number of reasons:
 Add the `?jsx` suffix **at the end** of the import
 
 ```tsx
-import Image from '[IMAGE_PATH]??w=24&h=24&jsx';
+import Image from '[IMAGE_PATH]?w=24&h=24&jsx';
 ```
 
 > ⚠️ Make sure to put the `jsx` query parameter at the end of the import path, otherwise typescript might complain.


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Docs / tests / types / typos

# Description

Typo in image path example (double ?): `'[IMAGE_PATH]??w=24&h=24&jsx';` -> `'[IMAGE_PATH]?w=24&h=24&jsx';`

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] I made corresponding changes to the Qwik docs