### PR TITLE
fix(starters): styled vanilla extract update devDependncies

### DIFF
--- a/starters/features/styled-vanilla-extract/package.json
+++ b/starters/features/styled-vanilla-extract/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@vanilla-extract/css": "^1.12.0",
-    "styled-vanilla-extract": "^0.5.4"
+    "styled-vanilla-extract": "^0.5.4",
+    "@vanilla-extract/vite-plugin": "^5.0.1"
   }
 }


### PR DESCRIPTION


# What is it?

<!-- pick one and remove the others -->

- Feature / enhancement
- Bug

# Description
@wmertens 

Hey Wout 
Sorry for the tag, but I think this is your integration, so would appreciate your input here.

Small update:

seems `@vanilla-extract/vite-plugin` was missing from the devDependencies  which would cause `error when starting dev server:
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@vanilla-extract/vite-plugin' ` 



I did link the CLI globally and just updating the devDependencies seems to have fixed the issue with the `/styled-flower/` route without any adjustments.

I'll leave it as a draft for now, let me know what you think.




- [ x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ x] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
