### PR TITLE
fix: remove usage of computedStyleMap

### DIFF
--- a/.changeset/cold-dogs-hunt.md
+++ b/.changeset/cold-dogs-hunt.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': patch
+---
+
+fix: remove usage of `computedStyleMap`

--- a/packages/qwik/src/optimizer/src/plugins/image-size-runtime.html
+++ b/packages/qwik/src/optimizer/src/plugins/image-size-runtime.html
@@ -312,11 +312,11 @@
         const browserArea = rect.width * rect.height;
         if (!node.hasAttribute('width') || !node.hasAttribute('height')) {
           skip = true;
-          const computedStyles = node.computedStyleMap();
-          const hasAspect = computedStyles.get('aspect-ratio').toString() !== 'auto';
-          const hasWidth = isDefinedUnit(computedStyles.get('width').toString());
-          const hasHeight = isDefinedUnit(computedStyles.get('height').toString());
-          const isAbsolute = computedStyles.get('position').toString() === 'absolute';
+          const computedStyles = getComputedStyle(node);
+          const hasAspect = computedStyles.getPropertyValue('aspect-ratio').toString() !== 'auto';
+          const hasWidth = isDefinedUnit(computedStyles.getPropertyValue('width').toString());
+          const hasHeight = isDefinedUnit(computedStyles.getPropertyValue('height').toString());
+          const isAbsolute = computedStyles.getPropertyValue('position').toString() === 'absolute';
           layoutInvalidation =
             browserArea > 1000 && !isAbsolute && !hasAspect && (!hasWidth || !hasHeight);
         }


### PR DESCRIPTION
`computedStyleMap` is not supported on Firefox