### PR TITLE
chore: improve theme-management cookbook

### DIFF
--- a/packages/docs/src/routes/docs/cookbook/theme-management/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/theme-management/index.mdx
@@ -56,23 +56,25 @@ module.exports = {
 Then we have to add this code in the head tag of our ```root.tsx``` file.
 
 ```js
-<script
+       <script
           dangerouslySetInnerHTML={`
         (function() {
           function setTheme(theme) {
             document.documentElement.className = theme;
             localStorage.setItem('theme', theme);
           }
-          var theme = localStorage.getItem('theme');
-          console.log(theme);
+          const theme = localStorage.getItem('theme');
+
           if (theme) {
             setTheme(theme);
           } else {
-            setTheme('light');
-          }
+            if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+              setTheme('dark');}
+              else {
+                setTheme('light');}}
         })();
         window.addEventListener('load', function() {
-          var themeSwitch = document.getElementById('hide-checkbox');
+          const themeSwitch = document.getElementById('hide-checkbox');
           themeSwitch.checked = localStorage.getItem('theme') === 'light'? true: false;
         }
         );


### PR DESCRIPTION


# What is it?
- Docs


# Description
Previous version of this set the theme to light if no theme was found in local storage. Updated version checks for preferences and sets accordingly.

That is: if nothing saved in local storage and prefers dark mode, local storage is set to dark etc....
# Checklist

-  [x] Tested locally and seems to work just fine on a new qwik app.
