### PR TITLE
fix: find correct context after rendering empty array

### DIFF
--- a/.changeset/purple-melons-invent.md
+++ b/.changeset/purple-melons-invent.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: find correct context after rendering empty array

--- a/packages/qwik/src/core/tests/use-context.spec.tsx
+++ b/packages/qwik/src/core/tests/use-context.spec.tsx
@@ -101,6 +101,59 @@ describe.each([
     );
   });
 
+  it('should add slot information for empty array', async () => {
+    const qErrorSpy = vi.spyOn(qError, 'qError');
+    const contextId = createContextId('contextId');
+
+    const ContextProducer = component$(() => {
+      const context = {
+        disabled: false,
+      };
+      useContextProvider(contextId, context);
+      return <Slot />;
+    });
+
+    const ProducerParent = component$(() => {
+      return (
+        <ContextProducer>
+          <Slot />
+        </ContextProducer>
+      );
+    });
+
+    const ContextConsumer = component$(() => {
+      useContext(contextId);
+      return <Slot />;
+    });
+
+    const Parent = component$(() => {
+      const array = useSignal<string[]>([]);
+      return (
+        <>
+          <ProducerParent>
+            {array.value.map((_, index) => (
+              <ContextConsumer key={index} />
+            ))}
+          </ProducerParent>
+          <button onClick$={() => (array.value = ['test'])}></button>
+        </>
+      );
+    });
+
+    try {
+      const { document } = await render(
+        <ErrorProvider>
+          <Parent />
+        </ErrorProvider>,
+        { debug }
+      );
+      await trigger(document.body, 'button', 'click');
+      expect(qErrorSpy).not.toHaveBeenCalled();
+    } catch (e) {
+      expect(qErrorSpy).not.toHaveBeenCalled();
+    }
+  });
+
   it('should find context parent from Slot inside Slot', async () => {
     const qErrorSpy = vi.spyOn(qError, 'qError');
     const contextId = createContextId('contextId');

--- a/packages/qwik/src/server/ssr-node.ts
+++ b/packages/qwik/src/server/ssr-node.ts
@@ -141,7 +141,7 @@ export class SsrComponentFrame implements ISsrComponentFrame {
     if (isJSXNode(children)) {
       const slotName = this.getSlotName(children);
       mapArray_set(this.slots, slotName, children, 0);
-    } else if (Array.isArray(children)) {
+    } else if (Array.isArray(children) && children.length > 0) {
       const defaultSlot = [];
       for (let i = 0; i < children.length; i++) {
         const child = children[i];
@@ -156,7 +156,7 @@ export class SsrComponentFrame implements ISsrComponentFrame {
           defaultSlot.push(child);
         }
       }
-      defaultSlot.length && mapArray_set(this.slots, QDefaultSlot, defaultSlot, 0);
+      defaultSlot.length > 0 && mapArray_set(this.slots, QDefaultSlot, defaultSlot, 0);
     } else {
       mapArray_set(this.slots, QDefaultSlot, children, 0);
     }


### PR DESCRIPTION
Fix a problem with slot prop for ssr. Empty arrays should be considered as empty content.