### PR TITLE
fix(docs repl): let rollup handle more chunks

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import type { Rollup, Plugin, ViteDevServer, HmrContext } from 'vite';
 import { hashCode } from '../../../core/util/hash_code';
 import { generateManifestFromBundles, getValidManifest } from '../manifest';
@@ -877,34 +878,19 @@ export const manifest = ${JSON.stringify(manifest)};\n`;
     const module = getModuleInfo(id)!;
     const segment = module.meta.segment;
 
+    // We need to specifically return segment.entry for qwik-insights
     if (segment) {
-      // We need to specifically return segment.entry for qwik-insights
       return segment.entry;
     }
 
-    // To prevent over-prefetching, we need to clearly seperate those chunks,
-    // otherwise rollup can bundle them together with the first component chunk it finds.
-    // For example, the core code could go into an Accordion.tsx chunk, which would make the whole app import accordion related chunks everywhere.
-    if (/\/(qwik|core)\/dist\/core.*js$/.test(id) || id.includes('@builder.io/qwik/build')) {
-      return 'core';
-    }
-    if (/\/(qwik-city|router)\/lib\/index.qwik.*js$/.test(id)) {
-      return 'qwik-city';
-    }
-    if (id.endsWith('vite/preload-helper.js')) {
-      return 'preload-helper';
-    }
-
-    // We can't return a chunk for each module as that creates too many small chunks that slow down the prefetching as well,
-    // nor can we bundle related node_modules together (e.g. all shiki modules together), as that can create very big 10MB chunks.
-    // So here we let rollup do its job.
     if (id.includes('node_modules')) {
       return null;
     }
 
-    // Also to prevent over-prefetching, we must clearly separate those chunks so that rollup doesn't add additional imports into entry files.
-    // We do this after the node_modules check, because some node_modules can end with .js, .ts, etc.
-    if (/\.(qwik\.mjs|qwik\.cjs|tsx|jsx|mdx|ts|js)$/.test(id)) {
+    // Patch to prevent over-prefetching, we must clearly separate .tsx/.jsx chunks so that rollup doesn't mix random imports into non-entry files such as hooks.
+    // Maybe a better solution would be to mark those files as entires earlier in the chain so that we can remove this check and the one above altogether.
+    // We check .(tsx|jsx) after node_modules in case some node_modules end with .jsx or .tsx.
+    if (/\.(tsx|jsx)$/.test(id)) {
       const optimizer = getOptimizer();
       const path = optimizer.sys.path;
       const relativePath = path.relative(optimizer.sys.cwd(), id);


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Bug
- Docs

# Description

- Actually removed manual chunks for core and qwik-city. After further analysis, I think it's more robust to let rollup do it's job here. For example it bundles the `isServer` from @builder.io/build properly on its own.
- Only return sanitizedPath for `.(tsx|jsx)` is enough to prevent over-prefetching on qwik-ui.
- We could simply return `id` instead of sanitizedPath, but keeping it for convenience for now for `debug: true`. I'll see in a follow-up PR if I can remove that too.

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
