### PR TITLE
docs: update ecosystem style

### DIFF
--- a/packages/docs/src/routes/(ecosystem)/ecosystem.css
+++ b/packages/docs/src/routes/(ecosystem)/ecosystem.css
@@ -252,3 +252,8 @@
 [data-theme='dark'] [alt='Twitter'] {
   filter: invert(1);
 }
+
+.custom-grid-cols-240px-1fr-tailwind-workaround {
+  /* temporary workaround .grid-cols-\[240px\,1fr\] is not currently working in tailwind */
+  grid-template-columns: 240px 1fr;
+}

--- a/packages/docs/src/routes/(ecosystem)/ecosystem/index.tsx
+++ b/packages/docs/src/routes/(ecosystem)/ecosystem/index.tsx
@@ -23,7 +23,7 @@ export default component$(() => {
 
   return (
     <>
-      <div class="ecosystem lg:grid grid-cols-[240px,1fr] m-auto max-w-screen-xl gap-8">
+      <div class="ecosystem lg:grid grid-cols-[240px,1fr] m-auto max-w-screen-xl gap-8 custom-grid-cols-240px-1fr-tailwind-workaround">
         <EcosystemMenu />
         <MobileEcosystemMenu />
 


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Styles - workaround

# Description

Ciao Gio

The Grid on the ecosystem page has broken for desktop view
https://qwik.dev/ecosystem/


This seems to be a tailwindcss v4.0.12 issue
Issue seems to be that the css  is not valid due to the `,` separator in the below image
![image](https://github.com/user-attachments/assets/2ecf4a9c-f090-48ad-935c-1cfb9298d0b1)

Current page layout:
![Current page layout](https://github.com/user-attachments/assets/6426a9f2-5963-412e-aa37-9b8ad8e080f4)

I did add a comment in the CSS hoping someone will see it in the future.

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [ x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x ] I performed a self-review of my own code

