### PR TITLE
fix: build.full fails because of TS confusion

### DIFF
--- a/packages/docs/src/repl/repl-output-modules.tsx
+++ b/packages/docs/src/repl/repl-output-modules.tsx
@@ -55,8 +55,8 @@ export const ReplOutputModules = component$(({ outputs, headerText }: ReplOutput
                   observerRootId={FILE_MODULE_DIV_ID}
                 />
                 {o.shorten && (
-                  <button onClick$={() => (o.shorten.value = !o.shorten.value)}>
-                    {o.shorten.value ? 'Truncated - show more' : 'Show less'}
+                  <button onClick$={() => (o.shorten!.value = !o.shorten!.value)}>
+                    {o.shorten!.value ? 'Truncated - show more' : 'Show less'}
                   </button>
                 )}
               </div>


### PR DESCRIPTION
For some reason TS fails on this perfectly valid code

```
packages/docs/src/repl/repl-output-modules.tsx:58:44 - error TS18048: 'o.shorten' is possibly 'undefined'.

58                   <button onClick$={() => (o.shorten.value = !o.shorten.value)}>
                                              ~~~~~~~~~

packages/docs/src/repl/repl-output-modules.tsx:58:63 - error TS18048: 'o.shorten' is possibly 'undefined'.

58                   <button onClick$={() => (o.shorten.value = !o.shorten.value)}>
                                                                 ~~~~~~~~~


Found 2 errors in the same file, starting at: packages/docs/src/repl/repl-output-modules.tsx:58


❌  Error: Command failed with exit code 2: tsc -p packages/docs/tsconfig.json
    at makeError (file:///home/wmertens/Projects/qwik/node_modules/.pnpm/execa@8.0.1/node_modules/execa/lib/error.js:60:11)
    at handlePromise (file:///home/wmertens/Projects/qwik/node_modules/.pnpm/execa@8.0.1/node_modules/execa/index.js:124:26)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async tscDocs (/home/wmertens/Projects/qwik/scripts/tsc-docs.ts:8:18)
    at async build (/home/wmertens/Projects/qwik/scripts/build.ts:147:7) {
```