### PR TITLE
feat(qwikVite): show build/[name].js output in preview with debug mode

### DIFF
--- a/.changeset/maiieul-manual-changeset.md
+++ b/.changeset/maiieul-manual-changeset.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': patch
+---
+
+✨ Add the ability to see chunks names in preview/production environments to facilitate debugging of production-only bugs

--- a/packages/docs/src/routes/docs/(qwik)/advanced/vite/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/advanced/vite/index.mdx
@@ -50,7 +50,7 @@ To modify the configuration, you can pass an object to the `qwikVite` function. 
 
 ```js
 /**
- * Prints verbose Qwik plugin debug logs.
+ * Prints verbose Qwik plugin debug logs and shows chunk file names ouput in preview/production environments.
  * Default `false`
  */
 debug?: boolean;

--- a/packages/qwik/src/optimizer/src/plugins/rollup.ts
+++ b/packages/qwik/src/optimizer/src/plugins/rollup.ts
@@ -201,8 +201,9 @@ export function normalizeRollupOutputOptionsObject(
         ? `${opts.assetsDir}/${assetFileNames}`
         : assetFileNames;
     }
-    // Friendly name in dev
-    const fileName = opts.buildMode == 'production' ? 'build/q-[hash].js' : 'build/[name].js';
+    // Friendly name in dev or preview with debug mode
+    const fileName =
+      opts.buildMode == 'production' && !opts.debug ? 'build/q-[hash].js' : 'build/[name].js';
     // client production output
     if (!outputOpts.entryFileNames) {
       outputOpts.entryFileNames = useAssetsDir ? `${opts.assetsDir}/${fileName}` : fileName;


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Feature / enhancement

# Description

To be able to debug production-only bugs more easily, instead of checking each `q-[hash]` manually to figure out what code it refers to.

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
