### PR TITLE
fix: reusing the same projection

### DIFF
--- a/.changeset/five-shoes-deny.md
+++ b/.changeset/five-shoes-deny.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: prevent infinity loop by inserting the same projection before itself

--- a/.changeset/tasty-penguins-ring.md
+++ b/.changeset/tasty-penguins-ring.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: prevent reusing projection if is marked as deleted

--- a/packages/qwik/src/core/client/dom-container.ts
+++ b/packages/qwik/src/core/client/dom-container.ts
@@ -29,6 +29,7 @@ import {
   Q_PROPS_SEPARATOR,
   USE_ON_LOCAL_SEQ_IDX,
   getQFuncs,
+  QLocaleAttr,
 } from '../shared/utils/markers';
 import { isPromise } from '../shared/utils/promises';
 import { isSlotProp } from '../shared/utils/prop';
@@ -141,7 +142,7 @@ export class DomContainer extends _SharedContainer implements IClientContainer {
       () => this.scheduleRender(),
       () => vnode_applyJournal(this.$journal$),
       {},
-      element.getAttribute('q:locale')!
+      element.getAttribute(QLocaleAttr)!
     );
     this.qContainer = element.getAttribute(QContainerAttr)!;
     if (!this.qContainer) {

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -73,6 +73,7 @@ import {
   vnode_getType,
   vnode_insertBefore,
   vnode_isElementVNode,
+  vnode_isProjection,
   vnode_isTextVNode,
   vnode_isVNode,
   vnode_isVirtualVNode,
@@ -94,7 +95,7 @@ import { getNewElementNamespaceData } from './vnode-namespace';
 import { WrappedSignal, EffectProperty, isSignal, SubscriptionData } from '../signal/signal';
 import type { Signal } from '../signal/signal.public';
 import { executeComponent } from '../shared/component-execution';
-import { isParentSlotProp, isSlotProp } from '../shared/utils/prop';
+import { isSlotProp } from '../shared/utils/prop';
 import { escapeHTML } from '../shared/utils/character-escaping';
 import { clearAllEffects } from '../signal/signal-cleanup';
 import { serializeAttribute } from '../shared/utils/styles';
@@ -507,6 +508,21 @@ export const vnode_diff = (
       // All is good.
       // console.log('  NOOP', String(vCurrent));
     } else {
+      const parent = vnode_getParent(vProjectedNode);
+      const isAlreadyProjected =
+        !!parent && !(vnode_isElementVNode(parent) && vnode_getElementName(parent) === QTemplate);
+      if (isAlreadyProjected && vParent !== parent) {
+        /**
+         * The node is already projected, but structure has been changed. In next steps we will
+         * insert the vProjectedNode at the end. However we will find existing projection elements
+         * (from already projected THE SAME projection as vProjectedNode!) during
+         * vnode_insertBefore. We need to remove vnode from the vnode tree to avoid referencing it
+         * to self and cause infinite loop. Don't remove it from DOM to avoid additional operations
+         * and flickering.
+         */
+        vnode_remove(journal, parent, vProjectedNode, false);
+      }
+
       // move from q:template to the target node
       vnode_insertBefore(
         journal,
@@ -1329,7 +1345,7 @@ export function cleanup(container: ClientContainer, vNode: VNode) {
         const attrs = vnode_getProps(vCursor);
         for (let i = 0; i < attrs.length; i = i + 2) {
           const key = attrs[i] as string;
-          if (!isParentSlotProp(key) && isSlotProp(key)) {
+          if (isSlotProp(key)) {
             const value = attrs[i + 1];
             if (value) {
               attrs[i + 1] = null; // prevent infinite loop
@@ -1349,8 +1365,7 @@ export function cleanup(container: ClientContainer, vNode: VNode) {
         }
       }
 
-      const isProjection =
-        type & VNodeFlags.Virtual && vnode_getProp(vCursor as VirtualVNode, QSlot, null) !== null;
+      const isProjection = vnode_isProjection(vCursor);
       // Descend into children
       if (!isProjection) {
         // Only if it is not a projection

--- a/packages/qwik/src/core/client/vnode.unit.tsx
+++ b/packages/qwik/src/core/client/vnode.unit.tsx
@@ -249,10 +249,10 @@ describe('vnode', () => {
     });
     it('should place attributes on Virtual', () => {
       parent.innerHTML = ``;
-      document.qVNodeData.set(parent, '{?:sref_@:key_}');
+      document.qVNodeData.set(parent, '{?:sparent_@:key_}');
       expect(vParent).toMatchVDOM(
         <test>
-          <Fragment {...({ 'q:sref': ':sref_' } as any)} key=":key_" />
+          <Fragment {...({ 'q:sparent': ':sparent_' } as any)} key=":key_" />
         </test>
       );
     });

--- a/packages/qwik/src/core/shared/utils/markers.ts
+++ b/packages/qwik/src/core/shared/utils/markers.ts
@@ -3,21 +3,12 @@ import { QContainerValue } from '../types';
 /** State factory of the component. */
 export const OnRenderProp = 'q:renderFn';
 
-/** Component style host prefix */
-export const ComponentStylesPrefixHost = '💎';
-
 /** Component style content prefix */
 export const ComponentStylesPrefixContent = '⚡️';
 
-/** Prefix used to identify on listeners. */
-export const EventPrefix = 'on:';
-
-/** Attribute used to mark that an event listener is attached. */
-export const EventAny = 'on:.';
 /** `<some-element q:slot="...">` */
 export const QSlot = 'q:slot';
-export const QSlotParent = ':';
-export const QSlotRef = 'q:sref';
+export const QSlotParent = 'q:sparent';
 export const QSlotS = 'q:s';
 export const QStyle = 'q:style';
 export const QStyleSelector = 'style[q\\:style]';
@@ -26,7 +17,6 @@ export const QStylesAllSelector = QStyleSelector + ',' + QStyleSSelector;
 export const QScopedStyle = 'q:sstyle';
 export const QCtxAttr = 'q:ctx';
 export const QBackRefs = 'q:brefs';
-export const QManifestHash = 'q:manifest-hash';
 export const QFuncsPrefix = 'qFuncs_';
 
 export const getQFuncs = (
@@ -49,7 +39,6 @@ export const QIgnore = 'q:ignore';
 export const QIgnoreEnd = '/' + QIgnore;
 export const QContainerAttr = 'q:container';
 export const QContainerAttrEnd = '/' + QContainerAttr;
-export const QShadowRoot = 'q:shadowroot';
 
 export const QTemplate = 'q:template';
 
@@ -72,7 +61,6 @@ export const RenderEvent = 'qRender';
 export const TaskEvent = 'qTask';
 
 /** `<q:slot name="...">` */
-export const QSlotInertName = '\u0000';
 export const QDefaultSlot = '';
 
 /**
@@ -88,10 +76,6 @@ export const ELEMENT_KEY = 'q:key';
 export const ELEMENT_PROPS = 'q:props';
 export const ELEMENT_SEQ = 'q:seq';
 export const ELEMENT_SEQ_IDX = 'q:seqIdx';
-export const ELEMENT_SELF_ID = -1;
-export const ELEMENT_ID_SELECTOR = '[q\\:id]';
-export const ELEMENT_ID_PREFIX = '#';
-export const INLINE_FN_PREFIX = '@';
 export const Q_PREFIX = 'q:';
 
 /** Non serializable markers - always begins with `:` character */

--- a/packages/qwik/src/core/shared/utils/prop.ts
+++ b/packages/qwik/src/core/shared/utils/prop.ts
@@ -1,13 +1,9 @@
 import { createPropsProxy, type Props, type PropsProxy } from '../jsx/jsx-runtime';
 import { _CONST_PROPS, _VAR_PROPS } from './constants';
-import { NON_SERIALIZABLE_MARKER_PREFIX, QSlotParent } from './markers';
+import { NON_SERIALIZABLE_MARKER_PREFIX } from './markers';
 
 export function isSlotProp(prop: string): boolean {
   return !prop.startsWith('q:') && !prop.startsWith(NON_SERIALIZABLE_MARKER_PREFIX);
-}
-
-export function isParentSlotProp(prop: string): boolean {
-  return prop.startsWith(QSlotParent);
 }
 
 /** @internal */

--- a/packages/qwik/src/core/shared/vnode-data-types.ts
+++ b/packages/qwik/src/core/shared/vnode-data-types.ts
@@ -61,8 +61,8 @@ export const VNodeDataChar = {
   ID_CHAR: /* ********* */ '=',
   PROPS: /* ************** */ 62, // `>` - `q:props' - Component Props
   PROPS_CHAR: /* ****** */ '>',
-  SLOT_REF: /* *********** */ 63, // `?` - `q:sref` - Slot reference.
-  SLOT_REF_CHAR: /* *** */ '?',
+  SLOT_PARENT: /* ******** */ 63, // `?` - `q:sparent` - Slot parent.
+  SLOT_PARENT_CHAR: /*  */ '?',
   KEY: /* **************** */ 64, // `@` - `q:key` - Element key.
   KEY_CHAR: /* ******** */ '@',
   SEQ: /* **************** */ 91, // `[` - `q:seq' - Seq value from `useSequentialScope()`

--- a/packages/qwik/src/core/ssr/ssr-render-jsx.ts
+++ b/packages/qwik/src/core/ssr/ssr-render-jsx.ts
@@ -25,6 +25,7 @@ import {
   QDefaultSlot,
   QScopedStyle,
   QSlot,
+  QSlotParent,
   qwikInspectorAttr,
 } from '../shared/utils/markers';
 import { isPromise } from '../shared/utils/promises';
@@ -192,7 +193,7 @@ function processJSXNode(
           if (componentFrame) {
             const compId = componentFrame.componentNode.id || '';
             const projectionAttrs = isDev ? [DEBUG_TYPE, VirtualType.Projection] : [];
-            projectionAttrs.push(':', compId);
+            projectionAttrs.push(QSlotParent, compId);
             ssr.openProjection(projectionAttrs);
             const host = componentFrame.componentNode;
             const node = ssr.getLastNode();

--- a/packages/qwik/src/core/tests/projection.spec.tsx
+++ b/packages/qwik/src/core/tests/projection.spec.tsx
@@ -1189,6 +1189,115 @@ describe.each([
     );
   });
 
+  it('should render the same content projection with different structure', async () => {
+    const Cmp1 = component$(() => {
+      return (
+        <>
+          <h1>Test</h1>
+          <p>Test content</p>
+        </>
+      );
+    });
+
+    const Cmp2 = component$((props: { toggle: boolean }) => {
+      return (
+        <>
+          {props.toggle && <Slot />}
+          {!props.toggle && (
+            <>
+              <Slot />
+            </>
+          )}
+        </>
+      );
+    });
+
+    const Parent = component$(() => {
+      const toggle = useSignal(true);
+      return (
+        <div>
+          <button onClick$={() => (toggle.value = !toggle.value)}>toggle</button>
+          <Cmp2 toggle={toggle.value}>
+            <Cmp1 />
+          </Cmp2>
+        </div>
+      );
+    });
+    const { vNode, document } = await render(<Parent />, { debug: DEBUG });
+    expect(cleanupAttrs(document.body.querySelector('div')?.outerHTML)).toEqual(
+      '<div><button>toggle</button><h1>Test</h1><p>Test content</p></div>'
+    );
+    expect(vNode).toMatchVDOM(
+      <Component ssr-required>
+        <div>
+          <button>toggle</button>
+          <Component ssr-required>
+            <Fragment ssr-required>
+              <Projection ssr-required>
+                <Component ssr-required>
+                  <Fragment ssr-required>
+                    <h1>Test</h1>
+                    <p>Test content</p>
+                  </Fragment>
+                </Component>
+              </Projection>
+            </Fragment>
+          </Component>
+        </div>
+      </Component>
+    );
+
+    await trigger(document.body, 'button', 'click');
+    expect(cleanupAttrs(document.body.querySelector('div')?.outerHTML)).toEqual(
+      '<div><button>toggle</button><h1>Test</h1><p>Test content</p></div>'
+    );
+
+    expect(vNode).toMatchVDOM(
+      <Component ssr-required>
+        <div>
+          <button>toggle</button>
+          <Component ssr-required>
+            <Fragment ssr-required>
+              <Projection ssr-required>
+                <Component ssr-required>
+                  <Fragment ssr-required>
+                    <Fragment ssr-required>
+                      <h1>Test</h1>
+                      <p>Test content</p>
+                    </Fragment>
+                  </Fragment>
+                </Component>
+              </Projection>
+            </Fragment>
+          </Component>
+        </div>
+      </Component>
+    );
+    await trigger(document.body, 'button', 'click');
+    expect(cleanupAttrs(document.body.querySelector('div')?.outerHTML)).toEqual(
+      '<div><button>toggle</button><h1>Test</h1><p>Test content</p></div>'
+    );
+    expect(vNode).toMatchVDOM(
+      <Component ssr-required>
+        <div>
+          <button>toggle</button>
+          <Component ssr-required>
+            <Fragment ssr-required>
+              <Projection ssr-required>
+                <Component ssr-required>
+                  <Fragment ssr-required>
+                    <h1>Test</h1>
+                    <p>Test content</p>
+                  </Fragment>
+                </Component>
+              </Projection>
+            </Fragment>
+          </Component>
+        </div>
+      </Component>
+    );
+  });
+
   describe('ensureProjectionResolved', () => {
     (globalThis as any).log = [] as string[];
     beforeEach(() => {

--- a/packages/qwik/src/server/qwik-copy.ts
+++ b/packages/qwik/src/server/qwik-copy.ts
@@ -41,7 +41,6 @@ export {
   QScopedStyle,
   QSlot,
   QSlotParent,
-  QSlotRef,
   QStyle,
   QTemplate,
   QVersionAttr,

--- a/packages/qwik/src/server/ssr-container.ts
+++ b/packages/qwik/src/server/ssr-container.ts
@@ -31,7 +31,6 @@ import {
   QScopedStyle,
   QSlot,
   QSlotParent,
-  QSlotRef,
   QStyle,
   QTemplate,
   QVersionAttr,
@@ -739,9 +738,6 @@ class SSRContainer extends _SharedContainer implements ISSRContainer {
           case ELEMENT_PROPS:
             write(VNodeDataChar.PROPS_CHAR);
             break;
-          case QSlotRef:
-            write(VNodeDataChar.SLOT_REF_CHAR);
-            break;
           case ELEMENT_KEY:
             write(VNodeDataChar.KEY_CHAR);
             break;
@@ -753,6 +749,9 @@ class SSRContainer extends _SharedContainer implements ISSRContainer {
             break;
           case QBackRefs:
             write(VNodeDataChar.BACK_REFS_CHAR);
+            break;
+          case QSlotParent:
+            write(VNodeDataChar.SLOT_PARENT_CHAR);
             break;
           // Skipping `\` character for now because it is used for escaping.
           case QCtxAttr:

--- a/packages/qwik/src/testing/element-fixture.ts
+++ b/packages/qwik/src/testing/element-fixture.ts
@@ -183,5 +183,8 @@ export async function advanceToNextTimerAndFlush() {
 }
 
 export function cleanupAttrs(innerHTML: string | undefined): any {
-  return innerHTML?.replaceAll(/ q:key="[^"]+"/g, '').replaceAll(/ :=""/g, '');
+  return innerHTML
+    ?.replaceAll(/ q:key="[^"]+"/g, '')
+    .replaceAll(/ :=""/g, '')
+    .replaceAll(/ on:\w+="[^"]+"/g, '');
 }


### PR DESCRIPTION
Qwik reuses content projections. Imagine an edge case:
```tsx
const Child = component$(() => {
  return <h1>Some title</h1>;
});

const Parent = component$((props) => {
  {props.toggle && <Slot />}
  {!props.toggle && (
    <>
      <Slot />
    </>
  )}
});

const Cmp = component$(() => {
  const toggle = useSignal(true);
  return <>
    <button onClick$={() => toggle.value = !toggle.value}>toggle</button>
    <Parent toggle={toggle.value}>
      <Child />
    </Parent>
  </>;
});
```

We render `Child` inside `Parent`, but `Parent` has multiple default slots. At the time of button click the node is already projected, but VIRTUAL structure has been changed. This means real DOM element parent is the same for both projections. In next steps we will insert the projection at the end of the DOM parent. However we will find existing projection elements (from already projected THE SAME projection!) during inserting, so we will try to insert `h1` before itself.

We need to remove old virtual projection and insert it in new place (something like moving projection vnode)