### PR TITLE
docs: fix grammar issue in Supabase Integration page

### DIFF
--- a/packages/docs/src/routes/docs/integrations/supabase/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/supabase/index.mdx
@@ -52,7 +52,7 @@ PUBLIC_SUPABASE_URL=https://xxxxxxx.supabase.co
 PUBLIC_SUPABASE_ANON_KEY=eyJhb.......
 ```
 
-You should be able to get this values from the Supabase dashboard, create a new `.env.local` file at the root of the project and paste them there.
+You should be able to get these values from the Supabase dashboard, create a new `.env.local` file at the root of the project and paste them there.
 
 > Note: It's possible to use Supabase with Qwik completely client-side, however, you would lose some of the performance benefits that you can achieve with leveraging the server. For a working example and code head over to [this repository](https://github.com/hamatoyogi/qwik-supabase-example).
 


### PR DESCRIPTION
# What is it?

- Docs / tests / types / typos

# Description

Grammar issue in the Supabase Integration doc page. Usage of 'this' with plural subject _values_. Should be 'these' instead.

# Checklist
