### PR TITLE
feat: Fix prevUrl on first render

### DIFF
--- a/packages/qwik-city/src/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/src/runtime/src/qwik-city-component.tsx
@@ -375,7 +375,10 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
         }
 
         // Update route location
-        routeLocation.prevUrl = prevUrl;
+        if (!isSamePath(trackUrl, prevUrl)) {
+          routeLocation.prevUrl = prevUrl;
+        }
+
         routeLocation.url = trackUrl;
         routeLocation.params = { ...params };
 


### PR DESCRIPTION
# What is it?
- Fix https://github.com/QwikDev/qwik/issues/6625

# Description
The first time you load a route, prevUrl should be undefined

https://github.com/user-attachments/assets/cc499a87-c65f-4d38-86e2-841d7846aa18


# Checklist
- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
