### PR TITLE
chore(v2 starter): add missing import

### DIFF
--- a/starters/apps/base/src/entry.preview.tsx
+++ b/starters/apps/base/src/entry.preview.tsx
@@ -10,7 +10,7 @@
  * - https://vitejs.dev/config/preview-options.html#preview-options
  *
  */
-import qwikRouterConfig from '@qwik-router-config';
+import qwikRouterConfig from "@qwik-router-config";
 import { createQwikRouter } from "@qwik.dev/router/middleware/node";
 // make sure qwikRouterConfig is imported before entry
 import render from "./entry.ssr";

--- a/starters/apps/base/src/entry.preview.tsx
+++ b/starters/apps/base/src/entry.preview.tsx
@@ -10,6 +10,7 @@
  * - https://vitejs.dev/config/preview-options.html#preview-options
  *
  */
+import qwikRouterConfig from '@qwik-router-config';
 import { createQwikRouter } from "@qwik.dev/router/middleware/node";
 // make sure qwikRouterConfig is imported before entry
 import render from "./entry.ssr";


### PR DESCRIPTION
I created a new app with `create qwik@2.0.0-alpha.1` and I found a missing import