### PR TITLE
feat: Add Standard Schema validator to Qwik City

### DIFF
--- a/packages/qwik-city/package.json
+++ b/packages/qwik-city/package.json
@@ -5,6 +5,7 @@
   "bugs": "https://github.com/QwikDev/qwik/issues",
   "dependencies": {
     "@mdx-js/mdx": "^3",
+    "@standard-schema/spec": "1.0.0-rc.0",
     "@types/mdx": "^2",
     "source-map": "^0.7.4",
     "svgo": "^3.3",

--- a/packages/qwik-city/src/runtime/src/types.ts
+++ b/packages/qwik-city/src/runtime/src/types.ts
@@ -15,6 +15,7 @@ import type {
   ResolveSyncValue,
   EnvGetter,
 } from '@builder.io/qwik-city/middleware/request-handler';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import type * as v from 'valibot';
 import type * as z from 'zod';
 
@@ -363,19 +364,23 @@ export type JSONObject = { [x: string]: JSONValue };
 
 /** @public */
 export type GetValidatorInputType<VALIDATOR extends TypedDataValidator> =
-  VALIDATOR extends ValibotDataValidator<infer TYPE>
-    ? v.InferInput<TYPE>
-    : VALIDATOR extends ZodDataValidator<infer TYPE>
-      ? z.input<TYPE>
-      : never;
+  VALIDATOR extends StandardSchemaDataValidator<infer TYPE>
+    ? StandardSchemaV1.InferInput<TYPE>
+    : VALIDATOR extends ValibotDataValidator<infer TYPE>
+      ? v.InferInput<TYPE>
+      : VALIDATOR extends ZodDataValidator<infer TYPE>
+        ? z.input<TYPE>
+        : never;
 
 /** @public */
 export type GetValidatorOutputType<VALIDATOR extends TypedDataValidator> =
-  VALIDATOR extends ValibotDataValidator<infer TYPE>
-    ? v.InferOutput<TYPE>
-    : VALIDATOR extends ZodDataValidator<infer TYPE>
-      ? z.output<TYPE>
-      : never;
+  VALIDATOR extends StandardSchemaDataValidator<infer TYPE>
+    ? StandardSchemaV1.InferOutput<TYPE>
+    : VALIDATOR extends ValibotDataValidator<infer TYPE>
+      ? v.InferOutput<TYPE>
+      : VALIDATOR extends ZodDataValidator<infer TYPE>
+        ? z.output<TYPE>
+        : never;
 
 /** @public */
 export type GetValidatorType<VALIDATOR extends TypedDataValidator> =
@@ -827,6 +832,29 @@ export type ValidatorConstructorQRL = {
 };
 
 /** @alpha */
+export type StandardSchemaDataValidator<T extends StandardSchemaV1 = StandardSchemaV1> = {
+  readonly __brand: 'standard-schema';
+  validate(
+    ev: RequestEvent,
+    data: unknown
+  ): Promise<ValidatorReturn<ValidatorErrorType<StandardSchemaV1.InferInput<T>>>>;
+};
+
+/** @alpha */
+export type StandardSchemaConstructor = {
+  <T extends StandardSchemaV1>(schema: T): StandardSchemaDataValidator<T>;
+  <T extends StandardSchemaV1>(schema: (ev: RequestEvent) => T): StandardSchemaDataValidator<T>;
+};
+
+/** @alpha */
+export type StandardSchemaConstructorQRL = {
+  <T extends StandardSchemaV1>(schema: QRL<T>): StandardSchemaDataValidator<T>;
+  <T extends StandardSchemaV1>(
+    schema: QRL<(ev: RequestEvent) => T>
+  ): StandardSchemaDataValidator<T>;
+};
+
+/** @alpha */
 export type ValibotDataValidator<
   T extends v.GenericSchema | v.GenericSchemaAsync = v.GenericSchema | v.GenericSchemaAsync,
 > = {
@@ -883,7 +911,10 @@ export type ZodConstructorQRL = {
 };
 
 /** @public */
-export type TypedDataValidator = ValibotDataValidator | ZodDataValidator;
+export type TypedDataValidator =
+  | StandardSchemaDataValidator
+  | ValibotDataValidator
+  | ZodDataValidator;
 
 /** @public */
 export interface ServerConfig {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -602,6 +602,9 @@ importers:
       '@mdx-js/mdx':
         specifier: ^3
         version: 3.0.1
+      '@standard-schema/spec':
+        specifier: 1.0.0-rc.0
+        version: 1.0.0-rc.0
       '@types/mdx':
         specifier: ^2
         version: 2.0.13
@@ -3291,6 +3294,9 @@ packages:
   '@sindresorhus/transliterate@1.6.0':
     resolution: {integrity: sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==}
     engines: {node: '>=12'}
+
+  '@standard-schema/spec@1.0.0-rc.0':
+    resolution: {integrity: sha512-DcY/ICFcZIESNTLTexIT108HOqd1FtxsiLV4ZYGluySWyjF6TZ6troNyXjiqoHU6j0wN3A6SmYnTA5CHQp9blw==}
 
   '@supabase/auth-helpers-shared@0.6.3':
     resolution: {integrity: sha512-xYQRLFeFkL4ZfwC7p9VKcarshj3FB2QJMgJPydvOY7J5czJe6xSG5/wM1z63RmAzGbCkKg+dzpq61oeSyWiGBQ==}
@@ -12370,6 +12376,8 @@ snapshots:
   '@sindresorhus/transliterate@1.6.0':
     dependencies:
       escape-string-regexp: 5.0.0
+
+  '@standard-schema/spec@1.0.0-rc.0': {}
 
   '@supabase/auth-helpers-shared@0.6.3(@supabase/supabase-js@2.44.4)':
     dependencies:


### PR DESCRIPTION
# What is it?

- Feature / enhancement

# Description

I started implementing a `schema$` validator function based on [Standard Schema](https://github.com/standard-schema/standard-schema) that should replace `zod$` and `valibot$` in the long run.

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
