### PR TITLE
fix: server$ not throwing for errors above 500

### DIFF
--- a/.changeset/three-donkeys-admire.md
+++ b/.changeset/three-donkeys-admire.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik-city': patch
+---
+
+server$ functions now correctly throw errors for > 500 error codes

--- a/packages/qwik-city/src/runtime/src/server-functions.ts
+++ b/packages/qwik-city/src/runtime/src/server-functions.ts
@@ -479,19 +479,19 @@ export const serverQrl = <T extends ServerFunction>(
         } else if (contentType === 'application/qwik-json') {
           const str = await res.text();
           const obj = await _deserializeData(str, ctxElm ?? document.documentElement);
-          if (res.status === 500) {
+          if (res.status >= 500) {
             throw obj;
           }
           return obj;
         } else if (contentType === 'application/json') {
           const obj = await res.json();
-          if (res.status === 500) {
+          if (res.status >= 500) {
             throw obj;
           }
           return obj;
         } else if (contentType === 'text/plain' || contentType === 'text/html') {
           const str = await res.text();
-          if (res.status === 500) {
+          if (res.status >= 500) {
             throw str;
           }
           return str;


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Bug

# Description

Server functions only throw errors in the browser with 500 status code errors.
For errors that are greater than 500, such as a 504, the server functions will return the text which means you are unable to correctly catch and handle the errors.

# Checklist

- [X] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [X] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [ ] I added new tests to cover the fix / functionality
