### PR TITLE
fix: removing text node from shared text node

### DIFF
--- a/.changeset/wicked-pets-chew.md
+++ b/.changeset/wicked-pets-chew.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: removing text node from shared text node

--- a/packages/qwik/src/core/client/vnode.ts
+++ b/packages/qwik/src/core/client/vnode.ts
@@ -1067,6 +1067,17 @@ export const vnode_remove = (
     vnode_ensureTextInflated(journal, vToRemove);
   }
 
+  if (removeDOM) {
+    const domParent = vnode_getDomParent(vParent);
+    const isInnerHTMLParent = vnode_getAttr(vParent, dangerouslySetInnerHTML);
+    if (isInnerHTMLParent) {
+      // ignore children, as they are inserted via innerHTML
+      return;
+    }
+    const children = vnode_getDOMChildNodes(journal, vToRemove);
+    domParent && children.length && journal.push(VNodeJournalOpCode.Remove, domParent, ...children);
+  }
+
   const vPrevious = vToRemove[VNodeProps.previousSibling];
   const vNext = vToRemove[VNodeProps.nextSibling];
   if (vPrevious) {
@@ -1081,16 +1092,6 @@ export const vnode_remove = (
   }
   vToRemove[VNodeProps.previousSibling] = null;
   vToRemove[VNodeProps.nextSibling] = null;
-  if (removeDOM) {
-    const domParent = vnode_getDomParent(vParent);
-    const isInnerHTMLParent = vnode_getAttr(vParent, dangerouslySetInnerHTML);
-    if (isInnerHTMLParent) {
-      // ignore children, as they are inserted via innerHTML
-      return;
-    }
-    const children = vnode_getDOMChildNodes(journal, vToRemove);
-    domParent && children.length && journal.push(VNodeJournalOpCode.Remove, domParent, ...children);
-  }
 };
 
 export const vnode_queryDomNodes = (

--- a/packages/qwik/src/core/client/vnode.unit.tsx
+++ b/packages/qwik/src/core/client/vnode.unit.tsx
@@ -227,6 +227,180 @@ describe('vnode', () => {
       vnode_applyJournal(journal);
       expect(parent.innerHTML).toEqual(`AB`);
     });
+
+    describe('node removing from shared text node', () => {
+      it('should inflate text nodes on first node remove', () => {
+        parent.innerHTML = `012`;
+        document.qVNodeData.set(parent, 'BBB');
+        vnode_getFirstChild(vParent) as VirtualVNode;
+        expect(vParent).toMatchVDOM(
+          <test>
+            {'0'}
+            {'1'}
+            {'2'}
+          </test>
+        );
+        const firstText = vnode_getFirstChild(vParent) as TextVNode;
+        vnode_remove(journal, vParent, firstText, true);
+        vnode_applyJournal(journal);
+        expect(vParent).toMatchVDOM(
+          <test>
+            {'1'}
+            {'2'}
+          </test>
+        );
+        expect(parent.innerHTML).toEqual(`12`);
+      });
+
+      it('should inflate text nodes on second node remove', () => {
+        parent.innerHTML = `012`;
+        document.qVNodeData.set(parent, 'BBB');
+        vnode_getFirstChild(vParent) as VirtualVNode;
+        expect(vParent).toMatchVDOM(
+          <test>
+            {'0'}
+            {'1'}
+            {'2'}
+          </test>
+        );
+        const firstText = vnode_getFirstChild(vParent) as TextVNode;
+        const secondText = vnode_getNextSibling(firstText) as TextVNode;
+        vnode_remove(journal, vParent, secondText, true);
+        vnode_applyJournal(journal);
+        expect(vParent).toMatchVDOM(
+          <test>
+            {'0'}
+            {'2'}
+          </test>
+        );
+        expect(parent.innerHTML).toEqual(`02`);
+      });
+
+      it('should inflate text nodes on last node remove', () => {
+        parent.innerHTML = `012`;
+        document.qVNodeData.set(parent, 'BBB');
+        vnode_getFirstChild(vParent) as VirtualVNode;
+        expect(vParent).toMatchVDOM(
+          <test>
+            {'0'}
+            {'1'}
+            {'2'}
+          </test>
+        );
+        const firstText = vnode_getFirstChild(vParent) as TextVNode;
+        const secondText = vnode_getNextSibling(firstText) as TextVNode;
+        const thirdText = vnode_getNextSibling(secondText) as TextVNode;
+        vnode_remove(journal, vParent, thirdText, true);
+        vnode_applyJournal(journal);
+        expect(vParent).toMatchVDOM(
+          <test>
+            {'0'}
+            {'1'}
+          </test>
+        );
+        expect(parent.innerHTML).toEqual(`01`);
+      });
+
+      it('should inflate text nodes on first node remove and change text of second', () => {
+        parent.innerHTML = `012`;
+        document.qVNodeData.set(parent, 'BBB');
+        vnode_getFirstChild(vParent) as VirtualVNode;
+        expect(vParent).toMatchVDOM(
+          <test>
+            {'0'}
+            {'1'}
+            {'2'}
+          </test>
+        );
+        const firstText = vnode_getFirstChild(vParent) as TextVNode;
+        const secondText = vnode_getNextSibling(firstText) as TextVNode;
+        vnode_remove(journal, vParent, firstText, true);
+        vnode_setText(journal, secondText, '!');
+        vnode_applyJournal(journal);
+        expect(vParent).toMatchVDOM(
+          <test>
+            {'!'}
+            {'2'}
+          </test>
+        );
+        expect(parent.innerHTML).toEqual(`!2`);
+      });
+
+      it('should inflate text nodes on first virtual node remove', () => {
+        parent.innerHTML = `0123`;
+        document.qVNodeData.set(parent, '{B}{B}{B}');
+        vnode_getFirstChild(vParent) as VirtualVNode;
+        expect(vParent).toMatchVDOM(
+          <test>
+            <>0</>
+            <>1</>
+            <>2</>
+          </test>
+        );
+        const firstVirtual = vnode_getFirstChild(vParent) as VirtualVNode;
+        vnode_remove(journal, vParent, firstVirtual, true);
+
+        vnode_applyJournal(journal);
+        expect(vParent).toMatchVDOM(
+          <test>
+            <>1</>
+            <>2</>
+          </test>
+        );
+        expect(parent.innerHTML).toEqual(`12`);
+      });
+
+      it('should inflate text nodes on middle virtual node remove', () => {
+        parent.innerHTML = `0123`;
+        document.qVNodeData.set(parent, '{B}{B}{B}');
+        vnode_getFirstChild(vParent) as VirtualVNode;
+        expect(vParent).toMatchVDOM(
+          <test>
+            <>0</>
+            <>1</>
+            <>2</>
+          </test>
+        );
+        const firstVirtual = vnode_getFirstChild(vParent) as VirtualVNode;
+        const secondVirtual = vnode_getNextSibling(firstVirtual) as VirtualVNode;
+        vnode_remove(journal, vParent, secondVirtual, true);
+
+        vnode_applyJournal(journal);
+        expect(vParent).toMatchVDOM(
+          <test>
+            <>0</>
+            <>2</>
+          </test>
+        );
+        expect(parent.innerHTML).toEqual(`02`);
+      });
+
+      it('should inflate text nodes on last virtual node remove', () => {
+        parent.innerHTML = `0123`;
+        document.qVNodeData.set(parent, '{B}{B}{B}');
+        vnode_getFirstChild(vParent) as VirtualVNode;
+        expect(vParent).toMatchVDOM(
+          <test>
+            <>0</>
+            <>1</>
+            <>2</>
+          </test>
+        );
+        const firstVirtual = vnode_getFirstChild(vParent) as VirtualVNode;
+        const secondVirtual = vnode_getNextSibling(firstVirtual) as VirtualVNode;
+        const thirdVirtual = vnode_getNextSibling(secondVirtual) as VirtualVNode;
+        vnode_remove(journal, vParent, thirdVirtual, true);
+
+        vnode_applyJournal(journal);
+        expect(vParent).toMatchVDOM(
+          <test>
+            <>0</>
+            <>1</>
+          </test>
+        );
+        expect(parent.innerHTML).toEqual(`01`);
+      });
+    });
   });
   describe('virtual', () => {
     it('should create empty Virtual', () => {


### PR DESCRIPTION
After ssr it, we get ie. "0123" as one text node, then we materialize 4 fragements with one letter in each.
We should get:
```tsx
<>0</><>1</><>2</><>3</>
```
but this also means that every vnode right after materializing will point to the same shared textnode "0123". Of course we need to split it to separate text nodes, and this should be done at time of removing. In this case we did it to late, when virtual parent didn't have connections to siblings.