### PR TITLE
docs: fix typo

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/api/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/api/index.mdx
@@ -316,7 +316,7 @@ It is recommended that you use this in your test files.
 
 > `QwikCityMockProvider` does not render any DOM elements, meaning it won't be visible in snapshots
 
-If you are looking for a general example on how to integrate vitest into your Qwik look checkout the [vitest integration documentation](/docs/integrations/vitest/index.mdx)
+If you are looking for a general example on how to integrate vitest into your Qwik checkout the [vitest integration documentation](/docs/integrations/vitest/index.mdx)
 
 ```tsx title="src/components/card.spec.tsx"
 import { createDOM } from '@builder.io/qwik/testing';


### PR DESCRIPTION
omitted a meaningless word.


# What is it?

- Docs / tests / types / typos

# Description

Omitted a meaningless word.

# Checklist

- [x] I made corresponding changes to the Qwik docs

