### PR TITLE
Expose missing types & fix package.json internal expose uri

### DIFF
--- a/.changeset/warm-camels-remain.md
+++ b/.changeset/warm-camels-remain.md
@@ -2,4 +2,4 @@
 '@qwik.dev/core': patch
 ---
 
-Expose missing types and utils into public.d.ts
+Expose missing types into `public.d.ts` and fix types uri for internal export inside `package.json`

--- a/.changeset/warm-camels-remain.md
+++ b/.changeset/warm-camels-remain.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+Expose missing types and utils into public.d.ts

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -42,7 +42,7 @@
       "require": "./dist/cli.cjs"
     },
     "./internal": {
-      "types": "./core-internal.d.ts",
+      "types": "./dist/core-internal.d.ts",
       "import": {
         "development": "./dist/core.mjs",
         "production": "./dist/core.prod.mjs",

--- a/packages/qwik/public.d.ts
+++ b/packages/qwik/public.d.ts
@@ -1,7 +1,4 @@
 export {
-  _serialize,
-  _deserialize,
-  _getContextElement,
   $,
   ClassList,
   Component,

--- a/packages/qwik/public.d.ts
+++ b/packages/qwik/public.d.ts
@@ -1,4 +1,7 @@
 export {
+  _serialize,
+  _deserialize,
+  _getContextElement,
   $,
   ClassList,
   Component,
@@ -28,6 +31,7 @@ export {
   JSXOutput,
   noSerialize,
   NoSerialize,
+  OnVisibleTaskOptions,
   PrefetchGraph,
   PrefetchServiceWorker,
   PropsOf,


### PR DESCRIPTION
# What is it?
- Docs / tests / types / typos

# Description
Expose `_serialize`, `_deserialize` & `_getContextElement` to make the `createWorker$` from RFC works with v2
Expose `OnVisibleTaskOptions` because it was missing

# Checklist

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
