### PR TITLE
docs: fix up typo

### DIFF
--- a/packages/docs/src/routes/docs/integrations/vitest/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/vitest/index.mdx
@@ -46,7 +46,7 @@ bun run qwik add vitest
 </span>
 </PackageManagerTabs>
 
-After running the command, vitest will be installed and a new component will be added to your project. The component will be added to the `src/components/example` directory as long as a new unit test named `example.spec.tsx`.
+After running the command, vitest will be installed and a new component will be added to your project. The component will be added to the `src/components/example` directory as well as a new unit test named `example.spec.tsx`.
 If you are looking for an example for a Component with QwikCity checkout [QwikCityMockProvider](/docs/(qwikcity)/api/index.mdx#qwikcitymockprovider).
 
 ```tsx title="example.spec.tsx"


### PR DESCRIPTION
"as long as" substituted by "as well as" for the statement to have meaning.

# What is it?
- Docs / tests / types / typos


# Description
"as long as" substituted by "as well as" for the statement to have meaning.

# Checklist

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)

- [ *] I made corresponding changes to the Qwik docs

