### PR TITLE
docs: fix bad link to zod validation

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/getting-started/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/getting-started/index.mdx
@@ -625,7 +625,7 @@ For more on just how much you can achieve with Qwik, check out the dedicated doc
 - [Directory-based routing](/docs/(qwikcity)/routing/index.mdx#directory-based-routing)
 - [Component](/docs/(qwik)/components/overview/index.mdx)
 - [Route loaders](/docs/(qwikcity)/route-loader/index.mdx)
-- [Form actions](/docs/(qwikcity)/action/index.mdx) && [zod validation](/docs/(qwikcity)/action/index.mdx#zod-validation)
+- [Form actions](/docs/(qwikcity)/action/index.mdx) && [zod validation](/docs/(qwikcity)/action/index.mdx#validation-and-type-safety)
 - [State management](/docs/(qwik)/components/state/index.mdx)
 - [Tasks](/docs/(qwik)/components/tasks/index.mdx#use-usetask-when-you-need-to)
 - [ServiceWorker cache](/docs/(qwikcity)/advanced/speculative-module-fetching/index.mdx#pre-populating-the-cache-with-a-service-worker)


### PR DESCRIPTION

# What is it?

Docs

# Description

The link to zod validation is incorrect

# Checklist

- [X] I made corresponding changes to the Qwik docs
