### PR TITLE
chore: don't serialize wrapped signal value

### DIFF
--- a/packages/qwik/src/core/shared/shared-serialization.unit.ts
+++ b/packages/qwik/src/core/shared/shared-serialization.unit.ts
@@ -377,7 +377,6 @@ describe('shared-serialization', () => {
             Number 3
           ]
           Constant null
-          Constant NEEDS_COMPUTATION
           Number 3
           Constant null
         ]
@@ -392,11 +391,10 @@ describe('shared-serialization', () => {
           ]
           Constant null
           Number 3
-          Number 3
           Constant null
         ]
         2 String "foo"
-        (88 chars)"
+        (80 chars)"
       `);
     });
     it(title(TypeIds.ComputedSignal), async () => {


### PR DESCRIPTION
Wrapped signals are always based on other values
- if they dont change we dont need value
- if they change we recompute anyway
- if we call `.value` on it - just compute value