### PR TITLE
fix: inserting new node edge case and creating error overlay

### DIFF
--- a/.changeset/cyan-bottles-speak.md
+++ b/.changeset/cyan-bottles-speak.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: creating error overlay

--- a/.changeset/tame-glasses-explain.md
+++ b/.changeset/tame-glasses-explain.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: inserting new node edge case

--- a/packages/qwik/src/core/client/dom-container.ts
+++ b/packages/qwik/src/core/client/dom-container.ts
@@ -200,15 +200,19 @@ export class DomContainer extends _SharedContainer implements IClientContainer {
         }
         errorDiv.setAttribute('q:key', '_error_');
         const journal: VNodeJournal = [];
-        vnode_getDOMChildNodes(journal, vHost).forEach((child) => errorDiv.appendChild(child));
-        const vErrorDiv = vnode_newElement(errorDiv, 'error-host');
+
+        const vErrorDiv = vnode_newElement(errorDiv, 'errored-host');
+
+        vnode_getDOMChildNodes(journal, vHost, true).forEach((child) => {
+          vnode_insertBefore(journal, vErrorDiv, child, null);
+        });
         vnode_insertBefore(journal, vHost, vErrorDiv, null);
         vnode_applyJournal(journal);
       }
 
       if (err && err instanceof Error) {
         if (!('hostElement' in err)) {
-          (err as any)['hostElement'] = host;
+          (err as any)['hostElement'] = String(host);
         }
       }
       if (!isRecoverable(err)) {

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -491,21 +491,6 @@ export const vnode_diff = (
       // All is good.
       // console.log('  NOOP', String(vCurrent));
     } else {
-      const parent = vnode_getParent(vProjectedNode);
-      const isAlreadyProjected =
-        !!parent && !(vnode_isElementVNode(parent) && vnode_getElementName(parent) === QTemplate);
-      if (isAlreadyProjected && vParent !== parent) {
-        /**
-         * The node is already projected, but structure has been changed. In next steps we will
-         * insert the vProjectedNode at the end. However we will find existing projection elements
-         * (from already projected THE SAME projection as vProjectedNode!) during
-         * vnode_insertBefore. We need to remove vnode from the vnode tree to avoid referencing it
-         * to self and cause infinite loop. Don't remove it from DOM to avoid additional operations
-         * and flickering.
-         */
-        vnode_remove(journal, parent, vProjectedNode, false);
-      }
-
       // move from q:template to the target node
       vnode_insertBefore(
         journal,

--- a/packages/qwik/src/core/tests/error-handling.spec.tsx
+++ b/packages/qwik/src/core/tests/error-handling.spec.tsx
@@ -1,0 +1,113 @@
+import { domRender, ssrRenderToDom, trigger } from '@qwik.dev/core/testing';
+import { describe, expect, it } from 'vitest';
+import {
+  Fragment,
+  Fragment as Component,
+  Fragment as Signal,
+  Fragment as Projection,
+  component$,
+  useSignal,
+  useTask$,
+} from '@qwik.dev/core';
+import { ErrorProvider } from '../../testing/rendering.unit-util';
+
+const debug = false; //true;
+Error.stackTraceLimit = 100;
+
+describe.each([
+  { render: ssrRenderToDom }, //
+  { render: domRender }, //
+])('$render.name: error handling', ({ render }) => {
+  it('should handle error in component with element wrapper', async () => {
+    const Cmp = component$(() => {
+      const counter = useSignal(0);
+      useTask$(async ({ track }) => {
+        const count = track(counter);
+        if (count === 0) {
+          return;
+        }
+        throw new Error('error');
+      });
+      return (
+        <main>
+          {''}
+          <button onClick$={() => counter.value++}>{counter.value}</button>
+        </main>
+      );
+    });
+
+    const { vNode, document } = await render(
+      <ErrorProvider>
+        <Cmp />
+      </ErrorProvider>,
+      { debug }
+    );
+    // override globalThis.document to make moving elements logic work
+    globalThis.document = document;
+
+    await trigger(document.body, 'button', 'click');
+
+    expect(vNode).toMatchVDOM(
+      <Component ssr-required>
+        <Projection ssr-required>
+          <Component ssr-required>
+            <errored-host>
+              <main>
+                {''}
+                <button>
+                  <Signal ssr-required>1</Signal>
+                </button>
+              </main>
+            </errored-host>
+          </Component>
+        </Projection>
+      </Component>
+    );
+  });
+
+  it('should handle error in component with virtual wrapper', async () => {
+    const Cmp = component$(() => {
+      const counter = useSignal(0);
+      useTask$(async ({ track }) => {
+        const count = track(counter);
+        if (count === 0) {
+          return;
+        }
+        throw new Error('error');
+      });
+      return (
+        <>
+          {''}
+          <button onClick$={() => counter.value++}>{counter.value}</button>
+        </>
+      );
+    });
+
+    const { vNode, document } = await render(
+      <ErrorProvider>
+        <Cmp />
+      </ErrorProvider>,
+      { debug }
+    );
+    // override globalThis.document to make moving elements logic work
+    globalThis.document = document;
+
+    await trigger(document.body, 'button', 'click');
+
+    expect(vNode).toMatchVDOM(
+      <Component ssr-required>
+        <Projection ssr-required>
+          <Component ssr-required>
+            <Fragment ssr-required></Fragment>
+            <errored-host>
+              {''}
+              <button>
+                <Signal ssr-required>1</Signal>
+              </button>
+            </errored-host>
+          </Component>
+        </Projection>
+      </Component>
+    );
+  });
+});


### PR DESCRIPTION
- create error overlay correctly using vnode transformations
- fix inserting node edge case and prevent referencing vnode to self
- add a lot of `insertBefore` tests