### PR TITLE
fix: finding vnodes on interaction

### DIFF
--- a/.changeset/proud-kangaroos-boil.md
+++ b/.changeset/proud-kangaroos-boil.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: finding vnodes on interaction

--- a/packages/qwik/src/core/client/vnode.ts
+++ b/packages/qwik/src/core/client/vnode.ts
@@ -1138,7 +1138,7 @@ export const vnode_getElementName = (vnode: ElementVNode): string => {
   let elementName = elementVNode[ElementVNodeProps.elementName];
   if (elementName === undefined) {
     const element = elementVNode[ElementVNodeProps.element];
-    const nodeName = isDev ? fastNodeName(element)!.toLowerCase() : fastNodeName(element)!;
+    const nodeName = fastNodeName(element)!.toLowerCase();
     elementName = elementVNode[ElementVNodeProps.elementName] = nodeName;
     elementVNode[VNodeProps.flags] |= vnode_getElementNamespaceFlags(element);
   }


### PR DESCRIPTION
We should always call the `toLowerCase` fn on node names, because they are always uppercased