### PR TITLE
fix migrating from V1 with module resolution "node'

### DIFF
--- a/.changeset/friendly-gorillas-walk.md
+++ b/.changeset/friendly-gorillas-walk.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+FIX: types error when migrating to V2 with `moduleResulution: "node"`

--- a/packages/qwik-router/package.json
+++ b/packages/qwik-router/package.json
@@ -158,7 +158,8 @@
       "types": "./lib/service-worker.d.ts",
       "import": "./lib/service-worker.mjs",
       "require": "./lib/service-worker.cjs"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "adapters",

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -134,7 +134,7 @@
     "./qwikloader.debug.js": "./dist/qwikloader.debug.js",
     "./qwik-prefetch.js": "./dist/qwik-prefetch.js",
     "./qwik-prefetch.debug.js": "./dist/qwik-prefetch.debug.js",
-    "./package.json": "./dist/package.json"
+    "./package.json": "./package.json"
   },
   "exports_annotation": "We use the build for the optimizer because esbuild doesn't like the html?raw imports in the server plugin and it's only used in the vite configs",
   "files": [
@@ -194,5 +194,5 @@
     "build.insights": "cd src/insights && vite build --mode lib --emptyOutDir"
   },
   "type": "module",
-  "types": "./dist/core.d.ts"
+  "types": "./public.d.ts"
 }


### PR DESCRIPTION

# What is it?

- Bug

# Description

Actually fixes #7130
Now migrating from V1 with `moduleResolution: "node"` in the `tscofnig.json` won't break typescript. 


# Checklist

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
