### PR TITLE
cleaned the `createQrl` code

### DIFF
--- a/packages/qwik/src/core/shared/qrl/qrl-class.ts
+++ b/packages/qwik/src/core/shared/qrl/qrl-class.ts
@@ -1,6 +1,8 @@
 import { isDev } from '@qwik.dev/core/build';
-import { isSignal } from '../../signal/signal';
-import type { Signal } from '../../signal/signal.public';
+import { assertDefined } from '../error/assert';
+import { qError, QError_qrlIsNotFunction } from '../error/error';
+import { getPlatform, isServerPlatform } from '../platform/platform';
+import { verifySerializable } from '../utils/serialize-utils';
 import {
   invoke,
   newInvokeContext,
@@ -9,16 +11,14 @@ import {
   type InvokeContext,
   type InvokeTuple,
 } from '../../use/use-core';
-import { assertDefined } from '../error/assert';
-import { QError_qrlIsNotFunction, qError } from '../error/error';
-import { getPlatform, isServerPlatform } from '../platform/platform';
-import { QInstanceAttr, getQFuncs } from '../utils/markers';
+import { getQFuncs, QInstanceAttr } from '../utils/markers';
 import { isPromise, maybeThen } from '../utils/promises';
 import { qDev, qSerialize, qTest, seal } from '../utils/qdev';
-import { verifySerializable } from '../utils/serialize-utils';
 import { isArray, isFunction, type ValueOrPromise } from '../utils/types';
+import { isSignal } from '../../signal/signal';
 import type { QRLDev } from './qrl';
 import type { QRL, QrlArgs, QrlReturn } from './qrl.public';
+import type { Signal } from '../../signal/signal.public';
 
 export const isQrl = <T = unknown>(value: unknown): value is QRLInternal<T> => {
   return typeof value === 'function' && typeof (value as any).getSymbol === 'function';

--- a/packages/qwik/src/core/shared/shared-serialization.ts
+++ b/packages/qwik/src/core/shared/shared-serialization.ts
@@ -6,13 +6,8 @@ import { VNodeDataFlag, type VNodeData } from '../../server/vnode-data';
 import { type DomContainer } from '../client/dom-container';
 import type { VNode } from '../client/types';
 import { vnode_getNode, vnode_isVNode, vnode_locate, vnode_toString } from '../client/vnode';
-import {
-  ComputedSignal,
-  EffectData,
-  NEEDS_COMPUTATION,
-  Signal,
-  WrappedSignal,
-} from '../signal/signal';
+import { NEEDS_COMPUTATION } from '../signal/flags';
+import { ComputedSignal, EffectData, Signal, WrappedSignal } from '../signal/signal';
 import type { Subscriber } from '../signal/signal-subscriber';
 import {
   STORE_ARRAY_PROP,

--- a/packages/qwik/src/core/signal/flags.ts
+++ b/packages/qwik/src/core/signal/flags.ts
@@ -1,0 +1,5 @@
+/**
+ * Special value used to mark that a given signal needs to be computed. This is essentially a
+ * "marked as dirty" flag.
+ */
+export const NEEDS_COMPUTATION: any = Symbol('invalid');

--- a/packages/qwik/src/core/signal/signal.ts
+++ b/packages/qwik/src/core/signal/signal.ts
@@ -11,34 +11,29 @@
  *   - It needs to store a function which needs to re-run.
  *   - It is `Readonly` because it is computed.
  */
+import type { VNode } from '../client/types';
+import { vnode_getProp, vnode_isVNode, vnode_isVirtualVNode, vnode_setProp } from '../client/vnode';
 import { pad, qwikDebugToString } from '../debug';
+import type { OnRenderFn } from '../shared/component.public';
 import { assertDefined, assertFalse, assertTrue } from '../shared/error/assert';
+import type { Props } from '../shared/jsx/jsx-runtime';
 import { type QRLInternal } from '../shared/qrl/qrl-class';
 import type { QRL } from '../shared/qrl/qrl.public';
-import { trackSignal, tryGetInvokeContext } from '../use/use-core';
-import { Task, TaskFlags, isTask } from '../use/use-task';
+import { ChoreType, type NodePropData, type NodePropPayload } from '../shared/scheduler';
+import type { Container, HostElement } from '../shared/types';
 import { logError, throwErrorAndStop } from '../shared/utils/log';
 import { ELEMENT_PROPS, OnRenderProp, QSubscribers } from '../shared/utils/markers';
 import { isPromise, retryOnPromise } from '../shared/utils/promises';
 import { qDev } from '../shared/utils/qdev';
-import type { VNode } from '../client/types';
-import { vnode_getProp, vnode_isVirtualVNode, vnode_isVNode, vnode_setProp } from '../client/vnode';
-import { ChoreType, type NodePropData, type NodePropPayload } from '../shared/scheduler';
-import type { Container, HostElement } from '../shared/types';
 import type { ISsrNode } from '../ssr/ssr-types';
+import { trackSignal, tryGetInvokeContext } from '../use/use-core';
+import { Task, TaskFlags, isTask } from '../use/use-task';
+import { NEEDS_COMPUTATION } from './flags';
+import { Subscriber, isSubscriber } from './signal-subscriber';
 import type { Signal as ISignal, ReadonlySignal } from './signal.public';
 import type { TargetType } from './store';
-import { isSubscriber, Subscriber } from './signal-subscriber';
-import type { Props } from '../shared/jsx/jsx-runtime';
-import type { OnRenderFn } from '../shared/component.public';
 
 const DEBUG = false;
-
-/**
- * Special value used to mark that a given signal needs to be computed. This is essentially a
- * "marked as dirty" flag.
- */
-export const NEEDS_COMPUTATION: any = Symbol('invalid');
 
 // eslint-disable-next-line no-console
 const log = (...args: any[]) => console.log('SIGNAL', ...args.map(qwikDebugToString));

--- a/packages/qwik/src/core/signal/signal.ts
+++ b/packages/qwik/src/core/signal/signal.ts
@@ -11,27 +11,27 @@
  *   - It needs to store a function which needs to re-run.
  *   - It is `Readonly` because it is computed.
  */
-import type { VNode } from '../client/types';
-import { vnode_getProp, vnode_isVNode, vnode_isVirtualVNode, vnode_setProp } from '../client/vnode';
 import { pad, qwikDebugToString } from '../debug';
-import type { OnRenderFn } from '../shared/component.public';
 import { assertDefined, assertFalse, assertTrue } from '../shared/error/assert';
-import type { Props } from '../shared/jsx/jsx-runtime';
 import { type QRLInternal } from '../shared/qrl/qrl-class';
 import type { QRL } from '../shared/qrl/qrl.public';
-import { ChoreType, type NodePropData, type NodePropPayload } from '../shared/scheduler';
-import type { Container, HostElement } from '../shared/types';
+import { trackSignal, tryGetInvokeContext } from '../use/use-core';
+import { Task, TaskFlags, isTask } from '../use/use-task';
 import { logError, throwErrorAndStop } from '../shared/utils/log';
 import { ELEMENT_PROPS, OnRenderProp, QSubscribers } from '../shared/utils/markers';
 import { isPromise, retryOnPromise } from '../shared/utils/promises';
 import { qDev } from '../shared/utils/qdev';
+import type { VNode } from '../client/types';
+import { vnode_getProp, vnode_isVirtualVNode, vnode_isVNode, vnode_setProp } from '../client/vnode';
+import { ChoreType, type NodePropData, type NodePropPayload } from '../shared/scheduler';
+import type { Container, HostElement } from '../shared/types';
 import type { ISsrNode } from '../ssr/ssr-types';
-import { trackSignal, tryGetInvokeContext } from '../use/use-core';
-import { Task, TaskFlags, isTask } from '../use/use-task';
-import { NEEDS_COMPUTATION } from './flags';
-import { Subscriber, isSubscriber } from './signal-subscriber';
 import type { Signal as ISignal, ReadonlySignal } from './signal.public';
 import type { TargetType } from './store';
+import { isSubscriber, Subscriber } from './signal-subscriber';
+import type { Props } from '../shared/jsx/jsx-runtime';
+import type { OnRenderFn } from '../shared/component.public';
+import { NEEDS_COMPUTATION } from './flags';
 
 const DEBUG = false;
 


### PR DESCRIPTION
# What is it?

- Infra

# Description

This PR should make the complicated code of `createQrl` a little bit easier to follow.

Renamed the `invokeFn` as it doesn't really mean what you think it means... 

and sorted the functions based on their order of their invocation, so it'll reduce the "scroll fatigue" caused by scrolling down and up multiple times just in order to follow the complicated timeline as if it was the movie pulp fiction o something... 😅

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
