### PR TITLE
fix: signal wrapper should not rerender

### DIFF
--- a/.changeset/unlucky-olives-knock.md
+++ b/.changeset/unlucky-olives-knock.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: signal wrapper should not rerender causing missing child error

--- a/packages/docs/src/repl/worker/repl-request-handler.ts
+++ b/packages/docs/src/repl/worker/repl-request-handler.ts
@@ -30,20 +30,6 @@ export const requestHandler = (ev: FetchEvent) => {
             return htmlRsp;
           }
 
-          // app client modules
-          // const replEvent: ReplEventMessage = {
-          //   type: 'event',
-          //   clientId,
-          //   event: {
-          //     kind: 'client-module',
-          //     scope: 'network',
-          //     message: [reqUrl.pathname + reqUrl.search],
-          //     start: performance.now(),
-          //   },
-          // };
-
-          // sendMessageToReplServer(replEvent);
-
           return rsp;
         }
 
@@ -169,5 +155,9 @@ const injectDevHtml = (clientId: string, html?: string) => {
   }, true);
 })();`;
 
-  return `<script :>${s}</script>${html || ''}`;
+  if (!html) {
+    return '';
+  }
+
+  return html.replace(/<\/body>/i, `<script>${s}</script></body>`);
 };

--- a/packages/qwik/src/core/client/types.ts
+++ b/packages/qwik/src/core/client/types.ts
@@ -96,8 +96,7 @@ export const enum VNodeFlags {
 }
 
 export const enum VNodeFlagsIndex {
-  mask /* ************* */ = ~0b11_111111,
-  negated_mask /* ****** */ = 0b11_111111,
+  mask /* ************** */ = 0b11_111111,
   shift /* ************* */ = 8,
 }
 

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -991,7 +991,13 @@ export const vnode_diff = (
   }
 
   function expectVirtual(type: VirtualType, jsxKey: string | null) {
-    if (vCurrent && vnode_isVirtualVNode(vCurrent) && getKey(vCurrent) === jsxKey && !!jsxKey) {
+    const checkKey = type === VirtualType.Fragment;
+    if (
+      vCurrent &&
+      vnode_isVirtualVNode(vCurrent) &&
+      getKey(vCurrent) === jsxKey &&
+      (checkKey ? !!jsxKey : true)
+    ) {
       // All is good.
       return;
     } else if (jsxKey !== null) {

--- a/packages/qwik/src/core/client/vnode.ts
+++ b/packages/qwik/src/core/client/vnode.ts
@@ -1810,7 +1810,7 @@ function materializeFromVNodeData(
 
   const addVNode = (node: VNode) => {
     node[VNodeProps.flags] =
-      (node[VNodeProps.flags] & VNodeFlagsIndex.negated_mask) | (idx << VNodeFlagsIndex.shift);
+      (node[VNodeProps.flags] & VNodeFlagsIndex.mask) | (idx << VNodeFlagsIndex.shift);
     idx++;
     vLast && (vLast[VNodeProps.nextSibling] = node);
     node[VNodeProps.previousSibling] = vLast;


### PR DESCRIPTION
Signal and promise virtual wrapper should not rerender, we should use the same one. Those wrappers don't have keys, so we should handle that case and check keys only for comparing actual fragments