### PR TITLE
fix: store effects cleanup & projection siblings serialization

### DIFF
--- a/.changeset/forty-garlics-train.md
+++ b/.changeset/forty-garlics-train.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: store effects cleanup

--- a/.changeset/friendly-sloths-return.md
+++ b/.changeset/friendly-sloths-return.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: projection siblings serialization

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -1288,7 +1288,7 @@ export function cleanup(container: ClientContainer, vNode: VNode) {
             const obj = seq[i];
             if (isTask(obj)) {
               const task = obj;
-              clearSubscriberEffectDependencies(task);
+              clearSubscriberEffectDependencies(container, task);
               if (task.$flags$ & TaskFlags.VISIBLE_TASK) {
                 container.$scheduler$(ChoreType.CLEANUP_VISIBLE, task);
               } else {

--- a/packages/qwik/src/core/client/vnode.ts
+++ b/packages/qwik/src/core/client/vnode.ts
@@ -1669,7 +1669,7 @@ export const vnode_getNode = (vnode: VNode | null): Element | Text | null => {
 
 export function vnode_toString(
   this: VNode | null,
-  depth: number = 10,
+  depth: number = 20,
   offset: string = '',
   materialize: boolean = false,
   siblings = false

--- a/packages/qwik/src/core/shared/shared-serialization.ts
+++ b/packages/qwik/src/core/shared/shared-serialization.ts
@@ -178,7 +178,7 @@ const inflate = (
   target: any,
   typeId: TypeIds,
   data: unknown
-): any => {
+): unknown => {
   if (typeId === undefined) {
     // Already processed
     return target;

--- a/packages/qwik/src/core/signal/signal-subscriber.ts
+++ b/packages/qwik/src/core/signal/signal-subscriber.ts
@@ -1,11 +1,17 @@
 import { QSubscribers } from '../shared/utils/markers';
-import type { VNode } from '../client/types';
-import { ensureMaterialized, vnode_getProp, vnode_isElementVNode } from '../client/vnode';
-import { EffectSubscriptionsProp, WrappedSignal, isSignal } from './signal';
+import type { ElementVNode, VNode, VirtualVNode } from '../client/types';
+import {
+  ensureMaterialized,
+  vnode_getProp,
+  vnode_isElementVNode,
+  vnode_setProp,
+} from '../client/vnode';
+import { EffectSubscriptionsProp, WrappedSignal, isSignal, type Signal } from './signal';
 import type { Container } from '../shared/types';
+import { StoreHandler, getStoreHandler, isStore, type TargetType } from './store';
 
 export abstract class Subscriber {
-  $effectDependencies$: Subscriber[] | null = null;
+  $effectDependencies$: (Subscriber | TargetType)[] | null = null;
 }
 
 export function isSubscriber(value: unknown): value is Subscriber {
@@ -22,35 +28,55 @@ export function clearVNodeEffectDependencies(container: Container, value: VNode)
   }
   for (let i = effects.length - 1; i >= 0; i--) {
     const subscriber = effects[i];
-    const subscriptionRemoved = clearEffects(subscriber, value);
-    if (subscriptionRemoved) {
-      effects.splice(i, 1);
-    }
+    clearEffects(subscriber, value, effects, i, container);
+  }
+
+  if (effects.length === 0) {
+    vnode_setProp(value as ElementVNode | VirtualVNode, QSubscribers, null);
   }
 }
 
-export function clearSubscriberEffectDependencies(value: Subscriber): void {
+export function clearSubscriberEffectDependencies(container: Container, value: Subscriber): void {
   if (value.$effectDependencies$) {
     for (let i = value.$effectDependencies$.length - 1; i >= 0; i--) {
       const subscriber = value.$effectDependencies$[i];
-      const subscriptionRemoved = clearEffects(subscriber, value);
-      if (subscriptionRemoved) {
-        value.$effectDependencies$.splice(i, 1);
-      }
+      clearEffects(subscriber, value, value.$effectDependencies$, i, container);
+    }
+
+    if (value.$effectDependencies$.length === 0) {
+      value.$effectDependencies$ = null;
     }
   }
 }
 
-function clearEffects(subscriber: Subscriber, value: Subscriber | VNode): boolean {
-  if (!isSignal(subscriber)) {
-    return false;
+function clearEffects(
+  subscriber: Subscriber | TargetType,
+  value: Subscriber | VNode,
+  effectArray: (Subscriber | TargetType)[],
+  indexToRemove: number,
+  container: Container
+) {
+  let subscriptionRemoved = false;
+  const seenSet = new Set();
+  if (subscriber instanceof WrappedSignal) {
+    subscriptionRemoved = clearSignalEffects(subscriber, value, seenSet);
+  } else if (container.$storeProxyMap$.has(subscriber)) {
+    const store = container.$storeProxyMap$.get(subscriber)!;
+    const handler = getStoreHandler(store)!;
+    subscriptionRemoved = clearStoreEffects(handler, value);
   }
-  const effectSubscriptions = (subscriber as WrappedSignal<unknown>).$effects$;
-  const hostElement = (subscriber as WrappedSignal<unknown>).$hostElement$;
+  if (subscriptionRemoved) {
+    effectArray.splice(indexToRemove, 1);
+  }
+}
 
-  if (hostElement && hostElement === value) {
-    (subscriber as WrappedSignal<unknown>).$hostElement$ = null;
-  }
+function clearSignalEffects(
+  subscriber: Signal,
+  value: Subscriber | VNode,
+  seenSet: Set<unknown>
+): boolean {
+  const effectSubscriptions = subscriber.$effects$;
+
   let subscriptionRemoved = false;
   if (effectSubscriptions) {
     for (let i = effectSubscriptions.length - 1; i >= 0; i--) {
@@ -62,13 +88,67 @@ function clearEffects(subscriber: Subscriber, value: Subscriber | VNode): boolea
     }
   }
 
-  // clear the effects of the arguments
-  const args = (subscriber as WrappedSignal<unknown>).$args$;
-  if (args) {
-    for (let i = args.length - 1; i >= 0; i--) {
-      clearEffects(args[i], subscriber);
+  if (subscriber instanceof WrappedSignal) {
+    const hostElement = subscriber.$hostElement$;
+    if (hostElement && hostElement === value) {
+      subscriber.$hostElement$ = null;
+    }
+
+    // clear the effects of the arguments
+    const args = subscriber.$args$;
+    if (args) {
+      clearArgsEffects(args, subscriber, seenSet);
     }
   }
 
   return subscriptionRemoved;
+}
+
+function clearStoreEffects(storeHandler: StoreHandler, value: Subscriber | VNode): boolean {
+  const effectSubscriptions = storeHandler.$effects$;
+  if (!effectSubscriptions) {
+    return false;
+  }
+  let subscriptionRemoved = false;
+  for (const key in effectSubscriptions) {
+    const effects = effectSubscriptions[key];
+    for (let i = effects.length - 1; i >= 0; i--) {
+      const effect = effects[i];
+      if (effect[EffectSubscriptionsProp.EFFECT] === value) {
+        effects.splice(i, 1);
+        subscriptionRemoved = true;
+      }
+    }
+  }
+
+  return subscriptionRemoved;
+}
+
+function clearArgsEffects(args: any[], subscriber: Subscriber, seenSet: Set<unknown>): void {
+  for (let i = args.length - 1; i >= 0; i--) {
+    const arg = args[i];
+    clearArgEffect(arg, subscriber, seenSet);
+  }
+}
+
+function clearArgEffect(arg: any, subscriber: Subscriber, seenSet: Set<unknown>): void {
+  if (seenSet.has(arg)) {
+    return;
+  }
+  seenSet.add(arg);
+  if (isSignal(arg)) {
+    clearSignalEffects(arg as Signal, subscriber, seenSet);
+  } else if (typeof arg === 'object' && arg !== null) {
+    if (isStore(arg)) {
+      clearStoreEffects(getStoreHandler(arg)!, subscriber);
+    } else {
+      for (const key in arg) {
+        clearArgEffect(arg[key], subscriber, seenSet);
+      }
+    }
+  } else if (Array.isArray(arg)) {
+    clearArgsEffects(arg, subscriber, seenSet);
+  } else {
+    // primitives
+  }
 }

--- a/packages/qwik/src/core/signal/signal-subscriber.ts
+++ b/packages/qwik/src/core/signal/signal-subscriber.ts
@@ -119,6 +119,9 @@ function clearStoreEffects(storeHandler: StoreHandler, value: Subscriber | VNode
         subscriptionRemoved = true;
       }
     }
+    if (effects.length === 0) {
+      delete effectSubscriptions[key];
+    }
   }
 
   return subscriptionRemoved;

--- a/packages/qwik/src/core/signal/signal.ts
+++ b/packages/qwik/src/core/signal/signal.ts
@@ -259,7 +259,7 @@ export const ensureContainsEffect = (
 
 export const ensureEffectContainsSubscriber = (
   effect: Effect,
-  subscriber: Subscriber,
+  subscriber: Subscriber | TargetType,
   container: Container | null
 ) => {
   if (isSubscriber(effect)) {
@@ -271,7 +271,7 @@ export const ensureEffectContainsSubscriber = (
 
     effect.$effectDependencies$.push(subscriber);
   } else if (vnode_isVNode(effect) && !vnode_isTextVNode(effect)) {
-    let subscribers = vnode_getProp<Subscriber[]>(
+    let subscribers = vnode_getProp<(Subscriber | TargetType)[]>(
       effect,
       QSubscribers,
       container ? container.$getObjectById$ : null
@@ -285,7 +285,7 @@ export const ensureEffectContainsSubscriber = (
     subscribers.push(subscriber);
     vnode_setProp(effect, QSubscribers, subscribers);
   } else if (isSSRNode(effect)) {
-    let subscribers = effect.getProp(QSubscribers) as Subscriber[];
+    let subscribers = effect.getProp(QSubscribers) as (Subscriber | TargetType)[];
     subscribers ||= [];
 
     if (subscriberExistInSubscribers(subscribers, subscriber)) {
@@ -301,7 +301,10 @@ const isSSRNode = (effect: Effect): effect is ISsrNode => {
   return 'setProp' in effect && 'getProp' in effect && 'removeProp' in effect && 'id' in effect;
 };
 
-const subscriberExistInSubscribers = (subscribers: Subscriber[], subscriber: Subscriber) => {
+const subscriberExistInSubscribers = (
+  subscribers: (Subscriber | TargetType)[],
+  subscriber: Subscriber | TargetType
+) => {
   for (let i = 0; i < subscribers.length; i++) {
     if (subscribers[i] === subscriber) {
       return true;

--- a/packages/qwik/src/core/tests/use-styles-scoped.spec.tsx
+++ b/packages/qwik/src/core/tests/use-styles-scoped.spec.tsx
@@ -374,8 +374,8 @@ describe.each([
     expect(vNode).toMatchVDOM(
       <Component>
         <div class={`${(globalThis as any).rawStyleId1} container`}>
-          <Fragment>
-            <Component>
+          <Fragment ssr-required>
+            <Component ssr-required>
               <div class={`${(globalThis as any).rawStyleId2} container`}>Hello world 2</div>
             </Component>
           </Fragment>

--- a/packages/qwik/src/core/use/use-resource.ts
+++ b/packages/qwik/src/core/use/use-resource.ts
@@ -191,14 +191,14 @@ function getResourceValueAsPromise<T>(props: ResourceProps<T>): Promise<JSXOutpu
       DEBUG && debugLog(`RESOURCE_CMP.${state}`, 'VALUE: ' + untrack(() => resource._resolved));
 
       if (state === 'pending' && props.onPending) {
-        return Promise.resolve(props.onPending());
+        return Promise.resolve().then(useBindInvokeContext(props.onPending));
       } else if (state === 'rejected' && props.onRejected) {
-        return Promise.resolve(resource._error!).then(props.onRejected);
+        return Promise.resolve(resource._error!).then(useBindInvokeContext(props.onRejected));
       } else {
         const resolvedValue = untrack(() => resource._resolved) as T;
         if (resolvedValue !== undefined) {
           // resolved, pending without onPending prop or rejected without onRejected prop
-          return Promise.resolve(resolvedValue).then(props.onResolved);
+          return Promise.resolve(resolvedValue).then(useBindInvokeContext(props.onResolved));
         }
       }
     }

--- a/packages/qwik/src/core/use/use-resource.ts
+++ b/packages/qwik/src/core/use/use-resource.ts
@@ -271,7 +271,7 @@ export const runResource = <T>(
   const iCtx = newInvokeContext(container.$locale$, host, undefined, ResourceEvent);
   iCtx.$container$ = container;
 
-  const taskFn = task.$qrl$.getFn(iCtx, () => clearSubscriberEffectDependencies(task));
+  const taskFn = task.$qrl$.getFn(iCtx, () => clearSubscriberEffectDependencies(container, task));
 
   const resource = task.$state$;
   assertDefined(

--- a/packages/qwik/src/core/use/use-task.ts
+++ b/packages/qwik/src/core/use/use-task.ts
@@ -190,7 +190,9 @@ export const runTask = (
   cleanupTask(task);
   const iCtx = newInvokeContext(container.$locale$, host, undefined, TaskEvent);
   iCtx.$container$ = container;
-  const taskFn = task.$qrl$.getFn(iCtx, () => clearSubscriberEffectDependencies(task)) as TaskFn;
+  const taskFn = task.$qrl$.getFn(iCtx, () =>
+    clearSubscriberEffectDependencies(container, task)
+  ) as TaskFn;
 
   const track: Tracker = (obj: (() => unknown) | object | Signal<unknown>, prop?: string) => {
     const ctx = newInvokeContext();

--- a/packages/qwik/src/server/ssr-container.ts
+++ b/packages/qwik/src/server/ssr-container.ts
@@ -458,12 +458,10 @@ class SSRContainer extends _SharedContainer implements ISSRContainer {
 
   openProjection(attrs: SsrAttrs) {
     this.openFragment(attrs);
-    const vNode = this.currentElementFrame?.vNodeData;
-    if (vNode) {
-      vNode[0] |= VNodeDataFlag.SERIALIZE;
-    }
     const componentFrame = this.getComponentFrame();
     if (componentFrame) {
+      // TODO: we should probably serialize only projection VNode
+      this.serializationCtx.$addRoot$(componentFrame.componentNode);
       componentFrame.projectionDepth++;
     }
   }


### PR DESCRIPTION
- Cleanup store effects on VNode destory etc.
- Serialize all projection siblings. Previously we only added the `SERIALIZE` flag, which is a bug, because we did not serialize component props that were siblings of the projection
- Run resource functions within invoke context