### PR TITLE
docs:force remove body overflow-hidden when search closes

### DIFF
--- a/packages/docs/src/components/docsearch/doc-search-modal.tsx
+++ b/packages/docs/src/components/docsearch/doc-search-modal.tsx
@@ -118,6 +118,7 @@ export const DocSearchModal = component$(
 
         return () => {
           document.body.classList.remove('DocSearch--active');
+          document.body.style.overflow = '';
         };
       }
     });


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

-docs

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

Ciao Gio,


`Bug: when you go to qwik.dev and then CLICK search and type "usesignal" and then CLICK on the result, then scrolling doesn't work any more`

This is originating from Qwik UI Modal in Single Page Applications

Package below is adding the overflow hidden - but not removing it, after clicking the link.
`name: body-scroll-lock-upgrade`

The links in the results  are `<Link>` (from Qwik) and not `<a> `


![](https://github.com/user-attachments/assets/bbfd7959-6929-4b0f-be4c-2679763eb713)

So this will just manually remove the overflow hidden from the body for now.
I'll have a look into fixing it within Qwik UI,  but just adding this pull request so that the search works as expected for now.

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x ] I performed a self-review of my own code

