### PR TITLE
fix v2 `latest` tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -857,6 +857,14 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      # Delete this after V2 is released
+      - name: Tag with latest
+        if: steps.changesets.outcome == 'success'
+        run: |
+          npm dist-tag add @qwik.dev/core@${{ fromJson(steps.changesets.outputs.publishedPackages)[0].version }} latest
+          npm dist-tag add @qwik.dev/router@${{ fromJson(steps.changesets.outputs.publishedPackages)[0].version }} latest
+          npm dist-tag add @qwik.dev/react@${{ fromJson(steps.changesets.outputs.publishedPackages)[0].version }} latest
+
       - name: Fixup package.json files
         run: pnpm run release.fixup-package-json
 


### PR DESCRIPTION
# What is it?

<!-- pick one and remove the others -->

- Infra

# Description

Currently the npm tag `latest` is stuck on `alpha.0`, this temporary fix should make sure it always sets the latest release to `latest` as well.

We should delete / change this once V2 is officially released.

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
