### PR TITLE
docs(cookbook): update class handling

### DIFF
--- a/.changeset/kind-bees-grin.md
+++ b/.changeset/kind-bees-grin.md
@@ -1,5 +1,0 @@
----
-"qwik-docs": patch
----
-
-Update index.mdx

--- a/.changeset/kind-bees-grin.md
+++ b/.changeset/kind-bees-grin.md
@@ -1,0 +1,5 @@
+---
+"qwik-docs": patch
+---
+
+Update index.mdx

--- a/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/nav-link/index.mdx
@@ -51,7 +51,7 @@ export const NavLink = component$(
     return (
       <Link
         {...props}
-        class={`${props.class || ''} ${isActive && activeClass ? activeClass : ''}`}
+        class={[props.class, isActive && activeClass ? activeClass : ""]}
         
       >
         <Slot />


### PR DESCRIPTION
current code results in unexpected behavior when `props.class` was an array. Updated to:

`class={[props.class, isActive && activeClass ? activeClass : ""]}`

ensuring proper class concatenation and maintaining Tailwind's expected behavior.

This fixes styling inconsistencies and improves component reliability.
