### PR TITLE
feat(cli): add ability to keep using tailwind v3

### DIFF
--- a/.changeset/pole-comfort-active.md
+++ b/.changeset/pole-comfort-active.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': patch
+---
+
+✨ Ability to keep using tailwind v3 through the cli

--- a/packages/docs/src/routes/docs/integrations/tailwind-v3/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/tailwind-v3/index.mdx
@@ -1,0 +1,71 @@
+---
+title: Tailwind | Integrations
+keywords: 'styles, styling'
+contributors:
+  - manucorporat
+  - leifermendez
+  - reemardelarosa
+  - mhevery
+  - nickclark
+  - igorbabko
+  - Benny-Nottonson
+  - mrhoodz
+  - NickClark
+  - adamdbradley
+  - sreeisalso
+  - maiieul
+updated_at: '2025-03-08T18:53:23Z'
+created_at: '2023-04-06T21:28:28Z'
+---
+
+import PackageManagerTabs from '~/components/package-manager-tabs/index.tsx';
+
+# Tailwind
+Tailwind is a CSS framework that provides us with single-purpose utility classes which are
+opinionated for the most part, and which help us design our web pages from right inside our
+markup or `.js/.jsx/.ts/.tsx/.mdx` files. [Tailwindcss Website](https://tailwindcss.com/)
+## Usage
+You can add Tailwind easily by using the following Qwik starter script:
+<PackageManagerTabs>
+<span q:slot="pnpm">
+```shell
+pnpm run qwik add tailwind-v3
+```
+</span>
+<span q:slot="npm">
+```shell
+npm run qwik add tailwind-v3
+```
+</span>
+<span q:slot="yarn">
+```shell
+yarn run qwik add tailwind-v3
+```
+</span>
+<span q:slot="bun">
+```shell
+bun run qwik add tailwind-v3
+```
+</span>
+</PackageManagerTabs>
+
+The previous command updates your app with the necessary dependencies.
+
+It also adds new files to your project folder:
+
+- `postcss.config.js`
+- `tailwind.config.js`
+- `.vscode/settings.json`
+
+and modifies your `src/global.css` to include
+
+```css title="src/global.css"
+
+# global.css file
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+...stuff...
+```

--- a/packages/docs/src/routes/docs/integrations/tailwind/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/tailwind/index.mdx
@@ -13,7 +13,8 @@ contributors:
   - NickClark
   - adamdbradley
   - sreeisalso
-updated_at: '2025-01-24T18:53:23Z'
+  - maiieul
+updated_at: '2025-03-08T18:53:23Z'
 created_at: '2023-04-06T21:28:28Z'
 ---
 
@@ -25,9 +26,11 @@ Tailwind is a CSS framework that provides us with single-purpose utility classes
 opinionated for the most part, and which help us design our web pages from right inside our
 markup or `.js/.jsx/.ts/.tsx/.mdx` files. [Tailwindcss Website](https://tailwindcss.com/)
 
+> This page contains updated instructions for tailwind v4. If you need to use tailwind v3, you can find the relevant documentation [here](/docs/integrations/tailwind-v3).
+
 ## Usage
 
-You can add Tailwind easily by using the following Qwik starter script:
+You can add Tailwind v4 easily by using the following Qwik starter script:
 
 <PackageManagerTabs>
 <span q:slot="pnpm">
@@ -53,7 +56,7 @@ bun run qwik add tailwind
 </PackageManagerTabs>
 
 The previous command updates your app with the necessary dependencies,
-and modifies following files
+and modifies the following files
 
 ```css title="src/global.css"
 

--- a/starters/README.md
+++ b/starters/README.md
@@ -1,47 +1,30 @@
 # Starters
 
-This folder stores "starter" projects for the CLI. The idea is that during the CLI execution, the developer can choose a particular starter app and combine it with a specific server and features.
+This folder stores "starter" projects for the cli. The idea is that during the cli execution, the developer can choose a particular starter app and combine it with a specific server and features.
 
 All starters are based on `starters/apps/base`, including the `package.json` and `tsconfig.json`. Depending on the options the user selects, their starter merges into the `base` app.
 
 ## Developer
 
-Here are steps to try out the CLI in a local environment.
+Here are steps to try out the cli in a local environment.
 
-1. Build CLI:
+1. Build the cli:
 
-   ```
-   # pnpm build.cli
-   ```
+```zsh
+pnpm build.cli
+```
 
-1. Run CLI:
+2. Run the cli:
 
-   ```
-   # node ./packages/create-qwik/dist/create-qwik.cjs
-   💫 Let's create a Qwik project 💫
+```zsh
+pnpm cli.qwik
+```
 
-   ✔ Project name … todo-express
-   ✔ Select a starter › Todo
-   ✔ Select a server › Express
+> If you want to test the cli on consumer repository, you can `pnpm link.dist` on the qwik monorepo, then `pnpm link --global @builder.io/qwik` on the consumer project, and finally run the cli from there.
 
-   ⭐️ Success! Project saved in todo-express directory
+## Publishing `create-qwik` cli Package
 
-   📟 Next steps:
-   cd todo-express
-   npm install
-   npm start
-   ```
-
-1. Change to generated location
-   ```
-   cd todo-express
-   npm install
-   npm start
-   ```
-
-## Publishing `create-qwik` CLI Package
-
-The starter CLI is published at the same time as `@builder.io/qwik`. When published, the CLI will update the `base` app's package.json to point to the published version of Qwik.
+The starter cli is published at the same time as `@builder.io/qwik`. When published, the cli will update the `base` app's package.json to point to the published version of Qwik.
 
 The base app's package.json's devDependencies are updated with:
 

--- a/starters/features/tailwind-v3/.vscode/settings.json
+++ b/starters/features/tailwind-v3/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "css.lint.unknownAtRules": "ignore"
+}

--- a/starters/features/tailwind-v3/package.json
+++ b/starters/features/tailwind-v3/package.json
@@ -1,0 +1,21 @@
+{
+  "description": "Use Tailwind v3 in your Qwik app",
+  "__qwik__": {
+    "displayName": "Integration: Tailwind v3 (styling)",
+    "priority": -10,
+    "viteConfig": {},
+    "docs": [
+      "https://qwik.dev/integrations/integration/tailwind/",
+      "https://tailwindcss.com/docs/utility-first"
+    ],
+    "alwaysInRoot": [
+      ".vscode"
+    ]
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.39",
+    "prettier-plugin-tailwindcss": "^0.5.4",
+    "tailwindcss": "^3.4.17"
+  }
+}

--- a/starters/features/tailwind-v3/postcss.config.cjs
+++ b/starters/features/tailwind-v3/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/starters/features/tailwind-v3/src/global.css
+++ b/starters/features/tailwind-v3/src/global.css
@@ -1,0 +1,7 @@
+/**
+ * Tailwind CSS imports
+ * View the full documentation at https://tailwindcss.com
+ */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/starters/features/tailwind-v3/tailwind.config.js
+++ b/starters/features/tailwind-v3/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/starters/features/tailwind/package.json
+++ b/starters/features/tailwind/package.json
@@ -1,7 +1,7 @@
 {
-  "description": "Use Tailwind in your Qwik app",
+  "description": "Use Tailwind v4 in your Qwik app",
   "__qwik__": {
-    "displayName": "Integration: Tailwind (styling)",
+    "displayName": "Integration: Tailwind v4 (styling)",
     "priority": -10,
         "viteConfig": {
             "imports": [


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Feature / enhancement

# Description

Some projects might not be able to use tailwind v4 yet. qwik-ui/styled hasn't been updated for tailwind v4 yet. I think even after updating to tailwind v4, we should keep a qwik-ui subdomain live for tailwind v3 for some time.

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [x] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
