### PR TITLE
fix: Remove all default content type fastify parsers

### DIFF
--- a/starters/adapters/fastify/src/plugins/fastify-qwik.ts
+++ b/starters/adapters/fastify/src/plugins/fastify-qwik.ts
@@ -33,6 +33,8 @@ const qwikPlugin: FastifyPluginAsync<FastifyQwikOptions> = async (
     decorateReply: false,
   });
 
+  fastify.removeAllContentTypeParsers();
+
   fastify.setNotFoundHandler(async (request, response) => {
     await router(request.raw, response.raw, (err) => fastify.log.error(err));
     await notFound(request.raw, response.raw, (err) => fastify.log.error(err));


### PR DESCRIPTION
Currently, Fastify/Qwik can not parse body on `onPost` requests due to the following exception:

`SyntaxError: Unexpected end of JSON input`

By removing the default content type parsers seems to let Fastify+Qwik handle the request body as expected.