### PR TITLE
Fix: Windows Docs.dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
     "cli.qwik": "pnpm build.cli && node packages/qwik/qwik-cli.cjs",
     "cli.validate": "tsx --require ./scripts/runBefore.ts scripts/validate-cli.ts",
     "deps": "corepack pnpm upgrade -i -r --latest && syncpack fix-mismatches && corepack pnpm dedupe",
-    "docs.dev": "cd packages/docs && pnpm build.repl-sw && pnpm dev",
+    "docs.dev": "pnpm -C packages/docs build.repl-sw && pnpm -C packages/docs dev",
     "docs.preview": "cd packages/docs && pnpm preview",
     "docs.sync": "tsx --require ./scripts/runBefore.ts scripts/docs_sync/index.ts && pnpm fmt",
     "eslint.update": "tsx --require ./scripts/runBefore.ts scripts/eslint-docs.ts",

--- a/packages/docs/check-qwik-build.ts
+++ b/packages/docs/check-qwik-build.ts
@@ -8,42 +8,39 @@ import { spawnSync } from 'node:child_process';
 
 let __dirname = path.dirname(new URL(import.meta.url).pathname);
 const isWindows = process.platform === 'win32';
-if (isWindows) {
+if (isWindows && __dirname.startsWith('/')) {
   // in Windows __dirname starts with a / causing errors
   // before
   //  /C:/Users/{location stuff}/qwik/packages/docs
+  __dirname = __dirname.substring(1);
+  // after
+  // C:/Users/{location stuff}/qwik/packages/docs
+}
+const qwikPkgDir = path.join(__dirname, '..', 'qwik', 'dist');
 
-  if (__dirname.startsWith('/')) {
-    __dirname = __dirname.substring(1);
-    // after
-    // C:/Users/{location stuff}/qwik/packages/docs
+if (!fs.existsSync(path.join(qwikPkgDir, 'core.d.ts'))) {
+  console.warn(
+    `\n\n=== Running 'pnpm run build.local' to generate missing imports for the docs ===\n`
+  );
+  const out = spawnSync('pnpm', ['run', 'build.local'], {
+    cwd: path.join(__dirname, '..', '..'),
+    stdio: 'inherit',
+  });
+  if (out.status !== 0) {
+    console.error('Failed to build local packages');
+    process.exit(1);
   }
-  const qwikPkgDir = path.join(__dirname, '..', 'qwik', 'dist');
+}
 
-  if (!fs.existsSync(path.join(qwikPkgDir, 'core.d.ts'))) {
-    console.warn(
-      `\n\n=== Running 'pnpm run build.local' to generate missing imports for the docs ===\n`
-    );
-    const out = spawnSync('pnpm', ['run', 'build.local'], {
-      cwd: path.join(__dirname, '..', '..'),
-      stdio: 'inherit',
-    });
-    if (out.status !== 0) {
-      console.error('Failed to build local packages');
-      process.exit(1);
-    }
-  }
-
-  if (!fs.existsSync(path.join(__dirname, 'public', 'repl', 'repl-sw.js'))) {
-    console.warn(
-      `\n\n=== Running 'pnpm run build.repl-sw' to generate missing REPL service worker public/repl/repl-sw.js ===\n`
-    );
-    const out = spawnSync('pnpm', ['run', 'build.repl-sw'], {
-      stdio: 'inherit',
-    });
-    if (out.status !== 0) {
-      console.error('Failed to build REPL service worker');
-      process.exit(1);
-    }
+if (!fs.existsSync(path.join(__dirname, 'public', 'repl', 'repl-sw.js'))) {
+  console.warn(
+    `\n\n=== Running 'pnpm run build.repl-sw' to generate missing REPL service worker public/repl/repl-sw.js ===\n`
+  );
+  const out = spawnSync('pnpm', ['run', 'build.repl-sw'], {
+    stdio: 'inherit',
+  });
+  if (out.status !== 0) {
+    console.error('Failed to build REPL service worker');
+    process.exit(1);
   }
 }

--- a/packages/docs/check-qwik-build.ts
+++ b/packages/docs/check-qwik-build.ts
@@ -1,36 +1,49 @@
 // verify that ../qwik/dist/core.d.ts exists or run `pnpm run build.core` in the root directory
 // Also make sure that the repl-sw.js file is present, for dev mode
 // we need it for development and for the REPL
-import fs from 'fs';
-import path from 'path';
-import { spawnSync } from 'child_process';
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname);
-const qwikPkgDir = path.join(__dirname, '..', 'qwik', 'dist');
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
 
-if (!fs.existsSync(path.join(qwikPkgDir, 'core.d.ts'))) {
-  console.warn(
-    `\n\n=== Running 'pnpm run build.local' to generate missing imports for the docs ===\n`
-  );
-  const out = spawnSync('pnpm', ['run', 'build.local'], {
-    cwd: path.join(__dirname, '..', '..'),
-    stdio: 'inherit',
-  });
-  if (out.status !== 0) {
-    console.error('Failed to build local packages');
-    process.exit(1);
+let __dirname = path.dirname(new URL(import.meta.url).pathname);
+const isWindows = process.platform === 'win32';
+if (isWindows) {
+  // in Windows __dirname starts with a / causing errors
+  // before
+  //  /C:/Users/{location stuff}/qwik/packages/docs
+
+  if (__dirname.startsWith('/')) {
+    __dirname = __dirname.substring(1);
+    // after
+    // C:/Users/{location stuff}/qwik/packages/docs
   }
-}
+  const qwikPkgDir = path.join(__dirname, '..', 'qwik', 'dist');
 
-if (!fs.existsSync(path.join(__dirname, 'public', 'repl', 'repl-sw.js'))) {
-  console.warn(
-    `\n\n=== Running 'pnpm run build.repl-sw' to generate missing REPL service worker public/repl/repl-sw.js ===\n`
-  );
-  const out = spawnSync('pnpm', ['run', 'build.repl-sw'], {
-    stdio: 'inherit',
-  });
-  if (out.status !== 0) {
-    console.error('Failed to build REPL service worker');
-    process.exit(1);
+  if (!fs.existsSync(path.join(qwikPkgDir, 'core.d.ts'))) {
+    console.warn(
+      `\n\n=== Running 'pnpm run build.local' to generate missing imports for the docs ===\n`
+    );
+    const out = spawnSync('pnpm', ['run', 'build.local'], {
+      cwd: path.join(__dirname, '..', '..'),
+      stdio: 'inherit',
+    });
+    if (out.status !== 0) {
+      console.error('Failed to build local packages');
+      process.exit(1);
+    }
+  }
+
+  if (!fs.existsSync(path.join(__dirname, 'public', 'repl', 'repl-sw.js'))) {
+    console.warn(
+      `\n\n=== Running 'pnpm run build.repl-sw' to generate missing REPL service worker public/repl/repl-sw.js ===\n`
+    );
+    const out = spawnSync('pnpm', ['run', 'build.repl-sw'], {
+      stdio: 'inherit',
+    });
+    if (out.status !== 0) {
+      console.error('Failed to build REPL service worker');
+      process.exit(1);
+    }
   }
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -75,7 +75,7 @@
     "codesandbox.sync": "tsx codesandbox.sync.ts",
     "contributors": "tsx contributors.ts",
     "deploy": "wrangler pages publish ./dist",
-    "dev": "concurrently \"tsx check-qwik-build.ts\" \"vite --mode ssr --open\"",
+    "dev": "tsx check-qwik-build.ts && vite --mode ssr --open",
     "dev.debug": "node --inspect-brk ../../node_modules/vite/bin/vite.js --mode ssr --force",
     "prebuild.core": "tsx check-qwik-build.ts",
     "preview": "qwik build preview && vite preview --open",

--- a/packages/eslint-plugin-qwik/qwik.unit.ts
+++ b/packages/eslint-plugin-qwik/qwik.unit.ts
@@ -42,7 +42,13 @@ interface InvalidTestCase extends TestCase {
 }
 await (async function setupEsLintRuleTesters() {
   // list './test' directory content and set up one RuleTester per directory
-  const testDir = join(dirname(new URL(import.meta.url).pathname), './tests');
+  let testDir = join(dirname(new URL(import.meta.url).pathname), './tests');
+  const isWindows = process.platform === 'win32';
+  if (isWindows && testDir.startsWith('\\')) {
+    // in Windows testDir starts with a \ causing errors
+    testDir = testDir.substring(1);
+  }
+
   const ruleNames = await readdir(testDir);
   for (const ruleName of ruleNames) {
     const rule = rules[ruleName];


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->


- Bug


# Description
Hey everyone,
Unfortunately the below PR did not fully fix the issue on Windows.

[https://github.com/QwikDev/qwik/pull/7301](https://github.com/QwikDev/qwik/pull/7301)

There were 2 underlying issues.
1) the cd to packages/docs in the root package.json did not work. packages/docs the "/" did not work on windows. 
-> moved to pnpm -c

2) in file: check-qwik-build.ts the dirname variable on windows began with a "/" (forward slash)
This would cause the check to fail on Windows as the directory was incorrect -> this has been resolved

3) revert the dev script in packages/docs package.json
The use of concurrently is no longer needed for Windows support as this has been resolved in step 2 above.

This has been tested on the below Operating Systems:
  System:
    OS: Windows 11 10.0.26100
    OS: Linux 6.8 Linux Mint 22.1 (Xia)




<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x ] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change` (no changes needed?)
- [ ] I made corresponding changes to the Qwik docs (no changes needed)
- [x ] I added new tests to cover the fix / functionality

When running tests locally on windows the below has failed

PR incoming at some point on the tests
It'll likely be next weekend (but confirm that you want an issue logged for it)



 FAIL  packages/qwik/src/cli/add/update-files.unit.ts > mergeIntegrationDir > should merge integration directory in a monorepo 
AssertionError: expected [ …(5) ] to deeply equal [ …(5) ]

- Expected
+ Received

  Array [
-   "destDir/subDestDir/apps/subpackage/fake.ts",
-   "destDir/subDestDir/should-stay-in-root.ts",
-   "destDir/subDestDir/package.json",
-   "destDir/subDestDir/should-stay/should-also-stay.ts",
-   "destDir/subDestDir/apps/subpackage/src/global.css",
+   "destDir\\subDestDir\\apps\\subpackage\\fake.ts",
+   "destDir\\subDestDir\\should-stay-in-root.ts",
+   "destDir\\subDestDir\\package.json",
+   "destDir\\subDestDir\\should-stay\\should-also-stay.ts",
+   "destDir\\subDestDir\\apps\\subpackage\\r\\src\\global.css",
  ]



 FAIL  packages/qwik/src/cli/add/update-files.unit.ts > mergeIntegrationDir > should merge integration directory
AssertionError: expected [ 'destDir\subDestDir\fake.ts', …(2) ] to deeply equal [ 'destDir/subDestDir/fake.ts', …(2) ]

- Expected
+ Received

  Array [
-   "destDir/subDestDir/fake.ts",
-   "destDir/subDestDir/package.json",
-   "destDir/subDestDir/src/global.css",
+   "destDir\\subDestDir\\fake.ts",
+   "destDir\\subDestDir\\package.json",
+   "destDir\\subDestDir\\r\\src\\global.css",
  ]

 FAIL  packages/eslint-plugin-qwik/qwik.unit.ts [ packages/eslint-plugin-qwik/qwik.unit.ts ]
Error: ENOENT: no such file or directory, scandir 'C:\C:\{lcoation of stuff}\qwik\packages\eslint-plugin-qwik\tests'
console.log results
testDir C:\Users\{location of stuff}\qwik\packages\eslint-plugin-qwik\tests
this now works on windows.

Test results before:

```terminal
Test Files  3 failed (3)
      Tests  3 failed | 24 passed (27)
   Duration  10ms
```
Test results after:
```terminal
 Test Files  2 failed | 1 passed (3)
      Tests  3 failed | 61 passed (64)
   Duration  2.98s
```