### PR TITLE
chore: some small fixes

### DIFF
--- a/packages/docs/src/entry.ssr.tsx
+++ b/packages/docs/src/entry.ssr.tsx
@@ -1,7 +1,37 @@
 import { renderToStream, type RenderToStreamOptions } from '@builder.io/qwik/server';
 import Root from './root';
 
+// You can pass these as query parameters, as well as `preloadDebug`
+const preloaderSettings = [
+  'maxPreloads',
+  'minProbability',
+  'maxSimultaneousPreloads',
+  'minPreloadProbability',
+] as const;
+
 export default function (opts: RenderToStreamOptions) {
+  const { serverData } = opts;
+  const urlStr = serverData?.url;
+  if (urlStr) {
+    const { searchParams } = new URL(urlStr);
+    if (searchParams.size) {
+      opts = {
+        ...opts,
+        prefetchStrategy: {
+          ...opts.prefetchStrategy,
+          implementation: { ...opts.prefetchStrategy?.implementation },
+        },
+      };
+      if (searchParams.has('preloadDebug')) {
+        opts.prefetchStrategy!.implementation!.debug = true;
+      }
+      for (const type of preloaderSettings) {
+        if (searchParams.has(type)) {
+          opts.prefetchStrategy!.implementation![type] = Number(searchParams.get(type));
+        }
+      }
+    }
+  }
   return renderToStream(<Root />, {
     qwikLoader: {
       // The docs can be long so make sure to intercept events before the end of the document.

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -25,7 +25,8 @@
     }
   ],
   "dependencies": {
-    "csstype": "^3.1"
+    "csstype": "^3.1",
+    "rollup": ">= 4.39.0"
   },
   "devDependencies": {
     "@builder.io/qwik": "workspace:^",

--- a/packages/qwik/src/core/preloader/bundle-graph.ts
+++ b/packages/qwik/src/core/preloader/bundle-graph.ts
@@ -7,7 +7,7 @@ import {
 } from './constants';
 import { adjustProbabilities, bundles, log, trigger } from './queue';
 import type { BundleGraph, BundleImport, ImportProbability } from './types';
-import { BundleImportState } from './types';
+import { BundleImportState_None, BundleImportState_Alias } from './types';
 
 export let base: string | undefined;
 export let graph: BundleGraph;
@@ -21,7 +21,7 @@ const makeBundle = (name: string, deps?: ImportProbability[]) => {
   return {
     $name$: name,
     $url$: url,
-    $state$: url ? BundleImportState.None : BundleImportState.Alias,
+    $state$: url ? BundleImportState_None : BundleImportState_Alias,
     $deps$: deps,
     $inverseProbability$: 1,
     $createdTs$: Date.now(),

--- a/packages/qwik/src/core/preloader/queue.ts
+++ b/packages/qwik/src/core/preloader/queue.ts
@@ -86,7 +86,8 @@ export const trigger = () => {
         Math.max(1, config[maxSimultaneousPreloadsStr] * probability)
       : // While the graph is not available, we limit to 2 preloads
         2;
-    if (preloadCount < allowedPreloads) {
+    // When we're 100% sure, everything needs to be queued
+    if (probability === 1 || preloadCount < allowedPreloads) {
       queue.shift();
       preloadOne(bundle);
     } else {

--- a/packages/qwik/src/core/preloader/types.ts
+++ b/packages/qwik/src/core/preloader/types.ts
@@ -1,10 +1,8 @@
-export const enum BundleImportState {
-  None,
-  Queued,
-  Preload,
-  Alias,
-  Loaded,
-}
+export const BundleImportState_None = 0;
+export const BundleImportState_Queued = 1;
+export const BundleImportState_Preload = 2;
+export const BundleImportState_Alias = 3;
+export const BundleImportState_Loaded = 4;
 
 export type BundleInfo = {
   $inverseProbability$: number;
@@ -15,7 +13,7 @@ export type BundleInfo = {
 export type BundleImport = BundleInfo & {
   $name$: string;
   $url$: string | null;
-  $state$: BundleImportState;
+  $state$: number;
   $createdTs$: number;
   $waitedMs$: number;
   $loadedMs$: number;

--- a/packages/qwik/src/server/prefetch-strategy.ts
+++ b/packages/qwik/src/server/prefetch-strategy.ts
@@ -48,9 +48,14 @@ export function getPreloadPaths(
   }
 
   // If we have a bundle graph, all we need is the symbols
-  return (snapshotResult?.qrls as QRLInternal[])
-    ?.map((qrl) => getSymbolHash(qrl.$refSymbol$ || qrl.$symbol$))
-    .filter(Boolean) as string[];
+  const symbols = new Set<string>();
+  for (const qrl of (snapshotResult?.qrls || []) as QRLInternal[]) {
+    const symbol = getSymbolHash(qrl.$refSymbol$ || qrl.$symbol$);
+    if (symbol && symbol.length >= 10) {
+      symbols.add(symbol);
+    }
+  }
+  return [...symbols];
 }
 
 export const expandBundles = (names: string[], resolvedManifest?: ResolvedManifest) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -566,6 +566,9 @@ importers:
       csstype:
         specifier: ^3.1
         version: 3.1.3
+      rollup:
+        specifier: '>= 4.39.0'
+        version: 4.39.0
     devDependencies:
       '@builder.io/qwik':
         specifier: workspace:^
@@ -6857,7 +6860,6 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   light-my-request@5.11.1:

--- a/scripts/submodule-preloader.ts
+++ b/scripts/submodule-preloader.ts
@@ -1,6 +1,47 @@
 import { join } from 'node:path';
 import { build } from 'vite';
 import { fileSize, type BuildConfig } from './util';
+import { minify } from 'terser';
+import type { Plugin } from 'vite';
+
+/**
+ * Custom plugin to apply terser during the bundle generation. Vite doesn't minify library ES
+ * modules.
+ */
+function customTerserPlugin(): Plugin {
+  return {
+    name: 'custom-terser',
+    async renderChunk(code, chunk) {
+      // Only process JavaScript chunks
+      if (!chunk.fileName.endsWith('.mjs') && !chunk.fileName.endsWith('.js')) {
+        return null;
+      }
+
+      // Keep the result readable for debugging
+      const result = await minify(code, {
+        compress: {
+          defaults: false,
+          module: true,
+          hoist_props: true,
+          unused: true,
+          booleans_as_integers: true,
+        },
+        mangle: {
+          toplevel: false,
+          properties: {
+            // use short attribute names for internal properties
+            regex: '^\\$.+\\$$|^[A-Z][a-zA-Z]+$',
+          },
+        },
+        format: {
+          comments: true,
+        },
+      });
+
+      return result.code || null;
+    },
+  };
+}
 
 /**
  * Builds the qwikloader javascript files using Vite. These files can be used by other tooling, and
@@ -18,24 +59,10 @@ export async function submodulePreloader(config: BuildConfig) {
       rollupOptions: {
         external: ['@builder.io/qwik/build'],
       },
-      minify: 'terser',
-      terserOptions: {
-        compress: {
-          dead_code: true,
-          unused: true,
-          conditionals: true,
-        },
-        mangle: {
-          toplevel: false,
-          module: false,
-          keep_fnames: true,
-          properties: {
-            regex: '^\\$.+\\$$',
-          },
-        },
-      },
+      minify: false, // This is the default, just to be explicit
       outDir: config.distQwikPkgDir,
     },
+    plugins: [customTerserPlugin()],
   });
 
   const preloaderSize = await fileSize(join(config.distQwikPkgDir, 'preloader.mjs'));


### PR DESCRIPTION
- require rollup with facade fix
- fix preloader minification
- when 100% sure add unlimited preload links and have the browser figure it out
- for docs, allow tweaking the preloader with query parameters. They are the same as in opts.prefetchStrategy.implementation, but `debug` is `preloadDebug`. For example, https://wmertens-fixes.qwik-8nx.pages.dev/?preloadDebug&maxPreload=0 to turn off initial preload links