### PR TITLE
fix: inflating text nodes from single shared text node

### DIFF
--- a/.changeset/wet-bobcats-decide.md
+++ b/.changeset/wet-bobcats-decide.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: inflating text nodes from single shared text node

--- a/packages/qwik/src/core/client/vnode.ts
+++ b/packages/qwik/src/core/client/vnode.ts
@@ -991,7 +991,74 @@ export const vnode_insertBefore = (
     }
   }
 
-  // ensure that the previous node is unlinked.
+  /**
+   * Find the parent node and the dom children with the correct namespaces before we unlink the
+   * previous node. If we don't do this, we will end up with situations where we inflate text nodes
+   * from shared text node not correctly.
+   *
+   * Example:
+   *
+   * ```
+   * <Component>
+   *   <Projection>a</Projection>
+   *   <Projection>b</Projection>
+   * </Component>
+   * ```
+   *
+   * Projection nodes are virtual nodes, so they don't have a dom parent. They will be written to
+   * the q:template element if not visible at the start. Inside the q:template element, the
+   * projection nodes will be streamed as single text node "ab". We need to split it, but if we
+   * unlink the previous or next sibling, we don't know that after "a" node is "b". So we need to
+   * find children first (and inflate them).
+   */
+  const domParentVNode = vnode_getDomParentVNode(parent);
+  const parentNode = domParentVNode && domParentVNode[ElementVNodeProps.element];
+  let domChildren: (Element | Text)[] | null = null;
+  if (domParentVNode) {
+    domChildren = vnode_getDomChildrenWithCorrectNamespacesToInsert(
+      journal,
+      domParentVNode,
+      newChild
+    );
+  }
+
+  /**
+   * Ensure that the previous node is unlinked.
+   *
+   * We need to do it before finding the adjustedInsertBefore. The problem is when you try to render
+   * the same projection multiple times in the same node but under different conditions. We reuse
+   * projection nodes, so when this happens, we can end up with a situation where the node is
+   * inserted before node above it.
+   *
+   * Example:
+   *
+   * ```
+   * <>
+   *   {props.toggle && <Slot />}
+   *   {!props.toggle && (
+   *     <>
+   *       <Slot />
+   *     </>
+   *   )}
+   * </>
+   * ```
+   *
+   * Projected content:
+   *
+   * ```
+   * <h1>Test</h1>
+   * <p>Test content</p>
+   * ```
+   *
+   * If we don't unlink the previous node, we will end up at some point with the following:
+   *
+   * ```
+   * <h1>Test</h1>
+   * <p>Test content</p> // <-- inserted before the first h1
+   * <h1>Test</h1> // <-- to remove, but still in the tree
+   * <p>Test content</p> // <-- to remove
+   * ```
+   */
   if (
     newChildCurrentParent &&
     (newChild[VNodeProps.previousSibling] ||
@@ -1008,7 +1075,6 @@ export const vnode_insertBefore = (
       // Well, not quite. If the parent is a virtual node, our "last node" is not the same
       // as the DOM "last node". So in that case we need to look for the "next node" from
       // our parent.
-
       adjustedInsertBefore = vnode_getDomSibling(parent, true, false);
     }
   } else if (vnode_isVirtualVNode(insertBefore)) {
@@ -1018,30 +1084,15 @@ export const vnode_insertBefore = (
     adjustedInsertBefore = insertBefore;
   }
   adjustedInsertBefore && vnode_ensureInflatedIfText(journal, adjustedInsertBefore);
-  // If `insertBefore` is null, than we need to insert at the end of the list.
-  // Well, not quite. If the parent is a virtual node, our "last node" is not the same
-  // as the DOM "last node". So in that case we need to look for the "next node" from
-  // our parent.
-  // const shouldWeUseParentVirtual = insertBefore == null && vnode_isVirtualVNode(parent);
-  // const insertBeforeNode = shouldWeUseParentVirtual
-  //   ? vnode_getDomSibling(parent, true)
-  //   : insertBefore;
-  const domParentVNode = vnode_getDomParentVNode(parent);
-  const parentNode = domParentVNode && domParentVNode[ElementVNodeProps.element];
 
-  if (parentNode) {
-    const domChildren = vnode_getDomChildrenWithCorrectNamespacesToInsert(
-      journal,
-      domParentVNode,
-      newChild
+  // Here we know the insertBefore node
+  if (domChildren && domChildren.length) {
+    journal.push(
+      VNodeJournalOpCode.Insert,
+      parentNode,
+      vnode_getNode(adjustedInsertBefore),
+      ...domChildren
     );
-    domChildren.length &&
-      journal.push(
-        VNodeJournalOpCode.Insert,
-        parentNode,
-        vnode_getNode(adjustedInsertBefore),
-        ...domChildren
-      );
   }
 
   // link newChild into the previous/next list

--- a/packages/qwik/src/core/tests/projection.spec.tsx
+++ b/packages/qwik/src/core/tests/projection.spec.tsx
@@ -1808,6 +1808,86 @@ describe.each([
         </Component>
       );
     });
+
+    it('should correctly inflate text nodes from q:template', async () => {
+      const Cmp = component$((props: { show: boolean }) => {
+        return <span>{props.show && <Slot />}</span>;
+      });
+      const Parent = component$(() => {
+        const show = useSignal(false);
+        return (
+          <>
+            <button onClick$={() => (show.value = !show.value)}></button>
+            <Cmp show={show.value}>a</Cmp>
+            <Cmp show={show.value}>b</Cmp>
+          </>
+        );
+      });
+      const { vNode, document } = await render(<Parent />, { debug: DEBUG });
+      expect(vNode).toMatchVDOM(
+        <Component ssr-required>
+          <Fragment ssr-required>
+            <button></button>
+            <Component ssr-required>
+              <span></span>
+            </Component>
+            <Component ssr-required>
+              <span></span>
+            </Component>
+          </Fragment>
+        </Component>
+      );
+      await trigger(document.body, 'button', 'click');
+      expect(vNode).toMatchVDOM(
+        <Component ssr-required>
+          <Fragment ssr-required>
+            <button></button>
+            <Component ssr-required>
+              <span>
+                <Projection ssr-required>a</Projection>
+              </span>
+            </Component>
+            <Component ssr-required>
+              <span>
+                <Projection ssr-required>b</Projection>
+              </span>
+            </Component>
+          </Fragment>
+        </Component>
+      );
+      await trigger(document.body, 'button', 'click');
+      expect(vNode).toMatchVDOM(
+        <Component ssr-required>
+          <Fragment ssr-required>
+            <button></button>
+            <Component ssr-required>
+              <span></span>
+            </Component>
+            <Component ssr-required>
+              <span></span>
+            </Component>
+          </Fragment>
+        </Component>
+      );
+      await trigger(document.body, 'button', 'click');
+      expect(vNode).toMatchVDOM(
+        <Component ssr-required>
+          <Fragment ssr-required>
+            <button></button>
+            <Component ssr-required>
+              <span>
+                <Projection ssr-required>a</Projection>
+              </span>
+            </Component>
+            <Component ssr-required>
+              <span>
+                <Projection ssr-required>b</Projection>
+              </span>
+            </Component>
+          </Fragment>
+        </Component>
+      );
+    });
   });
 
   describe('svg', () => {


### PR DESCRIPTION
Fixing insertBefore function for inserting text nodes from shared text node