### PR TITLE
refactor(rollup): move build mode + debug:true chunk names logic out of manualChunks

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -891,14 +891,7 @@ export const manifest = ${JSON.stringify(manifest)};\n`;
     // Maybe a better solution would be to mark those files as entires earlier in the chain so that we can remove this check and the one above altogether.
     // We check .(tsx|jsx) after node_modules in case some node_modules end with .jsx or .tsx.
     if (/\.(tsx|jsx)$/.test(id)) {
-      const optimizer = getOptimizer();
-      const path = optimizer.sys.path;
-      const relativePath = path.relative(optimizer.sys.cwd(), id);
-      const sanitizedPath = relativePath
-        .replace(/^(\.\.\/)+/, '')
-        .replace(/^\/+/, '')
-        .replace(/\//g, '-');
-      return sanitizedPath; // We return sanitizedPath for qwikVite plugin with debug:true
+      return id;
     }
 
     return null;

--- a/packages/qwik/src/optimizer/src/plugins/rollup.ts
+++ b/packages/qwik/src/optimizer/src/plugins/rollup.ts
@@ -230,16 +230,15 @@ export function normalizeRollupOutputOptionsObject(
           return 'build/qwik-city.js';
         }
 
-        // Sanitize The path to use dashes instead of slashes, to keep the same folder strucutre as without debug:true.
+        // The chunk name can often be a path. We sanitize it to use dashes instead of slashes, to keep the same folder structure as without debug:true.
         // Besides, Rollup doesn't accept absolute or relative paths as inputs for the [name] placeholder for the same reason.
         const path = optimizer.sys.path;
         const relativePath = path.relative(optimizer.sys.cwd(), chunkInfo.name);
-        const sanitizedPath = relativePath
+        const sanitized = relativePath
           .replace(/^(\.\.\/)+/, '')
           .replace(/^\/+/, '')
           .replace(/\//g, '-');
-        chunkInfo.name = sanitizedPath;
-        return `build/[name].js`;
+        return `build/${sanitized}.js`;
       };
     }
     // client production output

--- a/packages/qwik/src/optimizer/src/plugins/rollup.ts
+++ b/packages/qwik/src/optimizer/src/plugins/rollup.ts
@@ -78,6 +78,7 @@ export function qwikRollup(qwikRollupOpts: QwikRollupPluginOptions = {}): any {
 
     outputOptions(rollupOutputOpts) {
       return normalizeRollupOutputOptionsObject(
+        qwikPlugin.getOptimizer(),
         qwikPlugin.getOptions(),
         rollupOutputOpts,
         false,
@@ -160,6 +161,7 @@ export function qwikRollup(qwikRollupOpts: QwikRollupPluginOptions = {}): any {
 }
 
 export function normalizeRollupOutputOptions(
+  optimizer: Optimizer,
   opts: NormalizedQwikPluginOptions,
   rollupOutputOpts: Rollup.OutputOptions | Rollup.OutputOptions[] | undefined,
   useAssetsDir: boolean,
@@ -173,18 +175,31 @@ export function normalizeRollupOutputOptions(
     }
 
     return rollupOutputOpts.map((outputOptsObj) => ({
-      ...normalizeRollupOutputOptionsObject(opts, outputOptsObj, useAssetsDir, manualChunks),
+      ...normalizeRollupOutputOptionsObject(
+        optimizer,
+        opts,
+        outputOptsObj,
+        useAssetsDir,
+        manualChunks
+      ),
       dir: outDir || outputOptsObj.dir,
     }));
   }
 
   return {
-    ...normalizeRollupOutputOptionsObject(opts, rollupOutputOpts, useAssetsDir, manualChunks),
+    ...normalizeRollupOutputOptionsObject(
+      optimizer,
+      opts,
+      rollupOutputOpts,
+      useAssetsDir,
+      manualChunks
+    ),
     dir: outDir || rollupOutputOpts?.dir,
   };
 }
 
 export function normalizeRollupOutputOptionsObject(
+  optimizer: Optimizer,
   opts: NormalizedQwikPluginOptions,
   rollupOutputOptsObj: Rollup.OutputOptions | undefined,
   useAssetsDir: boolean,
@@ -201,9 +216,31 @@ export function normalizeRollupOutputOptionsObject(
         ? `${opts.assetsDir}/${assetFileNames}`
         : assetFileNames;
     }
-    // Friendly name in dev or preview with debug mode
-    const fileName =
-      opts.buildMode == 'production' && !opts.debug ? 'build/q-[hash].js' : 'build/[name].js';
+
+    let fileName: string | ((chunkInfo: Rollup.PreRenderedChunk) => string) | undefined;
+    if (opts.buildMode === 'production' && !opts.debug) {
+      fileName = 'build/q-[hash].js';
+    } else {
+      // Friendlier names in dev or preview with debug mode
+      fileName = (chunkInfo) => {
+        if (chunkInfo.moduleIds.some((id) => id.endsWith('core.prod.mjs'))) {
+          return 'build/core.js';
+        }
+        if (chunkInfo.moduleIds.some((id) => id.endsWith('qwik-city/lib/index.qwik.mjs'))) {
+          return 'build/qwik-city.js';
+        }
+
+        // some chunk names are absolute paths and rollup doesn't accept that so we must sanitize those instead of simply returning `build/[name].js`.
+        const path = optimizer.sys.path;
+        const relativePath = path.relative(optimizer.sys.cwd(), chunkInfo.name);
+        const sanitizedPath = relativePath
+          .replace(/^(\.\.\/)+/, '')
+          .replace(/^\/+/, '')
+          .replace(/\//g, '-');
+
+        return `build/${sanitizedPath}.js`;
+      };
+    }
     // client production output
     if (!outputOpts.entryFileNames) {
       outputOpts.entryFileNames = useAssetsDir ? `${opts.assetsDir}/${fileName}` : fileName;

--- a/packages/qwik/src/optimizer/src/plugins/rollup.ts
+++ b/packages/qwik/src/optimizer/src/plugins/rollup.ts
@@ -230,7 +230,14 @@ export function normalizeRollupOutputOptionsObject(
           return 'build/qwik-city.js';
         }
 
-        const sanitizedPath = sanitizePath(optimizer, chunkInfo.name);
+        // Sanitize The path to use dashes instead of slashes, to keep the same folder strucutre as without debug:true.
+        // Besides, Rollup doesn't accept absolute or relative paths as inputs for the [name] placeholder for the same reason.
+        const path = optimizer.sys.path;
+        const relativePath = path.relative(optimizer.sys.cwd(), chunkInfo.name);
+        const sanitizedPath = relativePath
+          .replace(/^(\.\.\/)+/, '')
+          .replace(/^\/+/, '')
+          .replace(/\//g, '-');
         chunkInfo.name = sanitizedPath;
         return `build/[name].js`;
       };
@@ -275,20 +282,6 @@ export function normalizeRollupOutputOptionsObject(
   }
 
   return outputOpts;
-}
-
-/**
- * @private Sanitize The path to use dashes instead of slashes, to keep the same folder strucutre as
- *   without debug:true. Besides, Rollup doesn't accept absolute or relative paths as inputs for the
- *   [name] placeholder for the same reason.
- */
-export function sanitizePath(optimizer: Optimizer, pathToSanitize: string) {
-  const path = optimizer.sys.path;
-  const relativePath = path.relative(optimizer.sys.cwd(), pathToSanitize);
-  return relativePath
-    .replace(/^(\.\.\/)+/, '')
-    .replace(/^\/+/, '')
-    .replace(/\//g, '-');
 }
 
 export function createRollupError(id: string, diagnostic: Diagnostic) {

--- a/packages/qwik/src/optimizer/src/plugins/rollup.ts
+++ b/packages/qwik/src/optimizer/src/plugins/rollup.ts
@@ -231,8 +231,8 @@ export function normalizeRollupOutputOptionsObject(
         }
 
         const sanitizedPath = sanitizePath(optimizer, chunkInfo.name);
-
-        return `build/${sanitizedPath}.js`;
+        chunkInfo.name = sanitizedPath;
+        return `build/[name].js`;
       };
     }
     // client production output

--- a/packages/qwik/src/optimizer/src/plugins/rollup.ts
+++ b/packages/qwik/src/optimizer/src/plugins/rollup.ts
@@ -230,13 +230,7 @@ export function normalizeRollupOutputOptionsObject(
           return 'build/qwik-city.js';
         }
 
-        // some chunk names are absolute paths and rollup doesn't accept that so we must sanitize those instead of simply returning `build/[name].js`.
-        const path = optimizer.sys.path;
-        const relativePath = path.relative(optimizer.sys.cwd(), chunkInfo.name);
-        const sanitizedPath = relativePath
-          .replace(/^(\.\.\/)+/, '')
-          .replace(/^\/+/, '')
-          .replace(/\//g, '-');
+        const sanitizedPath = sanitizePath(optimizer, chunkInfo.name);
 
         return `build/${sanitizedPath}.js`;
       };
@@ -281,6 +275,20 @@ export function normalizeRollupOutputOptionsObject(
   }
 
   return outputOpts;
+}
+
+/**
+ * @private Sanitize The path to use dashes instead of slashes, to keep the same folder strucutre as
+ *   without debug:true. Besides, Rollup doesn't accept absolute or relative paths as inputs for the
+ *   [name] placeholder for the same reason.
+ */
+export function sanitizePath(optimizer: Optimizer, pathToSanitize: string) {
+  const path = optimizer.sys.path;
+  const relativePath = path.relative(optimizer.sys.cwd(), pathToSanitize);
+  return relativePath
+    .replace(/^(\.\.\/)+/, '')
+    .replace(/^\/+/, '')
+    .replace(/\//g, '-');
 }
 
 export function createRollupError(id: string, diagnostic: Diagnostic) {

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -360,6 +360,7 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
         updatedViteConfig.build!.rollupOptions = {
           input: opts.input,
           output: normalizeRollupOutputOptions(
+            qwikPlugin.getOptimizer(),
             opts,
             viteConfig.build?.rollupOptions?.output,
             useAssetsDir,

--- a/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
@@ -12,6 +12,17 @@ import {
 
 const cwd = process.cwd();
 
+const chunkInfoMock: Rollup.PreRenderedChunk = {
+  exports: [''],
+  name: 'chunk.tsx',
+  facadeModuleId: 'chunk.tsx',
+  isDynamicEntry: false,
+  isEntry: false,
+  isImplicitEntry: false,
+  moduleIds: ['chunk.tsx'],
+  type: 'chunk',
+};
+
 function mockOptimizerOptions(): OptimizerOptions {
   return {
     sys: {
@@ -67,7 +78,6 @@ test('command: serve, mode: development', async () => {
   const entryFileNames = outputOptions.entryFileNames as (
     chunkInfo: Rollup.PreRenderedChunk
   ) => string;
-  const fakeChunkInfo = { name: 'chunk.tsx' } as Rollup.PreRenderedChunk;
 
   assert.deepEqual(opts.target, 'client');
   assert.deepEqual(opts.buildMode, 'development');
@@ -78,8 +88,8 @@ test('command: serve, mode: development', async () => {
   assert.deepEqual(rollupOptions.input, normalizePath(resolve(cwd, 'src', 'entry.dev')));
 
   assert.deepEqual(outputOptions.assetFileNames, 'assets/[hash]-[name].[ext]');
-  assert.deepEqual(chunkFileNames(fakeChunkInfo), 'build/[name].js');
-  assert.deepEqual(entryFileNames(fakeChunkInfo), 'build/[name].js');
+  assert.deepEqual(chunkFileNames(chunkInfoMock), 'build/[name].js');
+  assert.deepEqual(entryFileNames(chunkInfoMock), 'build/[name].js');
   assert.deepEqual(outputOptions.format, 'es');
 
   assert.deepEqual(build.dynamicImportVarsOptions?.exclude, [/./]);
@@ -138,6 +148,12 @@ test('command: build, mode: development', async () => {
   const build = c.build!;
   const rollupOptions = build!.rollupOptions!;
   const outputOptions = rollupOptions.output as Rollup.OutputOptions;
+  const chunkFileNames = outputOptions.chunkFileNames as (
+    chunkInfo: Rollup.PreRenderedChunk
+  ) => string;
+  const entryFileNames = outputOptions.entryFileNames as (
+    chunkInfo: Rollup.PreRenderedChunk
+  ) => string;
 
   assert.deepEqual(opts.target, 'client');
   assert.deepEqual(opts.buildMode, 'development');
@@ -151,8 +167,8 @@ test('command: build, mode: development', async () => {
   assert.deepEqual(rollupOptions.input, [normalizePath(resolve(cwd, 'src', 'root'))]);
 
   assert.deepEqual(outputOptions.assetFileNames, 'assets/[hash]-[name].[ext]');
-  assert.deepEqual(outputOptions.chunkFileNames, 'build/[name].js');
-  assert.deepEqual(outputOptions.entryFileNames, 'build/[name].js');
+  assert.deepEqual(chunkFileNames(chunkInfoMock), 'build/[name].js');
+  assert.deepEqual(entryFileNames(chunkInfoMock), 'build/[name].js');
 
   assert.deepEqual(build.dynamicImportVarsOptions?.exclude, [/./]);
   assert.deepEqual(build.ssr, undefined);

--- a/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
@@ -12,16 +12,28 @@ import {
 
 const cwd = process.cwd();
 
-const chunkInfoMock: Rollup.PreRenderedChunk = {
-  exports: [''],
-  name: 'chunk.tsx',
-  facadeModuleId: 'chunk.tsx',
-  isDynamicEntry: false,
-  isEntry: false,
-  isImplicitEntry: false,
-  moduleIds: ['chunk.tsx'],
-  type: 'chunk',
-};
+const chunkInfoMocks: Rollup.PreRenderedChunk[] = [
+  {
+    exports: [''],
+    name: 'chunk.tsx',
+    facadeModuleId: 'chunk.tsx',
+    isDynamicEntry: false,
+    isEntry: false,
+    isImplicitEntry: false,
+    moduleIds: ['chunk.tsx'],
+    type: 'chunk',
+  },
+  {
+    exports: [''],
+    name: '/Users/username/app/chunk.tsx',
+    facadeModuleId: '/Users/username/app/chunk.tsx',
+    isDynamicEntry: false,
+    isEntry: false,
+    isImplicitEntry: false,
+    moduleIds: ['/Users/username/app/chunk.tsx'],
+    type: 'chunk',
+  },
+];
 
 function mockOptimizerOptions(): OptimizerOptions {
   return {
@@ -88,8 +100,10 @@ test('command: serve, mode: development', async () => {
   assert.deepEqual(rollupOptions.input, normalizePath(resolve(cwd, 'src', 'entry.dev')));
 
   assert.deepEqual(outputOptions.assetFileNames, 'assets/[hash]-[name].[ext]');
-  assert.deepEqual(chunkFileNames(chunkInfoMock), 'build/[name].js');
-  assert.deepEqual(entryFileNames(chunkInfoMock), 'build/[name].js');
+  assert.deepEqual(chunkFileNames(chunkInfoMocks[0]), `build/chunk.tsx.js`);
+  assert.deepEqual(entryFileNames(chunkInfoMocks[0]), `build/chunk.tsx.js`);
+  assert.deepEqual(chunkFileNames(chunkInfoMocks[1]), 'build/username-app-chunk.tsx.js');
+  assert.deepEqual(entryFileNames(chunkInfoMocks[1]), 'build/username-app-chunk.tsx.js');
   assert.deepEqual(outputOptions.format, 'es');
 
   assert.deepEqual(build.dynamicImportVarsOptions?.exclude, [/./]);
@@ -167,8 +181,10 @@ test('command: build, mode: development', async () => {
   assert.deepEqual(rollupOptions.input, [normalizePath(resolve(cwd, 'src', 'root'))]);
 
   assert.deepEqual(outputOptions.assetFileNames, 'assets/[hash]-[name].[ext]');
-  assert.deepEqual(chunkFileNames(chunkInfoMock), 'build/[name].js');
-  assert.deepEqual(entryFileNames(chunkInfoMock), 'build/[name].js');
+  assert.deepEqual(chunkFileNames(chunkInfoMocks[0]), `build/chunk.tsx.js`);
+  assert.deepEqual(entryFileNames(chunkInfoMocks[0]), `build/chunk.tsx.js`);
+  assert.deepEqual(chunkFileNames(chunkInfoMocks[1]), 'build/username-app-chunk.tsx.js');
+  assert.deepEqual(entryFileNames(chunkInfoMocks[1]), 'build/username-app-chunk.tsx.js');
 
   assert.deepEqual(build.dynamicImportVarsOptions?.exclude, [/./]);
   assert.deepEqual(build.ssr, undefined);

--- a/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
@@ -61,6 +61,13 @@ test('command: serve, mode: development', async () => {
   const build = c.build!;
   const rollupOptions = build!.rollupOptions!;
   const outputOptions = rollupOptions.output as Rollup.OutputOptions;
+  const chunkFileNames = outputOptions.chunkFileNames as (
+    chunkInfo: Rollup.PreRenderedChunk
+  ) => string;
+  const entryFileNames = outputOptions.entryFileNames as (
+    chunkInfo: Rollup.PreRenderedChunk
+  ) => string;
+  const fakeChunkInfo = { name: 'chunk.tsx' } as Rollup.PreRenderedChunk;
 
   assert.deepEqual(opts.target, 'client');
   assert.deepEqual(opts.buildMode, 'development');
@@ -71,8 +78,8 @@ test('command: serve, mode: development', async () => {
   assert.deepEqual(rollupOptions.input, normalizePath(resolve(cwd, 'src', 'entry.dev')));
 
   assert.deepEqual(outputOptions.assetFileNames, 'assets/[hash]-[name].[ext]');
-  assert.deepEqual(outputOptions.chunkFileNames, 'build/[name].js');
-  assert.deepEqual(outputOptions.entryFileNames, 'build/[name].js');
+  assert.deepEqual(chunkFileNames(fakeChunkInfo), 'build/[name].js');
+  assert.deepEqual(entryFileNames(fakeChunkInfo), 'build/[name].js');
   assert.deepEqual(outputOptions.format, 'es');
 
   assert.deepEqual(build.dynamicImportVarsOptions?.exclude, [/./]);

--- a/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
@@ -25,12 +25,12 @@ const chunkInfoMocks: Rollup.PreRenderedChunk[] = [
   },
   {
     exports: [''],
-    name: '/Users/username/app/chunk.tsx',
-    facadeModuleId: '/Users/username/app/chunk.tsx',
+    name: cwd + '/app/chunk.tsx',
+    facadeModuleId: cwd + '/app/chunk.tsx',
     isDynamicEntry: false,
     isEntry: false,
     isImplicitEntry: false,
-    moduleIds: ['/Users/username/app/chunk.tsx'],
+    moduleIds: [cwd + '/app/chunk.tsx'],
     type: 'chunk',
   },
 ];
@@ -102,8 +102,8 @@ test('command: serve, mode: development', async () => {
   assert.deepEqual(outputOptions.assetFileNames, 'assets/[hash]-[name].[ext]');
   assert.deepEqual(chunkFileNames(chunkInfoMocks[0]), `build/chunk.tsx.js`);
   assert.deepEqual(entryFileNames(chunkInfoMocks[0]), `build/chunk.tsx.js`);
-  assert.deepEqual(chunkFileNames(chunkInfoMocks[1]), 'build/username-app-chunk.tsx.js');
-  assert.deepEqual(entryFileNames(chunkInfoMocks[1]), 'build/username-app-chunk.tsx.js');
+  assert.deepEqual(chunkFileNames(chunkInfoMocks[1]), 'build/app-chunk.tsx.js');
+  assert.deepEqual(entryFileNames(chunkInfoMocks[1]), 'build/app-chunk.tsx.js');
   assert.deepEqual(outputOptions.format, 'es');
 
   assert.deepEqual(build.dynamicImportVarsOptions?.exclude, [/./]);
@@ -183,8 +183,8 @@ test('command: build, mode: development', async () => {
   assert.deepEqual(outputOptions.assetFileNames, 'assets/[hash]-[name].[ext]');
   assert.deepEqual(chunkFileNames(chunkInfoMocks[0]), `build/chunk.tsx.js`);
   assert.deepEqual(entryFileNames(chunkInfoMocks[0]), `build/chunk.tsx.js`);
-  assert.deepEqual(chunkFileNames(chunkInfoMocks[1]), 'build/username-app-chunk.tsx.js');
-  assert.deepEqual(entryFileNames(chunkInfoMocks[1]), 'build/username-app-chunk.tsx.js');
+  assert.deepEqual(chunkFileNames(chunkInfoMocks[1]), 'build/app-chunk.tsx.js');
+  assert.deepEqual(entryFileNames(chunkInfoMocks[1]), 'build/app-chunk.tsx.js');
 
   assert.deepEqual(build.dynamicImportVarsOptions?.exclude, [/./]);
   assert.deepEqual(build.ssr, undefined);


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Feature / enhancement
- Bug
- Docs / tests / types / typos
- Infra

# Description

Because manualChunks should only be responsible for telling rollup to not bundle certain chunks together, not to specifically name certain chunks. Naming through the outputOptions ensures we don't interfere with Rollup's bundling unnecessarily.

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
