### PR TITLE
fix(ci): make pnpm work again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,6 @@ jobs:
 
       - name: Install NPM Dependencies
         run: |
-          corepack enable
           # Ensure that the qwik binary gets made
           mkdir -p packages/qwik/bindings/
           pnpm install --frozen-lockfile
@@ -275,6 +274,7 @@ jobs:
           node-version: 20.x
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
+
       - run: pnpm install
       - if: matrix.settings.wasm
         run: pnpm install wasm-pack
@@ -382,7 +382,6 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        if: needs.changes.outputs.build-others == 'true'
       - name: Setup Node
         if: needs.changes.outputs.build-others == 'true'
         uses: actions/setup-node@v4
@@ -399,7 +398,7 @@ jobs:
 
       - name: Install NPM Dependencies
         if: needs.changes.outputs.build-others == 'true'
-        run: corepack pnpm install
+        run: pnpm install
 
       - name: 'build: qwik-city & others'
         if: needs.changes.outputs.build-others == 'true'
@@ -530,7 +529,7 @@ jobs:
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
 
-      - run: corepack pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile
       - name: Build Qwik Insights
         run: pnpm run build.packages.insights
 
@@ -583,7 +582,7 @@ jobs:
           mv artifact-qwiklabs/vite packages/qwik-labs/vite
           mv artifact-qwikreact/lib packages/qwik-react/lib
 
-      - run: corepack pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile
       - name: Build Qwik Docs
         run: pnpm run build.packages.docs && echo ok > docs-build-completed.txt
 
@@ -626,7 +625,6 @@ jobs:
           node-version: 20.x
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
-      - run: corepack enable
 
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4
@@ -690,7 +688,6 @@ jobs:
           node-version: 20.x
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
-      - run: corepack enable
 
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4
@@ -747,7 +744,6 @@ jobs:
           node-version: 20.x
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
-      - run: corepack enable
 
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4
@@ -782,7 +778,6 @@ jobs:
           node-version: 20.x
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
-      - run: corepack enable
 
       - run: pnpm install --frozen-lockfile
 
@@ -847,7 +842,6 @@ jobs:
           node-version: 20.x
           cache: 'pnpm'
           registry-url: https://registry.npmjs.org/
-      - run: corepack enable
 
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "yarn": "please-use-pnpm",
     "pnpm": ">=9.0.5"
   },
-  "packageManager": "pnpm@9.0.5",
+  "packageManager": "pnpm@9.15.5",
   "pnpm": {
     "overrides": {
       "typescript": "5.4.5",


### PR DESCRIPTION
this fixes the problems caused by https://github.com/nodejs/corepack/issues/612

We no longer rely on corepack to get the correct pnpm version, and we hope that `pnpm/action-setup@v4` will do the right thing.
