### PR TITLE
docs(cookbox/theme-management): replaces deprecated tailwind "class" …

### DIFF
--- a/packages/docs/src/routes/docs/cookbook/theme-management/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/theme-management/index.mdx
@@ -46,7 +46,7 @@ You have to enable the darkmode from your ```tailwind.config.js``` file. It shou
 ```js
 module.exports = {
   content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
-  darkMode: "class",
+  darkMode: "selector",
   theme: {},
   plugins: [],
 };


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?
- Docs

# Description
TLDR: Fixes deprecated method.

This is a small change. At some point, the 'class' strategy was replaced by the 'selector' strategy. 

Despite the small code change, I'm marking this as a draft for one big reason:

1) I couldn't figure out the correct way to change the header/metadata of the file. 

If that gets  fixed, this should be an easy merge. Everything works as it did before (test [repo](https://github.com/TheMcnafaha/cookbook-theme-manegement) if curious).

 I plan on making a new PR after this as I want to improve the behavior of the guide. Mainly, the current guide doesn't respect the user's default theme. 

# Checklist



- [X] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [X] I performed a self-review of my own code
- [X] I made corresponding changes to the Qwik docs

