### PR TITLE
Revert "perf(docs): only load sidebar paths once"

### DIFF
--- a/packages/docs/src/routes/community/layout.tsx
+++ b/packages/docs/src/routes/community/layout.tsx
@@ -6,6 +6,8 @@ import { OnThisPage } from '../../components/on-this-page/on-this-page';
 import { ContentNav } from '../../components/content-nav/content-nav';
 import styles from '../docs/docs.css?inline';
 
+export { useMarkdownItems } from '../../components/sidebar/sidebar';
+
 export default component$(() => {
   useStyles$(styles);
 

--- a/packages/docs/src/routes/docs/layout.tsx
+++ b/packages/docs/src/routes/docs/layout.tsx
@@ -9,6 +9,8 @@ import { createBreadcrumbs, SideBar } from '../../components/sidebar/sidebar';
 import { GlobalStore } from '../../context';
 import styles from './docs.css?inline';
 
+export { useMarkdownItems } from '../../components/sidebar/sidebar';
+
 export default component$(() => {
   useStyles$(styles);
   const loc = useLocation();


### PR DESCRIPTION
This reverts commit eea117b5b159f37de93034c47de931d48f79e01c.

<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Docs / tests / types / typos

# Description

Using a server$ blocks SPA Link nav and is visibly slow on 4G/3G

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
