### PR TITLE
docs: clarify use of emojis in useStylesScoped$

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/components/styles/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/components/styles/index.mdx
@@ -187,6 +187,11 @@ export const Cmp = component$(() => {
 ## Scoped CSS
 
 To use scoped CSS, you can use the `useStylesScoped$()` hook exported from `@builder.io/qwik`.
+> `useStylesScoped$()` uses emojis to set a unique name on the selector. This is added by Qwik to avoid CSS name / selector clashes, and to ensure that the styles are correctly scoped as expected..
+
+
+
+
 
 ```tsx {4-8} title="src/components/MyComponent/MyComponent.tsx"
 import { component$, useStylesScoped$ } from '@builder.io/qwik';


### PR DESCRIPTION



# What is it?

<!-- pick one and remove the others -->

- Docs 


# Description
Hi Everyone.

Little bit of background on this PR.

In Discord the question was raised "what does the star icon represent when inspecting the DOM?"

See link: [https://discord.com/channels/842438759945601056/1326121240074780722](https://discord.com/channels/842438759945601056/1326121240074780722)


This emoji is in the process of being updated from start to a lightening bolt.
See PR: #7248 

I have tried to update the docs to futureproof this change by not referencing the specific emoji.
But may need to update this after the release in which the icon has changed.

Also as a note: there is a star reference in the docs that will need to be updated after the icon has changed.
Quote:
".list.⭐️8vzca0-0 > *:nth-child(3)"


Have a great day everyone.
<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->


- [x] I made corresponding changes to the Qwik docs
