### PR TITLE
removed build warnings due to improper order of default and min

### DIFF
--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -45,8 +45,8 @@
       "import": {
         "development": "./dist/core.mjs",
         "production": "./dist/core.prod.mjs",
-        "default": "./dist/core.prod.mjs",
-        "min": "./dist/core.min.mjs"
+        "min": "./dist/core.min.mjs",
+        "default": "./dist/core.prod.mjs"
       },
       "require": {
         "development": "./dist/core.cjs",
@@ -62,8 +62,8 @@
       "import": {
         "development": "./dist/core.mjs",
         "production": "./dist/core.prod.mjs",
-        "default": "./dist/core.prod.mjs",
-        "min": "./dist/core.min.mjs"
+        "min": "./dist/core.min.mjs",
+        "default": "./dist/core.prod.mjs"
       },
       "require": {
         "development": "./dist/core.cjs",
@@ -76,8 +76,8 @@
       "import": {
         "development": "./dist/core.mjs",
         "production": "./dist/core.prod.mjs",
-        "default": "./dist/core.mjs",
-        "min": "./dist/core.min.mjs"
+        "min": "./dist/core.min.mjs",
+        "default": "./dist/core.mjs"
       },
       "require": {
         "development": "./dist/core.cjs",


### PR DESCRIPTION
# What is it?

- Feature / enhancement

# Description

removed warnings due to improper order of default and min

# Checklist

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
