### PR TITLE
fix: create svg nested children with correct namespace

### DIFF
--- a/.changeset/long-shirts-thank.md
+++ b/.changeset/long-shirts-thank.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: create svg nested children with correct namespace

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -722,7 +722,9 @@ export const vnode_diff = (
 
   function expectElement(jsx: JSXNodeInternal, elementName: string) {
     const isSameElementName =
-      vCurrent && vnode_isElementVNode(vCurrent) && elementName === vnode_getElementName(vCurrent);
+      vCurrent &&
+      vnode_isElementVNode(vCurrent) &&
+      elementName.toLowerCase() === vnode_getElementName(vCurrent);
     const jsxKey: string | null = jsx.key;
     let needsQDispatchEventPatch = false;
     const currentFile = getFileLocationFromJsx(jsx.dev);

--- a/packages/qwik/src/core/client/vnode-namespace.ts
+++ b/packages/qwik/src/core/client/vnode-namespace.ts
@@ -10,6 +10,7 @@ import {
 } from './types';
 import {
   ensureElementVNode,
+  fastNamespaceURI,
   shouldIgnoreChildren,
   vnode_getDOMChildNodes,
   vnode_getDomParentVNode,
@@ -35,13 +36,15 @@ export const vnode_isDefaultNamespace = (vnode: ElementVNode): boolean => {
   return (flags & VNodeFlags.NAMESPACE_MASK) === 0;
 };
 
-export const vnode_getElementNamespaceFlags = (elementName: string) => {
-  if (isSvgElement(elementName)) {
-    return VNodeFlags.NS_svg;
-  } else if (isMathElement(elementName)) {
-    return VNodeFlags.NS_math;
-  } else {
-    return VNodeFlags.NS_html;
+export const vnode_getElementNamespaceFlags = (element: Element) => {
+  const namespace = fastNamespaceURI(element);
+  switch (namespace) {
+    case SVG_NS:
+      return VNodeFlags.NS_svg;
+    case MATH_NS:
+      return VNodeFlags.NS_math;
+    default:
+      return VNodeFlags.NS_html;
   }
 };
 

--- a/packages/qwik/src/core/client/vnode.ts
+++ b/packages/qwik/src/core/client/vnode.ts
@@ -1192,9 +1192,10 @@ export const vnode_getElementName = (vnode: ElementVNode): string => {
   const elementVNode = ensureElementVNode(vnode);
   let elementName = elementVNode[ElementVNodeProps.elementName];
   if (elementName === undefined) {
-    elementName = elementVNode[ElementVNodeProps.elementName] =
-      elementVNode[ElementVNodeProps.element].nodeName.toLowerCase();
-    elementVNode[VNodeProps.flags] |= vnode_getElementNamespaceFlags(elementName);
+    const element = elementVNode[ElementVNodeProps.element];
+    const nodeName = fastNodeName(element)!.toLowerCase();
+    elementName = elementVNode[ElementVNodeProps.elementName] = nodeName;
+    elementVNode[VNodeProps.flags] |= vnode_getElementNamespaceFlags(element);
   }
   return elementName;
 };
@@ -1403,6 +1404,22 @@ const fastFirstChild = (node: Node | null): Node | null => {
     node = fastNextSibling(node);
   }
   return node;
+};
+
+let _fastNamespaceURI: ((this: Element) => string | null) | null = null;
+export const fastNamespaceURI = (element: Element): string | null => {
+  if (!_fastNamespaceURI) {
+    _fastNamespaceURI = fastGetter<typeof _fastNamespaceURI>(element, 'namespaceURI')!;
+  }
+  return _fastNamespaceURI.call(element);
+};
+
+let _fastNodeName: ((this: Element) => string | null) | null = null;
+export const fastNodeName = (element: Element): string | null => {
+  if (!_fastNodeName) {
+    _fastNodeName = fastGetter<typeof _fastNodeName>(element, 'nodeName')!;
+  }
+  return _fastNodeName.call(element);
 };
 
 const fastGetter = <T>(prototype: any, name: string): T => {


### PR DESCRIPTION
In some cases vNodes didn't have the correct flags for the namespace