### PR TITLE
fix: retry computed qrl execution when not ready

### DIFF
--- a/.changeset/sweet-hairs-remember.md
+++ b/.changeset/sweet-hairs-remember.md
@@ -1,5 +1,5 @@
 ---
-'@qwik.dev/core': major
+'@qwik.dev/core': patch
 ---
 
-FIX: Add a new e2e test to verify QRL behavior without uncaught promises. Introduce retry logic for QRL resolution to handle potential promise retries, ensuring robustness in asynchronous operations.
+FIX: Introduce retry logic for QRL resolution to handle potential promise retries, ensuring robustness in asynchronous operations.

--- a/.changeset/sweet-hairs-remember.md
+++ b/.changeset/sweet-hairs-remember.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': major
+---
+
+FIX: Add a new e2e test to verify QRL behavior without uncaught promises. Introduce retry logic for QRL resolution to handle potential promise retries, ensuring robustness in asynchronous operations.

--- a/packages/qwik/src/core/shared/qrl/qrl-class.ts
+++ b/packages/qwik/src/core/shared/qrl/qrl-class.ts
@@ -93,11 +93,13 @@ export const createQRL = <TYPE>(
     // Note that we bind the current `this`
     const bound = (...args: QrlArgs<TYPE>): ValueOrPromise<QrlReturn<TYPE> | undefined> => {
       if (!qrl.resolved) {
-        return qrl.resolve().then((fn) => {
+        //@ts-ignore
+        return retryOnPromise(() => qrl.resolve()).then((fn) => {
           if (!isFunction(fn)) {
             throw qError(QError.qrlIsNotFunction);
           }
-          return retryOnPromise(() => bound(...args));
+          return bound(...args);
+          // @ts-ignore
         });
       }
       if (beforeFn && beforeFn() === false) {

--- a/packages/qwik/src/core/shared/qrl/qrl-class.ts
+++ b/packages/qwik/src/core/shared/qrl/qrl-class.ts
@@ -93,7 +93,8 @@ export const createQRL = <TYPE>(
     // Note that we bind the current `this`
     const bound = (...args: QrlArgs<TYPE>): ValueOrPromise<QrlReturn<TYPE> | undefined> => {
       if (!qrl.resolved) {
-        return retryOnPromise(() => qrl.resolve()).then((fn) => {
+        const promise = retryOnPromise(() => qrl.resolve()) as Promise<TYPE>;
+        return promise.then((fn) => {
           if (!isFunction(fn)) {
             throw qError(QError.qrlIsNotFunction);
           }

--- a/packages/qwik/src/core/shared/qrl/qrl-class.ts
+++ b/packages/qwik/src/core/shared/qrl/qrl-class.ts
@@ -93,14 +93,12 @@ export const createQRL = <TYPE>(
     // Note that we bind the current `this`
     const bound = (...args: QrlArgs<TYPE>): ValueOrPromise<QrlReturn<TYPE> | undefined> => {
       if (!qrl.resolved) {
-        return retryOnPromise(() =>
-          qrl.resolve().then((fn) => {
-            if (!isFunction(fn)) {
-              throw qError(QError.qrlIsNotFunction);
-            }
-            return bound(...args);
-          })
-        );
+        return qrl.resolve().then((fn) => {
+          if (!isFunction(fn)) {
+            throw qError(QError.qrlIsNotFunction);
+          }
+          return retryOnPromise(() => bound(...args));
+        });
       }
       if (beforeFn && beforeFn() === false) {
         return;

--- a/packages/qwik/src/core/shared/qrl/qrl-class.ts
+++ b/packages/qwik/src/core/shared/qrl/qrl-class.ts
@@ -93,13 +93,11 @@ export const createQRL = <TYPE>(
     // Note that we bind the current `this`
     const bound = (...args: QrlArgs<TYPE>): ValueOrPromise<QrlReturn<TYPE> | undefined> => {
       if (!qrl.resolved) {
-        //@ts-ignore
         return retryOnPromise(() => qrl.resolve()).then((fn) => {
           if (!isFunction(fn)) {
             throw qError(QError.qrlIsNotFunction);
           }
           return bound(...args);
-          // @ts-ignore
         });
       }
       if (beforeFn && beforeFn() === false) {

--- a/starters/apps/e2e/src/components/qrl/qrl.tsx
+++ b/starters/apps/e2e/src/components/qrl/qrl.tsx
@@ -1,0 +1,32 @@
+import { $, component$, useComputed$, useSignal } from "@qwik.dev/core";
+
+export const QRL = component$(() => {
+  return (
+    <>
+      <ShouldResolveInnerComputedQRL />
+    </>
+  );
+});
+
+export const ShouldResolveInnerComputedQRL = component$(() => {
+  const test = useComputed$(() => 0);
+  return <InnerComputedButton test={test} />;
+});
+
+export const InnerComputedButton = component$<any>((props) => {
+  const syncSelectionCounter = useSignal(0);
+  const syncSelection = $(() => {
+    syncSelectionCounter.value++;
+    props.test.value;
+  });
+
+  const handleClick = $(() => {
+    syncSelection();
+  });
+
+  return (
+    <button id="inner-computed-button" onClick$={handleClick}>
+      Click Me {syncSelectionCounter.value}
+    </button>
+  );
+});

--- a/starters/apps/e2e/src/root.tsx
+++ b/starters/apps/e2e/src/root.tsx
@@ -35,6 +35,7 @@ import { UseId } from "./components/useid/useid";
 import { Watch } from "./components/watch/watch";
 
 import "./global.css";
+import { QRL } from "./components/qrl/qrl";
 
 const tests: Record<string, FunctionComponent> = {
   "/e2e/two-listeners": () => <TwoListeners />,
@@ -71,6 +72,7 @@ const tests: Record<string, FunctionComponent> = {
   "/e2e/build-variables": () => <BuildVariables />,
   "/e2e/exception/render": () => <RenderExceptions />,
   "/e2e/exception/use-task": () => <UseTaskExceptions />,
+  "/e2e/qrl": () => <QRL />,
 };
 
 export const Root = component$<{ pathname: string }>(({ pathname }) => {

--- a/starters/e2e/e2e.qrl.e2e.ts
+++ b/starters/e2e/e2e.qrl.e2e.ts
@@ -1,25 +1,15 @@
 import { expect, test } from "@playwright/test";
-
-test.describe("qrl", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/e2e/qrl");
-    page.on("pageerror", (err) => expect(err).toEqual(undefined));
-    page.on("console", (msg) => {
-      if (msg.type() === "error") {
-        expect(msg.text()).toEqual(undefined);
-      }
-    });
+test("should update counter without uncaught promises", async ({ page }) => {
+  await page.goto("/e2e/qrl");
+  page.on("pageerror", (err) => expect(err).toEqual(undefined));
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      expect(msg.text()).toEqual(undefined);
+    }
   });
+  const button = page.locator("#inner-computed-button");
+  await expect(button).toContainText("Click Me 0");
 
-  test.only("should update counter without uncaught promises", async ({
-    page,
-  }) => {
-    await page.goto("/e2e/qrl");
-
-    const button = page.locator("#inner-computed-button");
-    await expect(button).toContainText("Click Me 0");
-
-    // 先执行点击操作
-    await button.click();
-  });
+  // 先执行点击操作
+  await button.click();
 });

--- a/starters/e2e/e2e.qrl.e2e.ts
+++ b/starters/e2e/e2e.qrl.e2e.ts
@@ -10,6 +10,5 @@ test("should update counter without uncaught promises", async ({ page }) => {
   const button = page.locator("#inner-computed-button");
   await expect(button).toContainText("Click Me 0");
 
-  // 先执行点击操作
   await button.click();
 });

--- a/starters/e2e/e2e.qrl.e2e.ts
+++ b/starters/e2e/e2e.qrl.e2e.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("qrl", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/e2e/qrl");
+    page.on("pageerror", (err) => expect(err).toEqual(undefined));
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        expect(msg.text()).toEqual(undefined);
+      }
+    });
+  });
+
+  test.only("should update counter without uncaught promises", async ({
+    page,
+  }) => {
+    await page.goto("/e2e/qrl");
+
+    const button = page.locator("#inner-computed-button");
+    await expect(button).toContainText("Click Me 0");
+
+    // 先执行点击操作
+    await button.click();
+  });
+});


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

fixes #7442

feat(qrl): add e2e test and retry logic for QRL resolution

Add a new e2e test to verify QRL behavior without uncaught promises. Introduce retry logic for QRL resolution to handle potential promise retries, ensuring robustness in asynchronous operations.

<!-- pick one and remove the others -->

- Feature / enhancement
- Bug
- Docs / tests / types / typos
- Infra

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [x] I made corresponding changes to the Qwik docs
- [x] I added new tests to cover the fix / functionality
