### PR TITLE
Create Qwik - Next Steps Deno Corrected - Bug #7520

### DIFF
--- a/.changeset/easy-boxes-win.md
+++ b/.changeset/easy-boxes-win.md
@@ -1,0 +1,7 @@
+---
+'create-qwik': patch
+---
+
+fix: create-qwik logAppCreated.ts now displays correct next steps for deno.
+
+After using the create-qwik command, the logAppCreated.ts file was not displaying the correct next steps for deno. Prior to this fix it would display "deno start" instead of "deno task start". This would cause a failure to run, as deno requires the 'task' keyword. This fixes bug 7520

--- a/packages/create-qwik/src/helpers/logAppCreated.ts
+++ b/packages/create-qwik/src/helpers/logAppCreated.ts
@@ -40,7 +40,11 @@ export function logAppCreated(pkgManager: string, result: CreateAppResult, ranIn
   if (!ranInstall) {
     outString.push(`   ${pkgManager} install`);
   }
-  outString.push(`   ${pkgManager} start`);
+  if (pkgManager === 'deno') {
+    outString.push(`   deno task start`);
+  } else {
+    outString.push(`   ${pkgManager} start`);
+  }
   outString.push(``);
 
   note(outString.join('\n'), 'Result');


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Bug

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->
Currently, when creating a new qwik app using deno, the cli output shows 'next steps' as 'deno start'. This is incorrect, as deno needs the keyword 'task' by default. Corrected to 'deno task start'. This fixes bug #7520 

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
