### PR TITLE
fix: replacing projection content with null or undefined

### DIFF
--- a/.changeset/twenty-goats-flow.md
+++ b/.changeset/twenty-goats-flow.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: replacing projection content with null or undefined

--- a/packages/qwik/src/core/tests/projection.spec.tsx
+++ b/packages/qwik/src/core/tests/projection.spec.tsx
@@ -101,11 +101,11 @@ describe.each([
     });
     const { vNode } = await render(<Parent />, { debug: DEBUG });
     expect(vNode).toMatchVDOM(
-      <Fragment>
-        <Fragment>
-          <Fragment>default-value</Fragment>
-        </Fragment>
-      </Fragment>
+      <Component>
+        <Component>
+          <Projection>default-value</Projection>
+        </Component>
+      </Component>
     );
   });
   it('should save default value in q:template if not used', async () => {
@@ -258,6 +258,207 @@ describe.each([
       </Fragment>
     );
   });
+
+  it('should replace projection content with undefined', async () => {
+    const Test = component$(() => {
+      return (
+        <div>
+          <Slot />
+        </div>
+      );
+    });
+
+    const Cmp = component$(() => {
+      const test = useSignal<number | undefined>(1);
+
+      return (
+        <div>
+          <Test>
+            {test.value ? (
+              <div>
+                <h1>Hello from Qwik</h1>
+              </div>
+            ) : undefined}
+          </Test>
+
+          <button
+            onClick$={() => {
+              test.value = test.value ? undefined : 1;
+            }}
+          ></button>
+        </div>
+      );
+    });
+
+    const { vNode, document } = await render(<Cmp />, { debug: DEBUG });
+
+    expect(vNode).toMatchVDOM(
+      <Component>
+        <div>
+          <Component>
+            <div>
+              <Projection>
+                <div>
+                  <h1>Hello from Qwik</h1>
+                </div>
+              </Projection>
+            </div>
+          </Component>
+          <button></button>
+        </div>
+      </Component>
+    );
+
+    await trigger(document.body, 'button', 'click');
+
+    expect(vNode).toMatchVDOM(
+      <Component>
+        <div>
+          <Component>
+            <div>
+              <Projection>{''}</Projection>
+            </div>
+          </Component>
+          <button></button>
+        </div>
+      </Component>
+    );
+
+    await trigger(document.body, 'button', 'click');
+
+    expect(vNode).toMatchVDOM(
+      <Component>
+        <div>
+          <Component>
+            <div>
+              <Projection>
+                <div>
+                  <h1>Hello from Qwik</h1>
+                </div>
+              </Projection>
+            </div>
+          </Component>
+          <button></button>
+        </div>
+      </Component>
+    );
+
+    await trigger(document.body, 'button', 'click');
+
+    expect(vNode).toMatchVDOM(
+      <Component>
+        <div>
+          <Component>
+            <div>
+              <Projection>{''}</Projection>
+            </div>
+          </Component>
+          <button></button>
+        </div>
+      </Component>
+    );
+  });
+
+  it('should replace projection content with null', async () => {
+    const Test = component$(() => {
+      return (
+        <div>
+          <Slot />
+        </div>
+      );
+    });
+
+    const Cmp = component$(() => {
+      const test = useSignal<number | null>(1);
+
+      return (
+        <div>
+          <Test>
+            {test.value ? (
+              <div>
+                <h1>Hello from Qwik</h1>
+              </div>
+            ) : null}
+          </Test>
+
+          <button
+            onClick$={() => {
+              test.value = test.value ? null : 1;
+            }}
+          ></button>
+        </div>
+      );
+    });
+
+    const { vNode, document } = await render(<Cmp />, { debug: DEBUG });
+
+    expect(vNode).toMatchVDOM(
+      <Component>
+        <div>
+          <Component>
+            <div>
+              <Projection>
+                <div>
+                  <h1>Hello from Qwik</h1>
+                </div>
+              </Projection>
+            </div>
+          </Component>
+          <button></button>
+        </div>
+      </Component>
+    );
+
+    await trigger(document.body, 'button', 'click');
+
+    expect(vNode).toMatchVDOM(
+      <Component>
+        <div>
+          <Component>
+            <div>
+              <Projection>{''}</Projection>
+            </div>
+          </Component>
+          <button></button>
+        </div>
+      </Component>
+    );
+
+    await trigger(document.body, 'button', 'click');
+
+    expect(vNode).toMatchVDOM(
+      <Component>
+        <div>
+          <Component>
+            <div>
+              <Projection>
+                <div>
+                  <h1>Hello from Qwik</h1>
+                </div>
+              </Projection>
+            </div>
+          </Component>
+          <button></button>
+        </div>
+      </Component>
+    );
+
+    await trigger(document.body, 'button', 'click');
+
+    expect(vNode).toMatchVDOM(
+      <Component>
+        <div>
+          <Component>
+            <div>
+              <Projection>{''}</Projection>
+            </div>
+          </Component>
+          <button></button>
+        </div>
+      </Component>
+    );
+  });
+
   it('should ignore Slot inside inline-component', async () => {
     const Child = (props: { children: any }) => {
       return (


### PR DESCRIPTION
Before we ignored children if they were equal to null or undefined. We should only ignore them if we don't have old projection slots and the children are null

closes #7147