### PR TITLE
fix: Write Response object in the send request event even on redirects

### DIFF
--- a/.changeset/tall-paint-help.md
+++ b/.changeset/tall-paint-help.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik-city': patch
+---
+
+fix: Write Response object in the send request event even on redirects

--- a/packages/qwik-city/src/middleware/request-handler/request-event.ts
+++ b/packages/qwik-city/src/middleware/request-handler/request-event.ts
@@ -120,11 +120,7 @@ export function createRequestEvent(
         const writableStream = requestEv.getWritableStream();
         statusOrResponse.body.pipeTo(writableStream);
       } else {
-        if (status >= 300 && status < 400) {
-          return new RedirectMessage();
-        } else {
-          requestEv.getWritableStream().getWriter().close();
-        }
+        requestEv.getWritableStream().getWriter().close();
       }
     }
     return exit();


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Bug

# Description

This is what qwik-city/qwik-router consumers can perform:
![image](https://github.com/user-attachments/assets/e0f9cf05-c862-4166-a6e3-cc006d1a22d1)

However the `Response` object is lost because on the `send` event, when performing any kind of redirect (code > 300 && < 400), qwik-city is returning a new RedirectMessage instead.

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [X] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [X] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
