### PR TITLE
chore: refactor vSiblings

### DIFF
--- a/packages/qwik/src/core/client/vnode-diff.unit.tsx
+++ b/packages/qwik/src/core/client/vnode-diff.unit.tsx
@@ -409,16 +409,18 @@ describe('vNode-diff', () => {
   describe('keys', () => {
     it('should not reuse element because old has a key and new one does not', () => {
       const { vNode, vParent, document } = vnode_fromJSX(
-        <test key="KA_6">
-          <b {...{ 'q:key': '1' }}>old</b>
-        </test>
+        _jsxSorted('test', {}, null, [_jsxSorted('b', {}, null, 'old', 0, '1')], 0, 'KA_6')
       );
-      const test = (
-        <test key="KA_6">
-          <b>new</b>
-        </test>
+      const test = _jsxSorted(
+        'test',
+        {},
+        null,
+        [_jsxSorted('b', {}, null, 'new', 0, null)],
+        0,
+        'KA_6'
       );
-      const bOriginal = document.querySelector('b[key=1]')!;
+      const bOriginal = document.querySelector('b[q\\:key=1]')!;
+      expect(bOriginal).toBeDefined();
       vnode_diff(
         { $journal$: journal, $scheduler$: scheduler, document } as any,
         test,
@@ -428,32 +430,46 @@ describe('vNode-diff', () => {
       vnode_applyJournal(journal);
       expect(vNode).toMatchVDOM(test);
       const bSecond = document.querySelector('b')!;
+      expect(bSecond).toBeDefined();
       expect(bSecond).not.toBe(bOriginal);
     });
     it('should reuse elements if keys match', () => {
       const { vNode, vParent, document } = vnode_fromJSX(
-        <test key="KA_6">
-          <b {...{ 'q:key': '1' }}>1</b>
-          <b {...{ 'q:key': '2' }}>2</b>
-        </test>
+        _jsxSorted(
+          'test',
+          {},
+          null,
+          [_jsxSorted('b', {}, null, '1', 0, '1'), _jsxSorted('b', {}, null, '2', 0, '2')],
+          0,
+          'KA_6'
+        )
       );
-      const test = (
-        <test key="KA_6">
-          <b>before</b>
-          <b key="2">2</b>
-          <b key="3">3</b>
-          <b>in</b>
-          <b key="1">1</b>
-          <b>after</b>
-        </test>
+      const test = _jsxSorted(
+        'test',
+        {},
+        null,
+        [
+          _jsxSorted('b', {}, null, 'before', 0, null),
+          _jsxSorted('b', {}, null, '2', 0, '2'),
+          _jsxSorted('b', {}, null, '3', 0, '3'),
+          _jsxSorted('b', {}, null, 'in', 0, null),
+          _jsxSorted('b', {}, null, '1', 0, '1'),
+          _jsxSorted('b', {}, null, 'after', 0, null),
+        ],
+        0,
+        'KA_6'
       );
-      const b1 = document.querySelector('b[key=1]')!;
-      const b2 = document.querySelector('b[key=1]')!;
+      const selectB1 = () => document.querySelector('b[q\\:key=1]')!;
+      const selectB2 = () => document.querySelector('b[q\\:key=2]')!;
+      const b1 = selectB1();
+      const b2 = selectB2();
+      expect(b1).toBeDefined();
+      expect(b2).toBeDefined();
       vnode_diff({ $journal$: journal, document } as any, test, vParent, null);
       vnode_applyJournal(journal);
       expect(vNode).toMatchVDOM(test);
-      expect(b1).toBe(document.querySelector('b[key=1]')!);
-      expect(b2).toBe(document.querySelector('b[key=2]')!);
+      expect(b1).toBe(selectB1());
+      expect(b2).toBe(selectB2());
     });
   });
   describe.todo('fragments', () => {});

--- a/packages/qwik/src/core/tests/component.spec.tsx
+++ b/packages/qwik/src/core/tests/component.spec.tsx
@@ -823,6 +823,52 @@ describe.each([
     );
   });
 
+  it('should preserve the same elements', async () => {
+    const Cmp = component$(() => {
+      const keys = useSignal(['A', 'B', 'C']);
+
+      return (
+        <div onClick$={() => (keys.value = ['B', 'C', 'A'])}>
+          {keys.value.map((key) => (
+            <span key={key} id={key}>
+              {key}
+            </span>
+          ))}
+        </div>
+      );
+    });
+
+    const { vNode, document } = await render(<Cmp />, { debug });
+    expect(vNode).toMatchVDOM(
+      <Component>
+        <div>
+          <span id="A">A</span>
+          <span id="B">B</span>
+          <span id="C">C</span>
+        </div>
+      </Component>
+    );
+    const a1 = document.getElementById('A');
+    const b1 = document.getElementById('B');
+    const c1 = document.getElementById('C');
+    await trigger(document.body, 'div', 'click');
+    expect(vNode).toMatchVDOM(
+      <Component>
+        <div>
+          <span id="B">B</span>
+          <span id="C">C</span>
+          <span id="A">A</span>
+        </div>
+      </Component>
+    );
+    const a2 = document.getElementById('A');
+    const b2 = document.getElementById('B');
+    const c2 = document.getElementById('C');
+    expect(a1).toBe(a2);
+    expect(b1).toBe(b2);
+    expect(c1).toBe(c2);
+  });
+
   it('should render correctly component only with text node and node sibling', async () => {
     const Child = component$(() => {
       return <>0</>;

--- a/packages/qwik/src/testing/vdom-diff.unit-util.ts
+++ b/packages/qwik/src/testing/vdom-diff.unit-util.ts
@@ -440,7 +440,6 @@ export function vnode_fromJSX(jsx: JSXOutput) {
         const child = vnode_newUnMaterializedElement(doc.createElement(type));
         vnode_insertBefore(journal, vParent, child, null);
 
-        // TODO(hack): jsx.props is an empty object
         const props = jsx.varProps;
         for (const key in props) {
           if (Object.prototype.hasOwnProperty.call(props, key)) {

--- a/starters/apps/e2e/src/components/attributes/attributes.tsx
+++ b/starters/apps/e2e/src/components/attributes/attributes.tsx
@@ -18,6 +18,7 @@ export const Attributes = component$(() => {
       >
         Rerender
       </button>
+      <span id="render-count">{render.value}</span>
       <AttributesChild v={render.value} key={render.value} />
       <ProgressParent />
     </>

--- a/starters/apps/e2e/src/components/context/context.tsx
+++ b/starters/apps/e2e/src/components/context/context.tsx
@@ -28,6 +28,7 @@ export const ContextRoot = component$(() => {
       <button id="btn-rerender" onClick$={() => count.value++}>
         Client Rerender
       </button>
+      <span id="render-count">{count.value}</span>
       <ContextApp key={count.value} />
     </div>
   );

--- a/starters/e2e/e2e.attributes.e2e.ts
+++ b/starters/e2e/e2e.attributes.e2e.ts
@@ -325,11 +325,8 @@ test.describe("attributes", () => {
   test.describe("client rerender", () => {
     test.beforeEach(async ({ page }) => {
       const toggleRender = page.locator("#force-rerender");
-      const v = Number(await toggleRender.getAttribute("data-v"));
       await toggleRender.click();
-      await expect(page.locator("#renderCount")).toHaveText(`Render ${v}`);
-      // Without this the tests still fail?
-      await page.waitForTimeout(50);
+      await expect(page.locator("#render-count")).toHaveText("1");
     });
     tests();
   });

--- a/starters/e2e/e2e.context.e2e.ts
+++ b/starters/e2e/e2e.context.e2e.ts
@@ -189,7 +189,7 @@ test.describe("context", () => {
     test.beforeEach(async ({ page }) => {
       const rerender = page.locator("#btn-rerender");
       await rerender.click();
-      await page.waitForTimeout(100);
+      await expect(page.locator("#render-count")).toHaveText("1");
     });
     tests(false);
   });


### PR DESCRIPTION
Remove vSiblings logic, they are no longer needed. Replace them with a Map for keyed nodes and with an array for non-keyed nodes to speed up diffing