### PR TITLE
docs: fix up typo

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/guides/qwik-nutshell/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/qwik-nutshell/index.mdx
@@ -686,7 +686,7 @@ const encryptOnServer = server$(function(message: string) {
 
 export default component$(() => {
   useTask$(() => {
-    if () {
+    if (isServer) {
       // This code will only run on the server only when the component is first rendered in the server
     }
   });


### PR DESCRIPTION
# What is it?

- Docs / tests / types / typos


# Description
missing expression in an if condition

# Checklist

- [* ] I made corresponding changes to the Qwik docs

