### PR TITLE
fix: don't wrap and serialize functions that are attribute values

### DIFF
--- a/.changeset/six-games-float.md
+++ b/.changeset/six-games-float.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: don't wrap and serialize functions that are attribute values

--- a/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__should_not_wrap_fn.snap
+++ b/packages/qwik/src/optimizer/core/src/snapshots/qwik_core__test__should_not_wrap_fn.snap
@@ -1,0 +1,116 @@
+---
+source: packages/qwik/src/optimizer/core/src/test.rs
+assertion_line: 4245
+expression: output
+snapshot_kind: text
+---
+==INPUT==
+
+
+import { component$, useSignal } from "@qwik.dev/core";
+import { A } from "./componentA";
+
+export const Cmp = component$(() => {
+	const currentStep = useSignal('STEP_1');
+	const currentType = useSignal<'NEXT' | 'PREVIOUS'>('PREVIOUS');
+
+	const getStep = (step: string, type: 'NEXT' | 'PREVIOUS') => {
+		return step === 'STEP_1' ? 'STEP_2' : 'STEP_1';
+	};
+
+	return (
+		<>
+			<button onClick$={() => (currentType.value = 'NEXT')}>CLICK</button>
+			<A href={getStep(currentStep.value, currentType.value)} />
+		</>
+	);
+});
+
+============================= test.tsx_Cmp_component_Fragment_button_onClick_GyS1w0fRTAk.js (ENTRY POINT)==
+
+import { useLexicalScope } from "@qwik.dev/core";
+export const Cmp_component_Fragment_button_onClick_GyS1w0fRTAk = ()=>{
+    const [currentType] = useLexicalScope();
+    return currentType.value = 'NEXT';
+};
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";iEAcqB;;WAAO,YAAY,KAAK,GAAG\"}")
+/*
+{
+  "origin": "test.tsx",
+  "name": "Cmp_component_Fragment_button_onClick_GyS1w0fRTAk",
+  "entry": null,
+  "displayName": "test.tsx_Cmp_component_Fragment_button_onClick",
+  "hash": "GyS1w0fRTAk",
+  "canonicalFilename": "test.tsx_Cmp_component_Fragment_button_onClick_GyS1w0fRTAk",
+  "path": "",
+  "extension": "js",
+  "parent": "Cmp_component_4ryKJTOKjWE",
+  "ctxKind": "eventHandler",
+  "ctxName": "onClick$",
+  "captures": true,
+  "loc": [
+    394,
+    428
+  ]
+}
+*/
+============================= test.js ==
+
+import { componentQrl } from "@qwik.dev/core";
+import { qrl } from "@qwik.dev/core";
+export const Cmp = /*#__PURE__*/ componentQrl(/*#__PURE__*/ qrl(()=>import("./test.tsx_Cmp_component_4ryKJTOKjWE"), "Cmp_component_4ryKJTOKjWE"));
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;AAIA,OAAO,MAAM,oBAAM,iHAchB\"}")
+============================= test.tsx_Cmp_component_4ryKJTOKjWE.js (ENTRY POINT)==
+
+import { A } from "./componentA";
+import { Fragment as _Fragment } from "@qwik.dev/core/jsx-runtime";
+import { _jsxSorted } from "@qwik.dev/core";
+import { qrl } from "@qwik.dev/core";
+import { useSignal } from "@qwik.dev/core";
+export const Cmp_component_4ryKJTOKjWE = ()=>{
+    const currentStep = useSignal('STEP_1');
+    const currentType = useSignal('PREVIOUS');
+    const getStep = (step, type)=>{
+        return step === 'STEP_1' ? 'STEP_2' : 'STEP_1';
+    };
+    return /*#__PURE__*/ _jsxSorted(_Fragment, null, null, [
+        /*#__PURE__*/ _jsxSorted("button", null, {
+            onClick$: /*#__PURE__*/ qrl(()=>import("./test.tsx_Cmp_component_Fragment_button_onClick_GyS1w0fRTAk"), "Cmp_component_Fragment_button_onClick_GyS1w0fRTAk", [
+                currentType
+            ])
+        }, "CLICK", 3, null),
+        /*#__PURE__*/ _jsxSorted(A, {
+            href: getStep(currentStep.value, currentType.value)
+        }, null, null, 3, "u6_0")
+    ], 1, "u6_1");
+};
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;yCAI8B;IAC7B,MAAM,cAAc,UAAU;IAC9B,MAAM,cAAc,UAA+B;IAEnD,MAAM,UAAU,CAAC,MAAc;QAC9B,OAAO,SAAS,WAAW,WAAW;IACvC;IAEA,qBACC;sBACC,WAAC;YAAO,QAAQ;;;WAAsC;sBACtD,WAAC;YAAE,MAAM,QAAQ,YAAY,KAAK,EAAE,YAAY,KAAK;;;AAGxD\"}")
+/*
+{
+  "origin": "test.tsx",
+  "name": "Cmp_component_4ryKJTOKjWE",
+  "entry": null,
+  "displayName": "test.tsx_Cmp_component",
+  "hash": "4ryKJTOKjWE",
+  "canonicalFilename": "test.tsx_Cmp_component_4ryKJTOKjWE",
+  "path": "",
+  "extension": "js",
+  "parent": null,
+  "ctxKind": "function",
+  "ctxName": "component$",
+  "captures": false,
+  "loc": [
+    123,
+    518
+  ]
+}
+*/
+== DIAGNOSTICS ==
+
+[]

--- a/packages/qwik/src/optimizer/core/src/test.rs
+++ b/packages/qwik/src/optimizer/core/src/test.rs
@@ -4240,6 +4240,35 @@ export const ModelImg = component$<ModelProps>((props) => {
 	});
 }
 
+#[test]
+fn should_not_wrap_fn() {
+	test_input!(TestInput {
+		code: r#"
+import { component$, useSignal } from "@qwik.dev/core";
+import { A } from "./componentA";
+
+export const Cmp = component$(() => {
+	const currentStep = useSignal('STEP_1');
+	const currentType = useSignal<'NEXT' | 'PREVIOUS'>('PREVIOUS');
+
+	const getStep = (step: string, type: 'NEXT' | 'PREVIOUS') => {
+		return step === 'STEP_1' ? 'STEP_2' : 'STEP_1';
+	};
+
+	return (
+		<>
+			<button onClick$={() => (currentType.value = 'NEXT')}>CLICK</button>
+			<A href={getStep(currentStep.value, currentType.value)} />
+		</>
+	);
+});
+"#
+		.to_string(),
+		transpile_ts: true,
+		transpile_jsx: true,
+		..TestInput::default()
+	});
+}
 // TODO(misko): Make this test work by implementing strict serialization.
 // #[test]
 // fn example_of_synchronous_qrl_that_cant_be_serialized() {


### PR DESCRIPTION
Do not convert attribute value function call to _fnSignal. This way it will create component-level subscription like in v1 and should work after resuming the application