### PR TITLE
fix: qwikcity sw SSR prefetching

### DIFF
--- a/.changeset/tidy-years-smile.md
+++ b/.changeset/tidy-years-smile.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik-city': patch
+---
+
+FIX: some qrls weren't fetched correctly on page load

--- a/packages/qwik/src/server/prefetch-utils.ts
+++ b/packages/qwik/src/server/prefetch-utils.ts
@@ -24,7 +24,9 @@ export function prefetchUrlsEventScript(base: string, prefetchResources: Prefetc
     bundles: flattenPrefetchResources(prefetchResources).map((u) => u.split('/').pop()!),
   };
   const args = JSON.stringify(['prefetch', base, ...data.bundles!]);
-  return `(window.qwikPrefetchSW||(window.qwikPrefetchSW=[])).push(${args});`;
+
+  return `document.dispatchEvent(new CustomEvent("qprefetch",{detail:${JSON.stringify(data)}}));
+          (window.qwikPrefetchSW||(window.qwikPrefetchSW=[])).push(${args});`;
 }
 
 export function flattenPrefetchResources(prefetchResources: PrefetchResource[]) {


### PR DESCRIPTION
# What is it?

<!-- pick one and remove the others -->

- Bug

# Description

A bug was accidently which caused the QwikCity service worker not to fetch some of the bundles for event handler and that caused latency on user interactions.

This PR  fixes it and should help improving the speed of Qwik. 

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
