### PR TITLE
feat: implement useAsyncComputed$

### DIFF
--- a/.changeset/little-ways-deny.md
+++ b/.changeset/little-ways-deny.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': minor
+---
+
+feat: new hook - useAsyncComputed$ in replacement of useComputed$ with async operations

--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -244,7 +244,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface AsyncComputedReadonlySignal<T = unknown> extends ReadonlySignal<T> \n```\n**Extends:** [ReadonlySignal](#readonlysignal)<!-- -->&lt;T&gt;\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n[error](#)\n\n\n</td><td>\n\n\n</td><td>\n\nError \\| null\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\n[pending](#)\n\n\n</td><td>\n\n\n</td><td>\n\nboolean\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>",
+      "content": "```typescript\nexport interface AsyncComputedReadonlySignal<T = unknown> extends ReadonlySignal<T> \n```\n**Extends:** [ReadonlySignal](#readonlysignal)<!-- -->&lt;T&gt;",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/reactive-primitives/signal.public.ts",
       "mdFile": "core.asynccomputedreadonlysignal.md"
     },
@@ -365,6 +365,20 @@
       "content": "```typescript\nexport type ComputedFn<T> = () => T;\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-computed.ts",
       "mdFile": "core.computedfn.md"
+    },
+    {
+      "name": "ComputedReturnType",
+      "id": "computedreturntype",
+      "hierarchy": [
+        {
+          "name": "ComputedReturnType",
+          "id": "computedreturntype"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "```typescript\nexport type ComputedReturnType<T> = T extends Promise<any> ? never : ReadonlySignal<T>;\n```\n**References:** [ReadonlySignal](#readonlysignal)",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-computed.ts",
+      "mdFile": "core.computedreturntype.md"
     },
     {
       "name": "ComputedSignal",
@@ -2102,7 +2116,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface TaskCtx \n```\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n[track](#)\n\n\n</td><td>\n\n\n</td><td>\n\n[Tracker](#tracker)\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n\n\n<table><thead><tr><th>\n\nMethod\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n[cleanup(callback)](#)\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>",
+      "content": "```typescript\nexport interface TaskCtx \n```\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n[cleanup](#)\n\n\n</td><td>\n\n\n</td><td>\n\n(callback: () =&gt; void) =&gt; void\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\n[track](#)\n\n\n</td><td>\n\n\n</td><td>\n\n[Tracker](#tracker)\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-task.ts",
       "mdFile": "core.taskctx.md"
     },
@@ -2186,7 +2200,7 @@
         }
       ],
       "kind": "Function",
-      "content": "Creates a computed signal which is calculated from the given function. A computed signal is a signal which is calculated from other signals. When the signals change, the computed signal is recalculated, and if the result changed, all tasks which are tracking the signal will be re-run and all components that read the signal will be re-rendered.\n\nThe function must be synchronous and must not have any side effects.\n\n\n```typescript\nuseComputed$: <T>(qrl: ComputedFn<T>) => T extends Promise<any> ? never : ReadonlySignal<T>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\n[ComputedFn](#computedfn)<!-- -->&lt;T&gt;\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\nT extends Promise&lt;any&gt; ? never : [ReadonlySignal](#readonlysignal)<!-- -->&lt;T&gt;",
+      "content": "Creates a computed signal which is calculated from the given function. A computed signal is a signal which is calculated from other signals. When the signals change, the computed signal is recalculated, and if the result changed, all tasks which are tracking the signal will be re-run and all components that read the signal will be re-rendered.\n\nThe function must be synchronous and must not have any side effects.\n\n\n```typescript\nuseComputed$: <T>(qrl: ComputedFn<T>) => ComputedReturnType<T>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\n[ComputedFn](#computedfn)<!-- -->&lt;T&gt;\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\n[ComputedReturnType](#computedreturntype)<!-- -->&lt;T&gt;",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-computed.ts",
       "mdFile": "core.usecomputed_.md"
     },

--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -230,9 +230,23 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "```typescript\nexport type AsyncComputedFn<T> = (ctx: TaskCtx) => Promise<T>;\n```\n**References:** [TaskCtx](#taskctx)",
+      "content": "```typescript\nexport type AsyncComputedFn<T> = (ctx: AsyncComputedCtx) => Promise<T>;\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-async-computed.ts",
       "mdFile": "core.asynccomputedfn.md"
+    },
+    {
+      "name": "AsyncComputedReadonlySignal",
+      "id": "asynccomputedreadonlysignal",
+      "hierarchy": [
+        {
+          "name": "AsyncComputedReadonlySignal",
+          "id": "asynccomputedreadonlysignal"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface AsyncComputedReadonlySignal<T = unknown> extends ReadonlySignal<T> \n```\n**Extends:** [ReadonlySignal](#readonlysignal)<!-- -->&lt;T&gt;\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n[error](#)\n\n\n</td><td>\n\n\n</td><td>\n\nError \\| null\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\n[pending](#)\n\n\n</td><td>\n\n\n</td><td>\n\nboolean\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/reactive-primitives/signal.public.ts",
+      "mdFile": "core.asynccomputedreadonlysignal.md"
     },
     {
       "name": "AsyncComputedReturnType",
@@ -244,7 +258,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "```typescript\nexport type AsyncComputedReturnType<T> = T extends Promise<infer T> ? ReadonlySignal<T> : ReadonlySignal<T>;\n```\n**References:** [ReadonlySignal](#readonlysignal)",
+      "content": "```typescript\nexport type AsyncComputedReturnType<T> = T extends Promise<infer T> ? AsyncComputedReadonlySignal<T> : AsyncComputedReadonlySignal<T>;\n```\n**References:** [AsyncComputedReadonlySignal](#asynccomputedreadonlysignal)",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-async-computed.ts",
       "mdFile": "core.asynccomputedreturntype.md"
     },

--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -221,6 +221,34 @@
       "mdFile": "core._.md"
     },
     {
+      "name": "AsyncComputedFn",
+      "id": "asynccomputedfn",
+      "hierarchy": [
+        {
+          "name": "AsyncComputedFn",
+          "id": "asynccomputedfn"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "```typescript\nexport type AsyncComputedFn<T> = (ctx: TaskCtx) => Promise<T>;\n```\n**References:** [TaskCtx](#taskctx)",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-async-computed.ts",
+      "mdFile": "core.asynccomputedfn.md"
+    },
+    {
+      "name": "AsyncComputedReturnType",
+      "id": "asynccomputedreturntype",
+      "hierarchy": [
+        {
+          "name": "AsyncComputedReturnType",
+          "id": "asynccomputedreturntype"
+        }
+      ],
+      "kind": "TypeAlias",
+      "content": "```typescript\nexport type AsyncComputedReturnType<T> = T extends Promise<infer T> ? ReadonlySignal<T> : ReadonlySignal<T>;\n```\n**References:** [ReadonlySignal](#readonlysignal)",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-async-computed.ts",
+      "mdFile": "core.asynccomputedreturntype.md"
+    },
+    {
       "name": "cache",
       "id": "resourcectx-cache",
       "hierarchy": [
@@ -2119,6 +2147,20 @@
       "content": "Get the original object that was wrapped by the store. Useful if you want to clone a store (structuredClone, IndexedDB,...)\n\n\n```typescript\nunwrapStore: <T>(value: T) => T\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nvalue\n\n\n</td><td>\n\nT\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\nT",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/reactive-primitives/impl/store.ts",
       "mdFile": "core.unwrapstore.md"
+    },
+    {
+      "name": "useAsyncComputed$",
+      "id": "useasynccomputed_",
+      "hierarchy": [
+        {
+          "name": "useAsyncComputed$",
+          "id": "useasynccomputed_"
+        }
+      ],
+      "kind": "Function",
+      "content": "Creates a computed signal which is calculated from the given function. A computed signal is a signal which is calculated from other signals. When the signals change, the computed signal is recalculated, and if the result changed, all tasks which are tracking the signal will be re-run and all components that read the signal will be re-rendered.\n\nThe function must be synchronous and must not have any side effects.\n\n\n```typescript\nuseAsyncComputed$: <T>(qrl: AsyncComputedFn<T>) => AsyncComputedReturnType<T>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\n[AsyncComputedFn](#asynccomputedfn)<!-- -->&lt;T&gt;\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n**Returns:**\n\n[AsyncComputedReturnType](#asynccomputedreturntype)<!-- -->&lt;T&gt;",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-async-computed.ts",
+      "mdFile": "core.useasynccomputed_.md"
     },
     {
       "name": "useComputed$",

--- a/packages/docs/src/routes/api/qwik/index.mdx
+++ b/packages/docs/src/routes/api/qwik/index.mdx
@@ -135,51 +135,6 @@ export interface AsyncComputedReadonlySignal<T = unknown> extends ReadonlySignal
 
 **Extends:** [ReadonlySignal](#readonlysignal)&lt;T&gt;
 
-<table><thead><tr><th>
-
-Property
-
-</th><th>
-
-Modifiers
-
-</th><th>
-
-Type
-
-</th><th>
-
-Description
-
-</th></tr></thead>
-<tbody><tr><td>
-
-[error](#)
-
-</td><td>
-
-</td><td>
-
-Error \| null
-
-</td><td>
-
-</td></tr>
-<tr><td>
-
-[pending](#)
-
-</td><td>
-
-</td><td>
-
-boolean
-
-</td><td>
-
-</td></tr>
-</tbody></table>
-
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/reactive-primitives/signal.public.ts)
 
 ## AsyncComputedReturnType
@@ -426,6 +381,17 @@ _(Optional)_
 ```typescript
 export type ComputedFn<T> = () => T;
 ```
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-computed.ts)
+
+## ComputedReturnType
+
+```typescript
+export type ComputedReturnType<T> =
+  T extends Promise<any> ? never : ReadonlySignal<T>;
+```
+
+**References:** [ReadonlySignal](#readonlysignal)
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-computed.ts)
 
@@ -8343,6 +8309,19 @@ Description
 </th></tr></thead>
 <tbody><tr><td>
 
+[cleanup](#)
+
+</td><td>
+
+</td><td>
+
+(callback: () =&gt; void) =&gt; void
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
 [track](#)
 
 </td><td>
@@ -8350,24 +8329,6 @@ Description
 </td><td>
 
 [Tracker](#tracker)
-
-</td><td>
-
-</td></tr>
-</tbody></table>
-
-<table><thead><tr><th>
-
-Method
-
-</th><th>
-
-Description
-
-</th></tr></thead>
-<tbody><tr><td>
-
-[cleanup(callback)](#)
 
 </td><td>
 
@@ -8557,7 +8518,7 @@ Creates a computed signal which is calculated from the given function. A compute
 The function must be synchronous and must not have any side effects.
 
 ```typescript
-useComputed$: <T>(qrl: ComputedFn<T>) => T extends Promise<any> ? never : ReadonlySignal<T>
+useComputed$: <T>(qrl: ComputedFn<T>) => ComputedReturnType<T>;
 ```
 
 <table><thead><tr><th>
@@ -8587,7 +8548,7 @@ qrl
 </tbody></table>
 **Returns:**
 
-T extends Promise&lt;any&gt; ? never : [ReadonlySignal](#readonlysignal)&lt;T&gt;
+[ComputedReturnType](#computedreturntype)&lt;T&gt;
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-computed.ts)
 

--- a/packages/docs/src/routes/api/qwik/index.mdx
+++ b/packages/docs/src/routes/api/qwik/index.mdx
@@ -119,6 +119,27 @@ Expression which should be lazy loaded
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/shared/qrl/qrl.public.ts)
 
+## AsyncComputedFn
+
+```typescript
+export type AsyncComputedFn<T> = (ctx: TaskCtx) => Promise<T>;
+```
+
+**References:** [TaskCtx](#taskctx)
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-async-computed.ts)
+
+## AsyncComputedReturnType
+
+```typescript
+export type AsyncComputedReturnType<T> =
+  T extends Promise<infer T> ? ReadonlySignal<T> : ReadonlySignal<T>;
+```
+
+**References:** [ReadonlySignal](#readonlysignal)
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-async-computed.ts)
+
 ## cache
 
 ```typescript
@@ -8432,6 +8453,47 @@ T
 T
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/reactive-primitives/impl/store.ts)
+
+## useAsyncComputed$
+
+Creates a computed signal which is calculated from the given function. A computed signal is a signal which is calculated from other signals. When the signals change, the computed signal is recalculated, and if the result changed, all tasks which are tracking the signal will be re-run and all components that read the signal will be re-rendered.
+
+The function must be synchronous and must not have any side effects.
+
+```typescript
+useAsyncComputed$: <T>(qrl: AsyncComputedFn<T>) => AsyncComputedReturnType<T>;
+```
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+qrl
+
+</td><td>
+
+[AsyncComputedFn](#asynccomputedfn)&lt;T&gt;
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+**Returns:**
+
+[AsyncComputedReturnType](#asynccomputedreturntype)&lt;T&gt;
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-async-computed.ts)
 
 ## useComputed$
 

--- a/packages/docs/src/routes/api/qwik/index.mdx
+++ b/packages/docs/src/routes/api/qwik/index.mdx
@@ -122,21 +122,76 @@ Expression which should be lazy loaded
 ## AsyncComputedFn
 
 ```typescript
-export type AsyncComputedFn<T> = (ctx: TaskCtx) => Promise<T>;
+export type AsyncComputedFn<T> = (ctx: AsyncComputedCtx) => Promise<T>;
 ```
 
-**References:** [TaskCtx](#taskctx)
-
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-async-computed.ts)
+
+## AsyncComputedReadonlySignal
+
+```typescript
+export interface AsyncComputedReadonlySignal<T = unknown> extends ReadonlySignal<T>
+```
+
+**Extends:** [ReadonlySignal](#readonlysignal)&lt;T&gt;
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+[error](#)
+
+</td><td>
+
+</td><td>
+
+Error \| null
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+[pending](#)
+
+</td><td>
+
+</td><td>
+
+boolean
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/reactive-primitives/signal.public.ts)
 
 ## AsyncComputedReturnType
 
 ```typescript
 export type AsyncComputedReturnType<T> =
-  T extends Promise<infer T> ? ReadonlySignal<T> : ReadonlySignal<T>;
+  T extends Promise<infer T>
+    ? AsyncComputedReadonlySignal<T>
+    : AsyncComputedReadonlySignal<T>;
 ```
 
-**References:** [ReadonlySignal](#readonlysignal)
+**References:** [AsyncComputedReadonlySignal](#asynccomputedreadonlysignal)
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-async-computed.ts)
 

--- a/packages/qwik/public.d.ts
+++ b/packages/qwik/public.d.ts
@@ -56,6 +56,7 @@ export {
   TaskCtx,
   // TODO do we really want to export this?
   untrack,
+  useAsyncComputed$,
   useComputed$,
   useConstant,
   useContext,

--- a/packages/qwik/src/core/index.ts
+++ b/packages/qwik/src/core/index.ts
@@ -111,7 +111,7 @@ export type { UseStylesScoped } from './use/use-styles';
 export type { UseSignal } from './use/use-signal';
 export type { ContextId } from './use/use-context';
 export type { UseStoreOptions } from './use/use-store.public';
-export type { ComputedFn } from './use/use-computed';
+export type { ComputedFn, ComputedReturnType } from './use/use-computed';
 export { useComputedQrl } from './use/use-computed';
 export { useSerializerQrl, useSerializer$ } from './use/use-serializer';
 export type { OnVisibleTaskOptions, VisibleTaskStrategy } from './use/use-visible-task';

--- a/packages/qwik/src/core/index.ts
+++ b/packages/qwik/src/core/index.ts
@@ -139,6 +139,7 @@ export { useErrorBoundary } from './use/use-error-boundary';
 export type { ErrorBoundaryStore } from './shared/error/error-handling';
 export {
   type ReadonlySignal,
+  type AsyncComputedReadonlySignal,
   type Signal,
   type ComputedSignal,
 } from './reactive-primitives/signal.public';

--- a/packages/qwik/src/core/index.ts
+++ b/packages/qwik/src/core/index.ts
@@ -133,6 +133,8 @@ export { useTaskQrl } from './use/use-task';
 export { useTask$ } from './use/use-task-dollar';
 export { useVisibleTask$ } from './use/use-visible-task-dollar';
 export { useComputed$ } from './use/use-computed';
+export type { AsyncComputedFn, AsyncComputedReturnType } from './use/use-async-computed';
+export { useAsyncComputedQrl, useAsyncComputed$ } from './use/use-async-computed';
 export { useErrorBoundary } from './use/use-error-boundary';
 export type { ErrorBoundaryStore } from './shared/error/error-handling';
 export {

--- a/packages/qwik/src/core/qwik.core.api.md
+++ b/packages/qwik/src/core/qwik.core.api.md
@@ -16,6 +16,12 @@ import { ValueOrPromise as ValueOrPromise_2 } from '..';
 // @public
 export const $: <T>(expression: T) => QRL<T>;
 
+// @public (undocumented)
+export type AsyncComputedFn<T> = (ctx: TaskCtx) => Promise<T>;
+
+// @public (undocumented)
+export type AsyncComputedReturnType<T> = T extends Promise<infer T> ? ReadonlySignal<T> : ReadonlySignal<T>;
+
 // @public
 export type ClassList = string | undefined | null | false | Record<string, boolean | string | number | null | undefined> | ClassList[];
 
@@ -73,6 +79,9 @@ export const componentQrl: <PROPS extends Record<any, any>>(componentQrl: QRL<On
 
 // @public (undocumented)
 export type ComputedFn<T> = () => T;
+
+// @public (undocumented)
+export type ComputedReturnType<T> = T extends Promise<infer T> ? ReadonlySignal<T> : ReadonlySignal<T>;
 
 // @public
 export interface ComputedSignal<T> extends ReadonlySignal<T> {
@@ -242,9 +251,6 @@ class DomContainer extends _SharedContainer implements ClientContainer {
 // Warning: (ae-internal-missing-underscore) The name "DomContainer" should be prefixed with an underscore because the declaration is marked as @internal
 export { DomContainer }
 export { DomContainer as _DomContainer }
-
-// @internal (undocumented)
-export const _dumpState: (state: unknown[], color?: boolean, prefix?: string, limit?: number | null) => string;
 
 // @internal (undocumented)
 export const _EFFECT_BACK_REF: unique symbol;
@@ -550,11 +556,6 @@ export const PrefetchServiceWorker: (opts: {
     fetchBundleGraph?: boolean;
     nonce?: string;
 }) => JSXOutput;
-
-// Warning: (ae-forgotten-export) The symbol "DeserializeContainer" needs to be exported by the entry point index.d.ts
-//
-// @internal
-export function _preprocessState(data: unknown[], container: DeserializeContainer): void;
 
 // @public
 export type PropFunction<T> = QRL<T>;
@@ -1621,12 +1622,20 @@ export const untrack: <T>(fn: () => T) => T;
 export const unwrapStore: <T>(value: T) => T;
 
 // @public
-export const useComputed$: <T>(qrl: ComputedFn<T>) => T extends Promise<any> ? never : ReadonlySignal<T>;
+export const useAsyncComputed$: <T>(qrl: AsyncComputedFn<T>) => AsyncComputedReturnType<T>;
+
+// Warning: (ae-internal-missing-underscore) The name "useAsyncComputedQrl" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export const useAsyncComputedQrl: <T>(qrl: QRL<AsyncComputedFn<T>>) => AsyncComputedReturnType<T>;
+
+// @public
+export const useComputed$: <T>(qrl: ComputedFn<T>) => ComputedReturnType<T>;
 
 // Warning: (ae-internal-missing-underscore) The name "useComputedQrl" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
-export const useComputedQrl: <T>(qrl: QRL<ComputedFn<T>>) => T extends Promise<any> ? never : ReadonlySignal<T>;
+export const useComputedQrl: <T>(qrl: QRL<ComputedFn<T>>) => ComputedReturnType<T>;
 
 // @public
 export const useConstant: <T>(value: (() => T) | T) => T;
@@ -1778,9 +1787,6 @@ export type VisibleTaskStrategy = 'intersection-observer' | 'document-ready' | '
 
 // @internal (undocumented)
 export type _VNode = _ElementVNode | _TextVNode | _VirtualVNode;
-
-// @internal (undocumented)
-export function _vnode_toString(this: _VNode | null, depth?: number, offset?: string, materialize?: boolean, siblings?: boolean, colorize?: boolean): string;
 
 // @internal
 export const enum _VNodeFlags {

--- a/packages/qwik/src/core/qwik.core.api.md
+++ b/packages/qwik/src/core/qwik.core.api.md
@@ -16,11 +16,21 @@ import { ValueOrPromise as ValueOrPromise_2 } from '..';
 // @public
 export const $: <T>(expression: T) => QRL<T>;
 
+// Warning: (ae-forgotten-export) The symbol "AsyncComputedCtx" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export type AsyncComputedFn<T> = (ctx: TaskCtx) => Promise<T>;
+export type AsyncComputedFn<T> = (ctx: AsyncComputedCtx) => Promise<T>;
 
 // @public (undocumented)
-export type AsyncComputedReturnType<T> = T extends Promise<infer T> ? ReadonlySignal<T> : ReadonlySignal<T>;
+export interface AsyncComputedReadonlySignal<T = unknown> extends ReadonlySignal<T> {
+    // (undocumented)
+    error: Error | null;
+    // (undocumented)
+    pending: boolean;
+}
+
+// @public (undocumented)
+export type AsyncComputedReturnType<T> = T extends Promise<infer T> ? AsyncComputedReadonlySignal<T> : AsyncComputedReadonlySignal<T>;
 
 // @public
 export type ClassList = string | undefined | null | false | Record<string, boolean | string | number | null | undefined> | ClassList[];

--- a/packages/qwik/src/core/qwik.core.api.md
+++ b/packages/qwik/src/core/qwik.core.api.md
@@ -23,10 +23,6 @@ export type AsyncComputedFn<T> = (ctx: AsyncComputedCtx) => Promise<T>;
 
 // @public (undocumented)
 export interface AsyncComputedReadonlySignal<T = unknown> extends ReadonlySignal<T> {
-    // (undocumented)
-    error: Error | null;
-    // (undocumented)
-    pending: boolean;
 }
 
 // @public (undocumented)
@@ -91,7 +87,7 @@ export const componentQrl: <PROPS extends Record<any, any>>(componentQrl: QRL<On
 export type ComputedFn<T> = () => T;
 
 // @public (undocumented)
-export type ComputedReturnType<T> = T extends Promise<infer T> ? ReadonlySignal<T> : ReadonlySignal<T>;
+export type ComputedReturnType<T> = T extends Promise<any> ? never : ReadonlySignal<T>;
 
 // @public
 export interface ComputedSignal<T> extends ReadonlySignal<T> {
@@ -261,6 +257,9 @@ class DomContainer extends _SharedContainer implements ClientContainer {
 // Warning: (ae-internal-missing-underscore) The name "DomContainer" should be prefixed with an underscore because the declaration is marked as @internal
 export { DomContainer }
 export { DomContainer as _DomContainer }
+
+// @internal (undocumented)
+export const _dumpState: (state: unknown[], color?: boolean, prefix?: string, limit?: number | null) => string;
 
 // @internal (undocumented)
 export const _EFFECT_BACK_REF: unique symbol;
@@ -566,6 +565,11 @@ export const PrefetchServiceWorker: (opts: {
     fetchBundleGraph?: boolean;
     nonce?: string;
 }) => JSXOutput;
+
+// Warning: (ae-forgotten-export) The symbol "DeserializeContainer" needs to be exported by the entry point index.d.ts
+//
+// @internal
+export function _preprocessState(data: unknown[], container: DeserializeContainer): void;
 
 // @public
 export type PropFunction<T> = QRL<T>;
@@ -1594,7 +1598,7 @@ export const _task: (_event: Event, element: Element) => void;
 // @public (undocumented)
 export interface TaskCtx {
     // (undocumented)
-    cleanup(callback: () => void): void;
+    cleanup: (callback: () => void) => void;
     // (undocumented)
     track: Tracker;
 }
@@ -1797,6 +1801,9 @@ export type VisibleTaskStrategy = 'intersection-observer' | 'document-ready' | '
 
 // @internal (undocumented)
 export type _VNode = _ElementVNode | _TextVNode | _VirtualVNode;
+
+// @internal (undocumented)
+export function _vnode_toString(this: _VNode | null, depth?: number, offset?: string, materialize?: boolean, siblings?: boolean, colorize?: boolean): string;
 
 // @internal
 export const enum _VNodeFlags {

--- a/packages/qwik/src/core/reactive-primitives/cleanup.ts
+++ b/packages/qwik/src/core/reactive-primitives/cleanup.ts
@@ -64,7 +64,7 @@ function clearAsyncComputedSignal(
   if (effects) {
     effects.delete(effect);
   }
-  const pendingEffects = producer.$pendingEffects$;
+  const pendingEffects = producer.$loadingEffects$;
   if (pendingEffects) {
     pendingEffects.delete(effect);
   }

--- a/packages/qwik/src/core/reactive-primitives/cleanup.ts
+++ b/packages/qwik/src/core/reactive-primitives/cleanup.ts
@@ -10,6 +10,7 @@ import {
   type EffectProperty,
   type EffectSubscription,
 } from './types';
+import { AsyncComputedSignalImpl } from './impl/async-computed-signal-impl';
 
 /** Class for back reference to the EffectSubscription */
 export abstract class BackRef {
@@ -32,6 +33,8 @@ export function clearAllEffects(container: Container, consumer: Consumer): void 
     for (const producer of backRefs) {
       if (producer instanceof SignalImpl) {
         clearSignal(container, producer, effect);
+      } else if (producer instanceof AsyncComputedSignalImpl) {
+        clearAsyncComputedSignal(producer, effect);
       } else if (container.$storeProxyMap$.has(producer)) {
         const target = container.$storeProxyMap$.get(producer)!;
         const storeHandler = getStoreHandler(target)!;
@@ -50,6 +53,20 @@ function clearSignal(container: Container, producer: SignalImpl, effect: EffectS
   if (producer instanceof WrappedSignalImpl) {
     producer.$hostElement$ = null;
     clearAllEffects(container, producer);
+  }
+}
+
+function clearAsyncComputedSignal(
+  producer: AsyncComputedSignalImpl<unknown>,
+  effect: EffectSubscription
+) {
+  const effects = producer.$effects$;
+  if (effects) {
+    effects.delete(effect);
+  }
+  const pendingEffects = producer.$pendingEffects$;
+  if (pendingEffects) {
+    pendingEffects.delete(effect);
   }
 }
 

--- a/packages/qwik/src/core/reactive-primitives/impl/async-computed-signal-impl.ts
+++ b/packages/qwik/src/core/reactive-primitives/impl/async-computed-signal-impl.ts
@@ -1,0 +1,151 @@
+import { qwikDebugToString } from '../../debug';
+import { QError, qError } from '../../shared/error/error';
+import type { Container } from '../../shared/types';
+import { ChoreType } from '../../shared/util-chore-type';
+import { isPromise } from '../../shared/utils/promises';
+import { invoke, newInvokeContext } from '../../use/use-core';
+import { isSignal, throwIfQRLNotResolved } from '../utils';
+import type { BackRef } from '../cleanup';
+import { getSubscriber } from '../subscriber';
+import type { AsyncComputeQRL, EffectSubscription } from '../types';
+import { _EFFECT_BACK_REF, EffectProperty, SignalFlags, STORE_ALL_PROPS } from '../types';
+import { addStoreEffect, getStoreHandler, getStoreTarget, isStore } from './store';
+import type { Signal } from '../signal.public';
+import { isFunction } from '../../shared/utils/types';
+import { ComputedSignalImpl } from './computed-signal-impl';
+import { setupSignalValueAccess } from './signal-impl';
+import { isDev } from '@qwik.dev/core/build';
+
+const DEBUG = false;
+const log = (...args: any[]) =>
+  // eslint-disable-next-line no-console
+  console.log('ASYNC COMPUTED SIGNAL', ...args.map(qwikDebugToString));
+
+export class AsyncComputedSignalImpl<T>
+  extends ComputedSignalImpl<T, AsyncComputeQRL<T>>
+  implements BackRef
+{
+  $untrackedPending$: boolean = false;
+  $untrackedError$: Error | null = null;
+
+  $pendingEffects$: null | Set<EffectSubscription> = null;
+  $errorEffects$: null | Set<EffectSubscription> = null;
+  private $promiseValue$: T | null = null;
+
+  [_EFFECT_BACK_REF]: Map<EffectProperty | string, EffectSubscription> | null = null;
+
+  constructor(container: Container | null, fn: AsyncComputeQRL<T>, flags = SignalFlags.INVALID) {
+    super(container, fn, flags);
+  }
+
+  get pending(): boolean {
+    return setupSignalValueAccess(
+      this,
+      () => (this.$pendingEffects$ ||= new Set()),
+      () => this.untrackedPending
+    );
+  }
+
+  set untrackedPending(value: boolean) {
+    if (value !== this.$untrackedPending$) {
+      this.$untrackedPending$ = value;
+      this.$container$?.$scheduler$(
+        ChoreType.RECOMPUTE_AND_SCHEDULE_EFFECTS,
+        null,
+        this,
+        this.$pendingEffects$
+      );
+    }
+  }
+
+  get untrackedPending() {
+    return this.$untrackedPending$;
+  }
+
+  get error(): Error | null {
+    return setupSignalValueAccess(
+      this,
+      () => (this.$errorEffects$ ||= new Set()),
+      () => this.untrackedError
+    );
+  }
+
+  set untrackedError(value: Error | null) {
+    if (value !== this.$untrackedError$) {
+      this.$untrackedError$ = value;
+      this.$container$?.$scheduler$(
+        ChoreType.RECOMPUTE_AND_SCHEDULE_EFFECTS,
+        null,
+        this,
+        this.$errorEffects$
+      );
+    }
+  }
+
+  get untrackedError() {
+    return this.$untrackedError$;
+  }
+
+  $computeIfNeeded$() {
+    if (!(this.$flags$ & SignalFlags.INVALID)) {
+      return false;
+    }
+    const computeQrl = this.$computeQrl$;
+    throwIfQRLNotResolved(computeQrl);
+
+    const untrackedValue =
+      this.$promiseValue$ ?? (computeQrl.getFn()({ track: this.$trackFn$.bind(this) }) as T);
+    if (isPromise(untrackedValue)) {
+      this.untrackedPending = true;
+      this.untrackedError = null;
+      throw untrackedValue
+        .then((promiseValue) => {
+          this.$promiseValue$ = promiseValue;
+          this.untrackedPending = false;
+        })
+        .catch((err) => {
+          if (isDev) {
+            console.error(err);
+          }
+          this.untrackedError = err;
+        });
+    }
+    this.$promiseValue$ = null;
+    DEBUG && log('Signal.$asyncCompute$', untrackedValue);
+
+    this.$flags$ &= ~SignalFlags.INVALID;
+
+    const didChange = untrackedValue !== this.$untrackedValue$;
+    if (didChange) {
+      this.$untrackedValue$ = untrackedValue;
+    }
+    return didChange;
+  }
+
+  private $trackFn$(obj: (() => unknown) | object | Signal<unknown>, prop?: string) {
+    const ctx = newInvokeContext();
+    ctx.$effectSubscriber$ = getSubscriber(this, EffectProperty.VNODE);
+    ctx.$container$ = this.$container$ || undefined;
+    return invoke(ctx, () => {
+      if (isFunction(obj)) {
+        return obj();
+      }
+      if (prop) {
+        return (obj as Record<string, unknown>)[prop];
+      } else if (isSignal(obj)) {
+        return obj.value;
+      } else if (isStore(obj)) {
+        // track whole store
+        addStoreEffect(
+          getStoreTarget(obj)!,
+          STORE_ALL_PROPS,
+          getStoreHandler(obj)!,
+          ctx.$effectSubscriber$!
+        );
+        return obj;
+      } else {
+        throw qError(QError.trackObjectWithoutProp);
+      }
+    });
+  }
+}

--- a/packages/qwik/src/core/reactive-primitives/impl/computed-signal-impl.ts
+++ b/packages/qwik/src/core/reactive-primitives/impl/computed-signal-impl.ts
@@ -96,7 +96,7 @@ export class ComputedSignalImpl<T, S extends QRLInternal = ComputeQRL<T>>
     const previousEffectSubscription = ctx?.$effectSubscriber$;
     ctx && (ctx.$effectSubscriber$ = getSubscriber(this, EffectProperty.VNODE));
     try {
-      const untrackedValue = ((computeQrl.getFn(ctx) as S)() as T);
+      const untrackedValue = (computeQrl.getFn(ctx) as S)() as T;
       if (isPromise(untrackedValue)) {
         throw qError(QError.computedNotSync, [
           computeQrl.dev ? computeQrl.dev.file : '',

--- a/packages/qwik/src/core/reactive-primitives/impl/computed-signal-impl.ts
+++ b/packages/qwik/src/core/reactive-primitives/impl/computed-signal-impl.ts
@@ -11,6 +11,7 @@ import { getSubscriber } from '../subscriber';
 import type { ComputeQRL, EffectSubscription } from '../types';
 import { _EFFECT_BACK_REF, EffectProperty, NEEDS_COMPUTATION, SignalFlags } from '../types';
 import { SignalImpl } from './signal-impl';
+import type { QRLInternal } from '../../shared/qrl/qrl-class';
 
 const DEBUG = false;
 // eslint-disable-next-line no-console
@@ -21,21 +22,24 @@ const log = (...args: any[]) => console.log('COMPUTED SIGNAL', ...args.map(qwikD
  *
  * The value is available synchronously, but the computation is done lazily.
  */
-export class ComputedSignalImpl<T> extends SignalImpl<T> implements BackRef {
+export class ComputedSignalImpl<T, S extends QRLInternal = ComputeQRL<T>>
+  extends SignalImpl<T>
+  implements BackRef
+{
   /**
    * The compute function is stored here.
    *
    * The computed functions must be executed synchronously (because of this we need to eagerly
    * resolve the QRL during the mark dirty phase so that any call to it will be synchronous). )
    */
-  $computeQrl$: ComputeQRL<T>;
+  $computeQrl$: S;
   $flags$: SignalFlags;
   $forceRunEffects$: boolean = false;
   [_EFFECT_BACK_REF]: Map<EffectProperty | string, EffectSubscription> | null = null;
 
   constructor(
     container: Container | null,
-    fn: ComputeQRL<T>,
+    fn: S,
     // We need a separate flag to know when the computation needs running because
     // we need the old value to know if effects need running after computation
     flags = SignalFlags.INVALID
@@ -50,7 +54,12 @@ export class ComputedSignalImpl<T> extends SignalImpl<T> implements BackRef {
   $invalidate$() {
     this.$flags$ |= SignalFlags.INVALID;
     this.$forceRunEffects$ = false;
-    this.$container$?.$scheduler$(ChoreType.RECOMPUTE_AND_SCHEDULE_EFFECTS, null, this);
+    this.$container$?.$scheduler$(
+      ChoreType.RECOMPUTE_AND_SCHEDULE_EFFECTS,
+      null,
+      this,
+      this.$effects$
+    );
   }
 
   /**
@@ -59,7 +68,12 @@ export class ComputedSignalImpl<T> extends SignalImpl<T> implements BackRef {
    */
   force() {
     this.$forceRunEffects$ = true;
-    this.$container$?.$scheduler$(ChoreType.RECOMPUTE_AND_SCHEDULE_EFFECTS, null, this);
+    this.$container$?.$scheduler$(
+      ChoreType.RECOMPUTE_AND_SCHEDULE_EFFECTS,
+      null,
+      this,
+      this.$effects$
+    );
   }
 
   get untrackedValue() {
@@ -82,7 +96,7 @@ export class ComputedSignalImpl<T> extends SignalImpl<T> implements BackRef {
     const previousEffectSubscription = ctx?.$effectSubscriber$;
     ctx && (ctx.$effectSubscriber$ = getSubscriber(this, EffectProperty.VNODE));
     try {
-      const untrackedValue = computeQrl.getFn(ctx)() as T;
+      const untrackedValue = ((computeQrl.getFn(ctx) as S)() as T);
       if (isPromise(untrackedValue)) {
         throw qError(QError.computedNotSync, [
           computeQrl.dev ? computeQrl.dev.file : '',

--- a/packages/qwik/src/core/reactive-primitives/impl/signal-impl.ts
+++ b/packages/qwik/src/core/reactive-primitives/impl/signal-impl.ts
@@ -9,10 +9,10 @@ import {
   addQrlToSerializationCtx,
   ensureContainsBackRef,
   ensureContainsSubscription,
+  triggerEffects,
 } from '../utils';
 import type { Signal } from '../signal.public';
 import { SignalFlags, type EffectSubscription } from '../types';
-import { ChoreType } from '../../shared/util-chore-type';
 
 const DEBUG = false;
 // eslint-disable-next-line no-console
@@ -54,12 +54,14 @@ export class SignalImpl<T = any> implements Signal<T> {
       DEBUG &&
         log('Signal.set', this.$untrackedValue$, '->', value, pad('\n' + this.toString(), '  '));
       this.$untrackedValue$ = value;
-      this.$container$?.$scheduler$(
-        ChoreType.RECOMPUTE_AND_SCHEDULE_EFFECTS,
-        null,
-        this,
-        this.$effects$
-      );
+      // TODO: move this to the scheduler
+      triggerEffects(this.$container$, this, this.$effects$);
+      // this.$container$?.$scheduler$(
+      //   ChoreType.RECOMPUTE_AND_SCHEDULE_EFFECTS,
+      //   null,
+      //   this,
+      //   this.$effects$
+      // );
     }
   }
 

--- a/packages/qwik/src/core/reactive-primitives/impl/signal-impl.ts
+++ b/packages/qwik/src/core/reactive-primitives/impl/signal-impl.ts
@@ -107,14 +107,14 @@ const addEffect = (
 
 export const setupSignalValueAccess = <T, S>(
   target: SignalImpl<T>,
-  effectsGetter: () => Set<EffectSubscription>,
-  valueGetter: () => S
+  effectsFn: () => Set<EffectSubscription>,
+  returnValueFn: () => S
 ) => {
   const ctx = tryGetInvokeContext();
   if (ctx) {
     if (target.$container$ === null) {
       if (!ctx.$container$) {
-        return valueGetter();
+        return returnValueFn();
       }
       // Grab the container now we have access to it
       target.$container$ = ctx.$container$;
@@ -126,9 +126,9 @@ export const setupSignalValueAccess = <T, S>(
     }
     const effectSubscriber = ctx.$effectSubscriber$;
     if (effectSubscriber) {
-      addEffect(target, effectSubscriber, effectsGetter());
+      addEffect(target, effectSubscriber, effectsFn());
       DEBUG && log('read->sub', pad('\n' + target.toString(), '  '));
     }
   }
-  return valueGetter();
+  return returnValueFn();
 };

--- a/packages/qwik/src/core/reactive-primitives/impl/store.ts
+++ b/packages/qwik/src/core/reactive-primitives/impl/store.ts
@@ -244,6 +244,7 @@ function setNewValueAndTriggerEffects<T extends Record<string | symbol, any>>(
   currentStore: StoreHandler
 ): void {
   (target as any)[prop] = value;
+  // TODO: trigger effects through the scheduler
   triggerEffects(
     currentStore.$container$,
     currentStore,

--- a/packages/qwik/src/core/reactive-primitives/impl/wrapped-signal-impl.ts
+++ b/packages/qwik/src/core/reactive-primitives/impl/wrapped-signal-impl.ts
@@ -49,7 +49,8 @@ export class WrappedSignalImpl<T> extends SignalImpl<T> implements BackRef {
     this.$container$?.$scheduler$(
       ChoreType.RECOMPUTE_AND_SCHEDULE_EFFECTS,
       this.$hostElement$,
-      this
+      this,
+      this.$effects$
     );
   }
 

--- a/packages/qwik/src/core/reactive-primitives/internal-api.ts
+++ b/packages/qwik/src/core/reactive-primitives/internal-api.ts
@@ -6,6 +6,7 @@ import { getStoreTarget } from './impl/store';
 import { isPropsProxy } from '../shared/jsx/jsx-runtime';
 import { SignalFlags, WrappedSignalFlags } from './types';
 import { WrappedSignalImpl } from './impl/wrapped-signal-impl';
+import { AsyncComputedSignalImpl } from './impl/async-computed-signal-impl';
 
 // Keep these properties named like this so they're the same as from wrapSignal
 const getValueProp = (p0: any) => p0.value;
@@ -33,7 +34,9 @@ export const _wrapProp = <T extends Record<any, any>, P extends keyof T>(...args
     return obj[prop];
   }
   if (isSignal(obj)) {
-    assertEqual(prop, 'value', 'Left side is a signal, prop must be value');
+    if (!(obj instanceof AsyncComputedSignalImpl)) {
+      assertEqual(prop, 'value', 'Left side is a signal, prop must be value');
+    }
     if (obj instanceof WrappedSignalImpl && obj.flags & WrappedSignalFlags.UNWRAP) {
       return obj;
     }

--- a/packages/qwik/src/core/reactive-primitives/signal-api.ts
+++ b/packages/qwik/src/core/reactive-primitives/signal-api.ts
@@ -4,8 +4,9 @@ import { SignalImpl } from './impl/signal-impl';
 import { ComputedSignalImpl } from './impl/computed-signal-impl';
 import { throwIfQRLNotResolved } from './utils';
 import type { Signal } from './signal.public';
-import type { SerializerArg } from './types';
+import type { AsyncComputedCtx, AsyncComputeQRL, ComputeQRL, SerializerArg } from './types';
 import { SerializerSignalImpl } from './impl/serializer-signal-impl';
+import { AsyncComputedSignalImpl } from './impl/async-computed-signal-impl';
 
 /** @internal */
 export const createSignal = <T>(value?: T): Signal<T> => {
@@ -15,7 +16,15 @@ export const createSignal = <T>(value?: T): Signal<T> => {
 /** @internal */
 export const createComputedSignal = <T>(qrl: QRL<() => T>): ComputedSignalImpl<T> => {
   throwIfQRLNotResolved(qrl);
-  return new ComputedSignalImpl<T>(null, qrl as QRLInternal<() => T>);
+  return new ComputedSignalImpl<T>(null, qrl as ComputeQRL<T>);
+};
+
+/** @internal */
+export const createAsyncComputedSignal = <T>(
+  qrl: QRL<(ctx: AsyncComputedCtx) => Promise<T>>
+): AsyncComputedSignalImpl<T> => {
+  throwIfQRLNotResolved(qrl);
+  return new AsyncComputedSignalImpl<T>(null, qrl as AsyncComputeQRL<T>);
 };
 
 /** @internal */

--- a/packages/qwik/src/core/reactive-primitives/signal.public.ts
+++ b/packages/qwik/src/core/reactive-primitives/signal.public.ts
@@ -16,8 +16,8 @@ export interface ReadonlySignal<T = unknown> {
 /** @public */
 export interface AsyncComputedReadonlySignal<T = unknown> extends ReadonlySignal<T> {
   // TODO: enable later this, after the scheduler changes for "streaming" signals values
-  // pending: boolean;
-  // failed: boolean;
+  // loading: boolean;
+  // error: Error | null;
 }
 
 /**

--- a/packages/qwik/src/core/reactive-primitives/signal.public.ts
+++ b/packages/qwik/src/core/reactive-primitives/signal.public.ts
@@ -15,8 +15,9 @@ export interface ReadonlySignal<T = unknown> {
 
 /** @public */
 export interface AsyncComputedReadonlySignal<T = unknown> extends ReadonlySignal<T> {
-  pending: boolean;
-  error: Error | null;
+  // TODO: enable later this, after the scheduler changes for "streaming" signals values
+  // pending: boolean;
+  // failed: boolean;
 }
 
 /**

--- a/packages/qwik/src/core/reactive-primitives/signal.public.ts
+++ b/packages/qwik/src/core/reactive-primitives/signal.public.ts
@@ -13,6 +13,12 @@ export interface ReadonlySignal<T = unknown> {
   readonly value: T;
 }
 
+/** @public */
+export interface AsyncComputedReadonlySignal<T = unknown> extends ReadonlySignal<T> {
+  pending: boolean;
+  error: Error | null;
+}
+
 /**
  * A signal is a reactive value which can be read and written. When the signal is written, all tasks
  * which are tracking the signal will be re-run and all components that read the signal will be

--- a/packages/qwik/src/core/reactive-primitives/types.ts
+++ b/packages/qwik/src/core/reactive-primitives/types.ts
@@ -1,11 +1,13 @@
 import type { VNode } from '../client/types';
 import type { ISsrNode } from '../ssr/ssr-types';
-import type { Task } from '../use/use-task';
+import type { Task, Tracker } from '../use/use-task';
 import type { SubscriptionData } from './subscription-data';
 import type { ReadonlySignal } from './signal.public';
 import type { SignalImpl } from './impl/signal-impl';
 import type { QRLInternal } from '../shared/qrl/qrl-class';
 import type { SerializerSymbol } from '../shared/utils/serialize-utils';
+import type { ComputedFn } from '../use/use-computed';
+import type { AsyncComputedFn } from '../use/use-async-computed';
 
 /**
  * # ================================
@@ -33,7 +35,11 @@ export interface InternalSignal<T = any> extends InternalReadonlySignal<T> {
   untrackedValue: T;
 }
 
-export type ComputeQRL<T> = QRLInternal<() => T>;
+export type ComputeQRL<T> = QRLInternal<ComputedFn<T>>;
+export type AsyncComputedCtx = {
+  track: Tracker;
+};
+export type AsyncComputeQRL<T> = QRLInternal<AsyncComputedFn<T>>;
 
 export const enum SignalFlags {
   INVALID = 1,

--- a/packages/qwik/src/core/reactive-primitives/types.ts
+++ b/packages/qwik/src/core/reactive-primitives/types.ts
@@ -38,6 +38,7 @@ export interface InternalSignal<T = any> extends InternalReadonlySignal<T> {
 export type ComputeQRL<T> = QRLInternal<ComputedFn<T>>;
 export type AsyncComputedCtx = {
   track: Tracker;
+  cleanup: (callback: () => void) => void;
 };
 export type AsyncComputeQRL<T> = QRLInternal<AsyncComputedFn<T>>;
 

--- a/packages/qwik/src/core/reactive-primitives/utils.ts
+++ b/packages/qwik/src/core/reactive-primitives/utils.ts
@@ -97,6 +97,8 @@ export const triggerEffects = (
         let choreType = ChoreType.TASK;
         if (consumer.$flags$ & TaskFlags.VISIBLE_TASK) {
           choreType = ChoreType.VISIBLE;
+        } else if (consumer.$flags$ & TaskFlags.ASYNC_COMPUTED) {
+          choreType = ChoreType.ASYNC_COMPUTED;
         }
         container.$scheduler$(choreType, consumer);
       } else if (consumer instanceof SignalImpl) {

--- a/packages/qwik/src/core/reactive-primitives/utils.ts
+++ b/packages/qwik/src/core/reactive-primitives/utils.ts
@@ -97,8 +97,6 @@ export const triggerEffects = (
         let choreType = ChoreType.TASK;
         if (consumer.$flags$ & TaskFlags.VISIBLE_TASK) {
           choreType = ChoreType.VISIBLE;
-        } else if (consumer.$flags$ & TaskFlags.ASYNC_COMPUTED) {
-          choreType = ChoreType.ASYNC_COMPUTED;
         }
         container.$scheduler$(choreType, consumer);
       } else if (consumer instanceof SignalImpl) {

--- a/packages/qwik/src/core/shared/scheduler.ts
+++ b/packages/qwik/src/core/shared/scheduler.ts
@@ -237,7 +237,9 @@ export const createScheduler = (
     const isClientOnly =
       type === ChoreType.JOURNAL_FLUSH ||
       type === ChoreType.NODE_DIFF ||
-      type === ChoreType.NODE_PROP;
+      type === ChoreType.NODE_PROP ||
+      type === ChoreType.QRL_RESOLVE ||
+      type === ChoreType.RECOMPUTE_AND_SCHEDULE_EFFECTS;
     if (isServer && isClientOnly) {
       DEBUG &&
         debugTrace(

--- a/packages/qwik/src/core/shared/shared-serialization.ts
+++ b/packages/qwik/src/core/shared/shared-serialization.ts
@@ -297,15 +297,15 @@ const inflate = (
         Array<EffectSubscription> | null,
         Array<EffectSubscription> | null,
         boolean,
-        boolean,
+        Error,
         unknown?,
       ];
       asyncComputed.$computeQrl$ = d[0];
       asyncComputed.$effects$ = new Set(d[1]);
-      asyncComputed.$pendingEffects$ = new Set(d[2]);
-      asyncComputed.$failedEffects$ = new Set(d[3]);
-      asyncComputed.$untrackedPending$ = d[4];
-      asyncComputed.$untrackedFailed$ = d[5];
+      asyncComputed.$loadingEffects$ = new Set(d[2]);
+      asyncComputed.$errorEffects$ = new Set(d[3]);
+      asyncComputed.$untrackedLoading$ = d[4];
+      asyncComputed.$untrackedError$ = d[5];
       const hasValue = d.length > 6;
       if (hasValue) {
         asyncComputed.$untrackedValue$ = d[6];
@@ -1192,15 +1192,15 @@ async function serialize(serializationContext: SerializationContext): Promise<vo
           Set<EffectSubscription> | null,
           Set<EffectSubscription> | null,
           boolean,
-          boolean,
+          Error | null,
           unknown?,
         ] = [
           value.$computeQrl$,
           value.$effects$,
-          value.$pendingEffects$,
-          value.$failedEffects$,
-          value.$untrackedPending$,
-          value.$untrackedFailed$,
+          value.$loadingEffects$,
+          value.$errorEffects$,
+          value.$untrackedLoading$,
+          value.$untrackedError$,
         ];
         if (v !== NEEDS_COMPUTATION) {
           out.push(v);

--- a/packages/qwik/src/core/shared/shared-serialization.unit.ts
+++ b/packages/qwik/src/core/shared/shared-serialization.unit.ts
@@ -540,7 +540,7 @@ describe('shared-serialization', () => {
           Constant null
           Constant null
           Constant false
-          Constant false
+          Constant null
         ]
         1 AsyncComputedSignal [
           RootRef 3
@@ -548,7 +548,7 @@ describe('shared-serialization', () => {
           Constant null
           Constant null
           Constant false
-          Constant false
+          Constant null
           Number 2
         ]
         2 PreloadQRL "mock-chunk#dirty[4]"

--- a/packages/qwik/src/core/shared/shared-serialization.unit.ts
+++ b/packages/qwik/src/core/shared/shared-serialization.unit.ts
@@ -26,6 +26,8 @@ import { isQrl } from './qrl/qrl-utils';
 import { NoSerializeSymbol, SerializerSymbol } from './utils/serialize-utils';
 import { SubscriptionData } from '../reactive-primitives/subscription-data';
 import { StoreFlags } from '../reactive-primitives/types';
+import { createAsyncComputedSignal } from '../reactive-primitives/signal-api';
+import { retryOnPromise } from './utils/promises';
 import { QError } from './error/error';
 
 const DEBUG = false;
@@ -506,6 +508,55 @@ describe('shared-serialization', () => {
         2
       ]
       (72 chars)"
+      `);
+    });
+    it(title(TypeIds.AsyncComputedSignal), async () => {
+      const foo = createSignal(1);
+      const dirty = createAsyncComputedSignal(
+        inlinedQrl(
+          ({ track }) => Promise.resolve(track(() => (foo as SignalImpl).value) + 1),
+          'dirty',
+          [foo]
+        )
+      );
+      const clean = createAsyncComputedSignal(
+        inlinedQrl(
+          ({ track }) => Promise.resolve(track(() => (foo as SignalImpl).value) + 1),
+          'clean',
+          [foo]
+        )
+      );
+      await retryOnPromise(() => {
+        // note that this won't subscribe because we're not setting up the context
+        expect(clean.value).toBe(2);
+      });
+
+      const objs = await serialize(dirty, clean);
+      expect(dumpState(objs)).toMatchInlineSnapshot(`
+        "
+        0 AsyncComputedSignal [
+          RootRef 2
+          Constant null
+          Constant null
+          Constant null
+          Constant false
+          Constant false
+        ]
+        1 AsyncComputedSignal [
+          RootRef 3
+          Constant null
+          Constant null
+          Constant null
+          Constant false
+          Constant false
+          Number 2
+        ]
+        2 PreloadQRL "mock-chunk#dirty[4]"
+        3 PreloadQRL "mock-chunk#clean[4]"
+        4 Signal [
+          Number 1
+        ]
+        (122 chars)"
       `);
     });
     it(title(TypeIds.Store), async () => {

--- a/packages/qwik/src/core/shared/util-chore-type.ts
+++ b/packages/qwik/src/core/shared/util-chore-type.ts
@@ -7,6 +7,7 @@ export const enum ChoreType {
   /** Ensure that the QRL promise is resolved before processing next chores in the queue */
   QRL_RESOLVE /* ********************** */ = 1,
   RUN_QRL,
+  ASYNC_COMPUTED,
   TASK,
   NODE_DIFF,
   NODE_PROP,

--- a/packages/qwik/src/core/shared/util-chore-type.ts
+++ b/packages/qwik/src/core/shared/util-chore-type.ts
@@ -7,13 +7,11 @@ export const enum ChoreType {
   /** Ensure that the QRL promise is resolved before processing next chores in the queue */
   QRL_RESOLVE /* ********************** */ = 1,
   RUN_QRL,
-  ASYNC_COMPUTED,
   TASK,
   NODE_DIFF,
   NODE_PROP,
   COMPONENT,
   RECOMPUTE_AND_SCHEDULE_EFFECTS,
-
   // Next macro level
   JOURNAL_FLUSH /* ******************** */ = 16,
   // Next macro level

--- a/packages/qwik/src/core/shared/utils/markers.ts
+++ b/packages/qwik/src/core/shared/utils/markers.ts
@@ -56,7 +56,7 @@ export const SVG_NS = 'http://www.w3.org/2000/svg';
 export const MATH_NS = 'http://www.w3.org/1998/Math/MathML';
 
 export const ResourceEvent = 'qResource';
-export const ComputedEvent = 'qComputed';
+export const AsyncComputedEvent = 'qAsyncComputed';
 export const RenderEvent = 'qRender';
 export const TaskEvent = 'qTask';
 

--- a/packages/qwik/src/core/shared/utils/markers.ts
+++ b/packages/qwik/src/core/shared/utils/markers.ts
@@ -56,7 +56,6 @@ export const SVG_NS = 'http://www.w3.org/2000/svg';
 export const MATH_NS = 'http://www.w3.org/1998/Math/MathML';
 
 export const ResourceEvent = 'qResource';
-export const AsyncComputedEvent = 'qAsyncComputed';
 export const RenderEvent = 'qRender';
 export const TaskEvent = 'qTask';
 

--- a/packages/qwik/src/core/ssr/ssr-render-jsx.ts
+++ b/packages/qwik/src/core/ssr/ssr-render-jsx.ts
@@ -28,7 +28,7 @@ import {
   QSlotParent,
   qwikInspectorAttr,
 } from '../shared/utils/markers';
-import { isPromise } from '../shared/utils/promises';
+import { isPromise, retryOnPromise } from '../shared/utils/promises';
 import { qInspector } from '../shared/utils/qdev';
 import { addComponentStylePrefix, isClassAttr } from '../shared/utils/scoped-styles';
 import { serializeAttribute } from '../shared/utils/styles';
@@ -78,7 +78,7 @@ export async function _walkJSX(
         await (value as StackFn).apply(ssr);
         continue;
       }
-      processJSXNode(ssr, enqueue, value as JSXOutput, {
+      await processJSXNode(ssr, enqueue, value as JSXOutput, {
         styleScoped: options.currentStyleScoped,
         parentComponentFrame: options.parentComponentFrame,
       });
@@ -87,7 +87,7 @@ export async function _walkJSX(
   await drain();
 }
 
-function processJSXNode(
+async function processJSXNode(
   ssr: SSRContainer,
   enqueue: (value: StackValue) => void,
   value: JSXOutput,
@@ -114,7 +114,9 @@ function processJSXNode(
       ssr.openFragment(isDev ? [DEBUG_TYPE, VirtualType.WrappedSignal] : EMPTY_ARRAY);
       const signalNode = ssr.getLastNode();
       enqueue(ssr.closeFragment);
-      enqueue(trackSignalAndAssignHost(value, signalNode, EffectProperty.VNODE, ssr));
+      await retryOnPromise(() => {
+        enqueue(trackSignalAndAssignHost(value, signalNode, EffectProperty.VNODE, ssr));
+      });
     } else if (isPromise(value)) {
       ssr.openFragment(isDev ? [DEBUG_TYPE, VirtualType.Awaited] : EMPTY_ARRAY);
       enqueue(ssr.closeFragment);

--- a/packages/qwik/src/core/tests/use-async-computed.spec.tsx
+++ b/packages/qwik/src/core/tests/use-async-computed.spec.tsx
@@ -3,7 +3,7 @@ import { domRender, ssrRenderToDom, trigger } from '@qwik.dev/core/testing';
 import { describe, expect, it } from 'vitest';
 import { useAsyncComputed$ } from '../use/use-async-computed';
 
-const debug = true; //true;
+const debug = false; //true;
 Error.stackTraceLimit = 100;
 
 describe.each([

--- a/packages/qwik/src/core/tests/use-async-computed.spec.tsx
+++ b/packages/qwik/src/core/tests/use-async-computed.spec.tsx
@@ -3,19 +3,17 @@ import { domRender, ssrRenderToDom, trigger } from '@qwik.dev/core/testing';
 import { describe, expect, it } from 'vitest';
 import { useAsyncComputed$ } from '../use/use-async-computed';
 
-const debug = false; //true;
+const debug = true; //true;
 Error.stackTraceLimit = 100;
 
 describe.each([
   { render: ssrRenderToDom }, //
   { render: domRender }, //
-])('$render.name: useComputed', ({ render }) => {
+])('$render.name: useAsyncComputed', ({ render }) => {
   it('should resolve promise in computed result', async () => {
     const Counter = component$(() => {
       const count = useSignal(1);
-      const doubleCount = useAsyncComputed$(({ track }) =>
-        Promise.resolve(track(() => count.value * 2))
-      );
+      const doubleCount = useAsyncComputed$(({ track }) => Promise.resolve(track(count) * 2));
       return <button onClick$={() => count.value++}>{doubleCount.value}</button>;
     });
     const { vNode, container } = await render(<Counter />, { debug });
@@ -31,6 +29,33 @@ describe.each([
       <>
         <button>
           <Signal ssr-required>{'4'}</Signal>
+        </button>
+      </>
+    );
+  });
+
+  it('should compute async computed result from async computed result', async () => {
+    const Counter = component$(() => {
+      const count = useSignal(1);
+      const doubleCount = useAsyncComputed$(({ track }) => Promise.resolve(track(count) * 2));
+      const quadrupleCount = useAsyncComputed$(({ track }) =>
+        Promise.resolve(track(doubleCount) * 2)
+      );
+      return <button onClick$={() => count.value++}>{quadrupleCount.value}</button>;
+    });
+    const { vNode, container } = await render(<Counter />, { debug });
+    expect(vNode).toMatchVDOM(
+      <>
+        <button>
+          <Signal ssr-required>{'4'}</Signal>
+        </button>
+      </>
+    );
+    await trigger(container.element, 'button', 'click');
+    expect(vNode).toMatchVDOM(
+      <>
+        <button>
+          <Signal ssr-required>{'8'}</Signal>
         </button>
       </>
     );

--- a/packages/qwik/src/core/tests/use-async-computed.spec.tsx
+++ b/packages/qwik/src/core/tests/use-async-computed.spec.tsx
@@ -1,0 +1,70 @@
+import { Fragment as Signal, component$, useSignal } from '@qwik.dev/core';
+import { domRender, ssrRenderToDom, trigger } from '@qwik.dev/core/testing';
+import { describe, expect, it } from 'vitest';
+import { useAsyncComputed$ } from '../use/use-async-computed';
+
+const debug = false; //true;
+Error.stackTraceLimit = 100;
+
+describe.each([
+  { render: ssrRenderToDom }, //
+  { render: domRender }, //
+])('$render.name: useComputed', ({ render }) => {
+  it('should resolve promise in computed result', async () => {
+    const Counter = component$(() => {
+      const count = useSignal(1);
+      const doubleCount = useAsyncComputed$(({ track }) =>
+        Promise.resolve(track(() => count.value * 2))
+      );
+      return <button onClick$={() => count.value++}>{doubleCount.value}</button>;
+    });
+    const { vNode, container } = await render(<Counter />, { debug });
+    expect(vNode).toMatchVDOM(
+      <>
+        <button>
+          <Signal ssr-required>{'2'}</Signal>
+        </button>
+      </>
+    );
+    await trigger(container.element, 'button', 'click');
+    expect(vNode).toMatchVDOM(
+      <>
+        <button>
+          <Signal ssr-required>{'4'}</Signal>
+        </button>
+      </>
+    );
+  });
+
+  it('should resolve delayed promise in computed result', async () => {
+    const Counter = component$(() => {
+      const count = useSignal(1);
+      const doubleCount = useAsyncComputed$(
+        ({ track }) =>
+          new Promise<number>((resolve) => {
+            setTimeout(() => {
+              resolve(track(() => count.value * 2));
+            });
+          })
+      );
+      return <button onClick$={() => count.value++}>{doubleCount.value}</button>;
+    });
+    const { vNode, container } = await render(<Counter />, { debug });
+
+    expect(vNode).toMatchVDOM(
+      <>
+        <button>
+          <Signal ssr-required>{'2'}</Signal>
+        </button>
+      </>
+    );
+    await trigger(container.element, 'button', 'click');
+    expect(vNode).toMatchVDOM(
+      <>
+        <button>
+          <Signal ssr-required>{'4'}</Signal>
+        </button>
+      </>
+    );
+  });
+});

--- a/packages/qwik/src/core/use/use-async-computed.ts
+++ b/packages/qwik/src/core/use/use-async-computed.ts
@@ -1,0 +1,154 @@
+import { implicit$FirstArg } from '../shared/qrl/implicit_dollar';
+import { assertQrl } from '../shared/qrl/qrl-utils';
+import type { QRL } from '../shared/qrl/qrl.public';
+import { isSignal, throwIfQRLNotResolved } from '../reactive-primitives/utils';
+import {
+  createSignal,
+  type ReadonlySignal,
+  type Signal,
+} from '../reactive-primitives/signal.public';
+import { useSequentialScope } from './use-sequential-scope';
+import { ChoreType } from '../shared/util-chore-type';
+import { Task, TaskFlags, type TaskCtx, type TaskFn, type Tracker } from './use-task';
+import type { Container, HostElement } from '../shared/types';
+import { isFunction, type ValueOrPromise } from '../shared/utils/types';
+import { invoke, newInvokeContext, untrack } from './use-core';
+import { AsyncComputedEvent } from '../shared/utils/markers';
+import { getSubscriber } from '../reactive-primitives/subscriber';
+import { EffectProperty, STORE_ALL_PROPS } from '../reactive-primitives/types';
+import { clearAllEffects } from '../reactive-primitives/cleanup';
+import { isPromise, safeCall } from '../shared/utils/promises';
+import { isStore } from '../reactive-primitives/impl/store';
+import { addStoreEffect } from '../reactive-primitives/impl/store';
+import { getStoreTarget } from '../reactive-primitives/impl/store';
+import { QError } from '../shared/error/error';
+import { qError } from '../shared/error/error';
+import { getStoreHandler } from '../reactive-primitives/impl/store';
+import { noSerialize } from '../shared/utils/serialize-utils';
+import type { SignalImpl } from '../reactive-primitives/impl/signal-impl';
+
+/** @public */
+export type AsyncComputedFn<T> = (ctx: TaskCtx) => Promise<T>;
+/** @public */
+export type AsyncComputedReturnType<T> =
+  T extends Promise<infer T> ? ReadonlySignal<T> : ReadonlySignal<T>;
+
+export const runAsyncComputed = (
+  task: Task,
+  container: Container,
+  host: HostElement
+): ValueOrPromise<void> => {
+  task.$flags$ &= ~TaskFlags.DIRTY;
+  const iCtx = newInvokeContext(container.$locale$, host, undefined, AsyncComputedEvent);
+  iCtx.$container$ = container;
+
+  const taskFn = task.$qrl$.getFn(iCtx, () => clearAllEffects(container, task)) as TaskFn;
+
+  const handleError = (reason: unknown) => container.handleError(reason, host);
+
+  const track: Tracker = (obj: (() => unknown) | object | Signal<unknown>, prop?: string) => {
+    const ctx = newInvokeContext();
+    ctx.$effectSubscriber$ = getSubscriber(task, EffectProperty.COMPONENT);
+    ctx.$container$ = container;
+    return invoke(ctx, () => {
+      if (isFunction(obj)) {
+        return obj();
+      }
+      if (prop) {
+        return (obj as Record<string, unknown>)[prop];
+      } else if (isSignal(obj)) {
+        return obj.value;
+      } else if (isStore(obj)) {
+        // track whole store
+        addStoreEffect(
+          getStoreTarget(obj)!,
+          STORE_ALL_PROPS,
+          getStoreHandler(obj)!,
+          ctx.$effectSubscriber$!
+        );
+        return obj;
+      } else {
+        throw qError(QError.trackObjectWithoutProp);
+      }
+    });
+  };
+
+  let cleanupFns: (() => void)[] | null = null;
+  const cleanup = (fn: () => void) => {
+    if (typeof fn == 'function') {
+      if (!cleanupFns) {
+        cleanupFns = [];
+        task.$destroy$ = noSerialize(() => {
+          task.$destroy$ = null;
+          cleanupFns!.forEach((fn) => {
+            try {
+              fn();
+            } catch (err) {
+              handleError(err);
+            }
+          });
+        });
+      }
+      cleanupFns.push(fn);
+    }
+  };
+
+  const taskApi: TaskCtx = { track, cleanup };
+  const result = safeCall(
+    () => taskFn(taskApi),
+    (returnValue) =>
+      untrack(() => {
+        const signal = task.$state$! as SignalImpl<unknown>;
+        signal.value = returnValue;
+      }),
+    handleError
+  );
+  return result;
+};
+
+/** @internal */
+export const useAsyncComputedQrl = <T>(
+  qrl: QRL<AsyncComputedFn<T>>
+): AsyncComputedReturnType<T> => {
+  const { val, set, iCtx, i } = useSequentialScope<Signal<Promise<T>>>();
+  if (val) {
+    return val as any;
+  }
+  assertQrl(qrl);
+  const signal = createSignal(iCtx.$container$) as any;
+  set(signal);
+
+  const task = new Task(
+    TaskFlags.DIRTY | TaskFlags.ASYNC_COMPUTED,
+    i,
+    iCtx.$hostElement$,
+    qrl,
+    signal,
+    null
+  );
+
+  // Note that we first save the signal
+  // and then we throw to load the qrl
+  // This is why we can't use useConstant, we need to keep using the same qrl object
+  throwIfQRLNotResolved(qrl);
+
+  const container = iCtx.$container$;
+  const promise = container.$scheduler$(ChoreType.ASYNC_COMPUTED, task);
+  if (isPromise(promise)) {
+    // TODO: should we handle this differently?
+    promise.catch(() => {});
+  }
+  return signal as unknown as AsyncComputedReturnType<T>;
+};
+
+/**
+ * Creates a computed signal which is calculated from the given function. A computed signal is a
+ * signal which is calculated from other signals. When the signals change, the computed signal is
+ * recalculated, and if the result changed, all tasks which are tracking the signal will be re-run
+ * and all components that read the signal will be re-rendered.
+ *
+ * The function must be synchronous and must not have any side effects.
+ *
+ * @public
+ */
+export const useAsyncComputed$ = implicit$FirstArg(useAsyncComputedQrl);

--- a/packages/qwik/src/core/use/use-async-computed.ts
+++ b/packages/qwik/src/core/use/use-async-computed.ts
@@ -1,144 +1,22 @@
+import { AsyncComputedSignalImpl } from '../reactive-primitives/impl/async-computed-signal-impl';
+import type { ComputedSignalImpl } from '../reactive-primitives/impl/computed-signal-impl';
+import { type AsyncComputedReadonlySignal } from '../reactive-primitives/signal.public';
+import type { AsyncComputedCtx } from '../reactive-primitives/types';
 import { implicit$FirstArg } from '../shared/qrl/implicit_dollar';
-import { assertQrl } from '../shared/qrl/qrl-utils';
 import type { QRL } from '../shared/qrl/qrl.public';
-import { isSignal, throwIfQRLNotResolved } from '../reactive-primitives/utils';
-import {
-  createSignal,
-  type ReadonlySignal,
-  type Signal,
-} from '../reactive-primitives/signal.public';
-import { useSequentialScope } from './use-sequential-scope';
-import { ChoreType } from '../shared/util-chore-type';
-import { Task, TaskFlags, type TaskCtx, type TaskFn, type Tracker } from './use-task';
-import type { Container, HostElement } from '../shared/types';
-import { isFunction, type ValueOrPromise } from '../shared/utils/types';
-import { invoke, newInvokeContext, untrack } from './use-core';
-import { AsyncComputedEvent } from '../shared/utils/markers';
-import { getSubscriber } from '../reactive-primitives/subscriber';
-import { EffectProperty, STORE_ALL_PROPS } from '../reactive-primitives/types';
-import { clearAllEffects } from '../reactive-primitives/cleanup';
-import { isPromise, safeCall } from '../shared/utils/promises';
-import { isStore } from '../reactive-primitives/impl/store';
-import { addStoreEffect } from '../reactive-primitives/impl/store';
-import { getStoreTarget } from '../reactive-primitives/impl/store';
-import { QError } from '../shared/error/error';
-import { qError } from '../shared/error/error';
-import { getStoreHandler } from '../reactive-primitives/impl/store';
-import { noSerialize } from '../shared/utils/serialize-utils';
-import type { SignalImpl } from '../reactive-primitives/impl/signal-impl';
+import { useComputedCommon } from './use-computed';
 
 /** @public */
-export type AsyncComputedFn<T> = (ctx: TaskCtx) => Promise<T>;
+export type AsyncComputedFn<T> = (ctx: AsyncComputedCtx) => Promise<T>;
 /** @public */
 export type AsyncComputedReturnType<T> =
-  T extends Promise<infer T> ? ReadonlySignal<T> : ReadonlySignal<T>;
-
-export const runAsyncComputed = (
-  task: Task,
-  container: Container,
-  host: HostElement
-): ValueOrPromise<void> => {
-  task.$flags$ &= ~TaskFlags.DIRTY;
-  const iCtx = newInvokeContext(container.$locale$, host, undefined, AsyncComputedEvent);
-  iCtx.$container$ = container;
-
-  const taskFn = task.$qrl$.getFn(iCtx, () => clearAllEffects(container, task)) as TaskFn;
-
-  const handleError = (reason: unknown) => container.handleError(reason, host);
-
-  const track: Tracker = (obj: (() => unknown) | object | Signal<unknown>, prop?: string) => {
-    const ctx = newInvokeContext();
-    ctx.$effectSubscriber$ = getSubscriber(task, EffectProperty.COMPONENT);
-    ctx.$container$ = container;
-    return invoke(ctx, () => {
-      if (isFunction(obj)) {
-        return obj();
-      }
-      if (prop) {
-        return (obj as Record<string, unknown>)[prop];
-      } else if (isSignal(obj)) {
-        return obj.value;
-      } else if (isStore(obj)) {
-        // track whole store
-        addStoreEffect(
-          getStoreTarget(obj)!,
-          STORE_ALL_PROPS,
-          getStoreHandler(obj)!,
-          ctx.$effectSubscriber$!
-        );
-        return obj;
-      } else {
-        throw qError(QError.trackObjectWithoutProp);
-      }
-    });
-  };
-
-  let cleanupFns: (() => void)[] | null = null;
-  const cleanup = (fn: () => void) => {
-    if (typeof fn == 'function') {
-      if (!cleanupFns) {
-        cleanupFns = [];
-        task.$destroy$ = noSerialize(() => {
-          task.$destroy$ = null;
-          cleanupFns!.forEach((fn) => {
-            try {
-              fn();
-            } catch (err) {
-              handleError(err);
-            }
-          });
-        });
-      }
-      cleanupFns.push(fn);
-    }
-  };
-
-  const taskApi: TaskCtx = { track, cleanup };
-  const result = safeCall(
-    () => taskFn(taskApi),
-    (returnValue) =>
-      untrack(() => {
-        const signal = task.$state$! as SignalImpl<unknown>;
-        signal.value = returnValue;
-      }),
-    handleError
-  );
-  return result;
-};
+  T extends Promise<infer T> ? AsyncComputedReadonlySignal<T> : AsyncComputedReadonlySignal<T>;
 
 /** @internal */
 export const useAsyncComputedQrl = <T>(
   qrl: QRL<AsyncComputedFn<T>>
 ): AsyncComputedReturnType<T> => {
-  const { val, set, iCtx, i } = useSequentialScope<Signal<Promise<T>>>();
-  if (val) {
-    return val as any;
-  }
-  assertQrl(qrl);
-  const signal = createSignal(iCtx.$container$) as any;
-  set(signal);
-
-  const task = new Task(
-    TaskFlags.DIRTY | TaskFlags.ASYNC_COMPUTED,
-    i,
-    iCtx.$hostElement$,
-    qrl,
-    signal,
-    null
-  );
-
-  // Note that we first save the signal
-  // and then we throw to load the qrl
-  // This is why we can't use useConstant, we need to keep using the same qrl object
-  throwIfQRLNotResolved(qrl);
-
-  const container = iCtx.$container$;
-  const promise = container.$scheduler$(ChoreType.ASYNC_COMPUTED, task);
-  if (isPromise(promise)) {
-    // TODO: should we handle this differently?
-    promise.catch(() => {});
-  }
-  return signal as unknown as AsyncComputedReturnType<T>;
+  return useComputedCommon(qrl, AsyncComputedSignalImpl as typeof ComputedSignalImpl);
 };
 
 /**

--- a/packages/qwik/src/core/use/use-computed.ts
+++ b/packages/qwik/src/core/use/use-computed.ts
@@ -9,8 +9,7 @@ import { useSequentialScope } from './use-sequential-scope';
 /** @public */
 export type ComputedFn<T> = () => T;
 /** @public */
-export type ComputedReturnType<T> =
-  T extends Promise<any> ? never : ReadonlySignal<T>;
+export type ComputedReturnType<T> = T extends Promise<any> ? never : ReadonlySignal<T>;
 
 export const useComputedCommon = <
   T,

--- a/packages/qwik/src/core/use/use-computed.ts
+++ b/packages/qwik/src/core/use/use-computed.ts
@@ -8,11 +8,18 @@ import { useSequentialScope } from './use-sequential-scope';
 
 /** @public */
 export type ComputedFn<T> = () => T;
+/** @public */
+export type ComputedReturnType<T> =
+  T extends Promise<any> ? never : ReadonlySignal<T>;
 
-export const useComputedCommon = <T>(
-  qrl: QRL<ComputedFn<T>>,
+export const useComputedCommon = <
+  T,
+  FUNC extends Function = ComputedFn<T>,
+  RETURN = ComputedReturnType<T>,
+>(
+  qrl: QRL<FUNC>,
   Class: typeof ComputedSignalImpl
-): T extends Promise<any> ? never : ReadonlySignal<T> => {
+): RETURN => {
   const { val, set } = useSequentialScope<Signal<T>>();
   if (val) {
     return val as any;
@@ -29,9 +36,7 @@ export const useComputedCommon = <T>(
 };
 
 /** @internal */
-export const useComputedQrl = <T>(
-  qrl: QRL<ComputedFn<T>>
-): T extends Promise<any> ? never : ReadonlySignal<T> => {
+export const useComputedQrl = <T>(qrl: QRL<ComputedFn<T>>): ComputedReturnType<T> => {
   return useComputedCommon(qrl, ComputedSignalImpl);
 };
 

--- a/packages/qwik/src/core/use/use-core.ts
+++ b/packages/qwik/src/core/use/use-core.ts
@@ -3,7 +3,7 @@ import { assertDefined } from '../shared/error/assert';
 import { QError, qError } from '../shared/error/error';
 import type { QRLInternal } from '../shared/qrl/qrl-class';
 import type { QRL } from '../shared/qrl/qrl.public';
-import { AsyncComputedEvent, RenderEvent, ResourceEvent, TaskEvent } from '../shared/utils/markers';
+import { RenderEvent, ResourceEvent, TaskEvent } from '../shared/utils/markers';
 import { seal } from '../shared/utils/qdev';
 import { isArray } from '../shared/utils/types';
 import { setLocale } from './use-locale';
@@ -32,7 +32,6 @@ export type PossibleEvents =
   | SimplifiedServerRequestEvent
   | typeof TaskEvent
   | typeof RenderEvent
-  | typeof AsyncComputedEvent
   | typeof ResourceEvent;
 
 export interface RenderInvokeContext extends InvokeContext {

--- a/packages/qwik/src/core/use/use-core.ts
+++ b/packages/qwik/src/core/use/use-core.ts
@@ -3,7 +3,7 @@ import { assertDefined } from '../shared/error/assert';
 import { QError, qError } from '../shared/error/error';
 import type { QRLInternal } from '../shared/qrl/qrl-class';
 import type { QRL } from '../shared/qrl/qrl.public';
-import { ComputedEvent, RenderEvent, ResourceEvent, TaskEvent } from '../shared/utils/markers';
+import { AsyncComputedEvent, RenderEvent, ResourceEvent, TaskEvent } from '../shared/utils/markers';
 import { seal } from '../shared/utils/qdev';
 import { isArray } from '../shared/utils/types';
 import { setLocale } from './use-locale';
@@ -32,7 +32,7 @@ export type PossibleEvents =
   | SimplifiedServerRequestEvent
   | typeof TaskEvent
   | typeof RenderEvent
-  | typeof ComputedEvent
+  | typeof AsyncComputedEvent
   | typeof ResourceEvent;
 
 export interface RenderInvokeContext extends InvokeContext {

--- a/packages/qwik/src/core/use/use-resource.ts
+++ b/packages/qwik/src/core/use/use-resource.ts
@@ -1,25 +1,24 @@
+import { Fragment, _jsxSorted } from '../shared/jsx/jsx-runtime';
 import { isServerPlatform } from '../shared/platform/platform';
 import { assertQrl } from '../shared/qrl/qrl-utils';
 import { type QRL } from '../shared/qrl/qrl.public';
-import { Fragment, _jsxSorted } from '../shared/jsx/jsx-runtime';
 import { invoke, newInvokeContext, untrack, useBindInvokeContext } from './use-core';
 import { Task, TaskFlags, cleanupTask, type DescriptorBase, type Tracker } from './use-task';
 
 import type { Container, HostElement, ValueOrPromise } from '../../server/qwik-types';
-import type { JSXOutput } from '../shared/jsx/types/jsx-node';
-import { delay, isPromise, safeCall } from '../shared/utils/promises';
-import { isFunction, isObject } from '../shared/utils/types';
-import { createStore, getStoreTarget, unwrapStore } from '../reactive-primitives/impl/store';
-import { useSequentialScope } from './use-sequential-scope';
-import { isSignal } from '../reactive-primitives/utils';
-import type { Signal } from '../reactive-primitives/signal.public';
 import { clearAllEffects } from '../reactive-primitives/cleanup';
-import { ResourceEvent } from '../shared/utils/markers';
+import { createStore, getStoreTarget, unwrapStore } from '../reactive-primitives/impl/store';
+import type { Signal } from '../reactive-primitives/signal.public';
+import { StoreFlags } from '../reactive-primitives/types';
+import { isSignal } from '../reactive-primitives/utils';
 import { assertDefined } from '../shared/error/assert';
-import { noSerialize } from '../shared/utils/serialize-utils';
+import type { JSXOutput } from '../shared/jsx/types/jsx-node';
 import { ChoreType } from '../shared/util-chore-type';
-import { getSubscriber } from '../reactive-primitives/subscriber';
-import { EffectProperty, StoreFlags } from '../reactive-primitives/types';
+import { ResourceEvent } from '../shared/utils/markers';
+import { delay, isPromise, safeCall } from '../shared/utils/promises';
+import { isObject } from '../shared/utils/types';
+import { useSequentialScope } from './use-sequential-scope';
+import { cleanupFn, trackFn } from './utils/tracker';
 
 const DEBUG: boolean = false;
 
@@ -285,46 +284,15 @@ export const runResource = <T>(
     task
   );
 
-  const track: Tracker = (obj: (() => unknown) | object | Signal<unknown>, prop?: string) => {
-    const ctx = newInvokeContext();
-    ctx.$effectSubscriber$ = getSubscriber(task, EffectProperty.COMPONENT);
-    ctx.$container$ = container;
-    return invoke(ctx, () => {
-      if (isFunction(obj)) {
-        return obj();
-      }
-      if (prop) {
-        return (obj as Record<string, unknown>)[prop];
-      } else if (isSignal(obj)) {
-        return obj.value;
-      } else {
-        return obj;
-      }
-    });
-  };
-
-  const handleError = (reason: unknown) => container.handleError(reason, host);
-
-  const cleanups: (() => void)[] = [];
-  task.$destroy$ = noSerialize(() => {
-    cleanups.forEach((fn) => {
-      try {
-        fn();
-      } catch (err) {
-        handleError(err);
-      }
-    });
-    done = true;
-  });
+  const track = trackFn(task, container);
+  const [cleanup, cleanups] = cleanupFn(task, (reason: unknown) =>
+    container.handleError(reason, host)
+  );
 
   const resourceTarget = unwrapStore(resource);
   const opts: ResourceCtx<T> = {
     track,
-    cleanup(fn) {
-      if (typeof fn === 'function') {
-        cleanups.push(fn);
-      }
-    },
+    cleanup,
     cache(policy) {
       let milliseconds = 0;
       if (policy === 'immutable') {

--- a/packages/qwik/src/core/use/use-task.ts
+++ b/packages/qwik/src/core/use/use-task.ts
@@ -30,7 +30,8 @@ export const enum TaskFlags {
   VISIBLE_TASK = 1 << 0,
   TASK = 1 << 1,
   RESOURCE = 1 << 2,
-  DIRTY = 1 << 3,
+  ASYNC_COMPUTED = 1 << 3,
+  DIRTY = 1 << 4,
 }
 
 // <docs markdown="../readme.md#Tracker">
@@ -285,7 +286,12 @@ export const isTask = (value: any): value is Task => {
  */
 export const scheduleTask = (_event: Event, element: Element) => {
   const [task] = useLexicalScope<[Task]>();
-  const type = task.$flags$ & TaskFlags.VISIBLE_TASK ? ChoreType.VISIBLE : ChoreType.TASK;
+  let type = ChoreType.TASK;
+  if (task.$flags$ & TaskFlags.VISIBLE_TASK) {
+    type = ChoreType.VISIBLE;
+  } else if (task.$flags$ & TaskFlags.ASYNC_COMPUTED) {
+    type = ChoreType.ASYNC_COMPUTED;
+  }
   const container = getDomContainer(element);
   container.$scheduler$(type, task);
 };

--- a/packages/qwik/src/core/use/use-task.ts
+++ b/packages/qwik/src/core/use/use-task.ts
@@ -1,30 +1,21 @@
 import { getDomContainer } from '../client/dom-container';
-import { QError, qError } from '../shared/error/error';
+import { BackRef, clearAllEffects } from '../reactive-primitives/cleanup';
+import { type Signal } from '../reactive-primitives/signal.public';
 import { type QRLInternal } from '../shared/qrl/qrl-class';
 import { assertQrl } from '../shared/qrl/qrl-utils';
 import type { QRL } from '../shared/qrl/qrl.public';
-import { ChoreType } from '../shared/util-chore-type';
 import { type Container, type HostElement } from '../shared/types';
+import { ChoreType } from '../shared/util-chore-type';
 import { logError } from '../shared/utils/log';
 import { TaskEvent } from '../shared/utils/markers';
 import { isPromise, safeCall } from '../shared/utils/promises';
-import { noSerialize, type NoSerialize } from '../shared/utils/serialize-utils';
-import { isFunction, type ValueOrPromise } from '../shared/utils/types';
-import { isSignal } from '../reactive-primitives/utils';
-import { BackRef, clearAllEffects } from '../reactive-primitives/cleanup';
-import { type Signal } from '../reactive-primitives/signal.public';
-import { invoke, newInvokeContext } from './use-core';
+import { type NoSerialize } from '../shared/utils/serialize-utils';
+import { type ValueOrPromise } from '../shared/utils/types';
+import { newInvokeContext } from './use-core';
 import { useLexicalScope } from './use-lexical-scope.public';
 import type { ResourceReturnInternal } from './use-resource';
 import { useSequentialScope } from './use-sequential-scope';
-import { getSubscriber } from '../reactive-primitives/subscriber';
-import {
-  addStoreEffect,
-  getStoreHandler,
-  getStoreTarget,
-  isStore,
-} from '../reactive-primitives/impl/store';
-import { EffectProperty, STORE_ALL_PROPS } from '../reactive-primitives/types';
+import { cleanupFn, trackFn } from './utils/tracker';
 
 export const enum TaskFlags {
   VISIBLE_TASK = 1 << 0,
@@ -127,7 +118,7 @@ export interface Tracker {
 /** @public */
 export interface TaskCtx {
   track: Tracker;
-  cleanup(callback: () => void): void;
+  cleanup: (callback: () => void) => void;
 }
 
 /** @public */
@@ -183,52 +174,8 @@ export const runTask = (
   iCtx.$container$ = container;
   const taskFn = task.$qrl$.getFn(iCtx, () => clearAllEffects(container, task)) as TaskFn;
 
-  const track: Tracker = (obj: (() => unknown) | object | Signal<unknown>, prop?: string) => {
-    const ctx = newInvokeContext();
-    ctx.$effectSubscriber$ = getSubscriber(task, EffectProperty.COMPONENT);
-    ctx.$container$ = container;
-    return invoke(ctx, () => {
-      if (isFunction(obj)) {
-        return obj();
-      }
-      if (prop) {
-        return (obj as Record<string, unknown>)[prop];
-      } else if (isSignal(obj)) {
-        return obj.value;
-      } else if (isStore(obj)) {
-        // track whole store
-        addStoreEffect(
-          getStoreTarget(obj)!,
-          STORE_ALL_PROPS,
-          getStoreHandler(obj)!,
-          ctx.$effectSubscriber$!
-        );
-        return obj;
-      } else {
-        throw qError(QError.trackObjectWithoutProp);
-      }
-    });
-  };
-  const handleError = (reason: unknown) => container.handleError(reason, host);
-  let cleanupFns: (() => void)[] | null = null;
-  const cleanup = (fn: () => void) => {
-    if (typeof fn == 'function') {
-      if (!cleanupFns) {
-        cleanupFns = [];
-        task.$destroy$ = noSerialize(() => {
-          task.$destroy$ = null;
-          cleanupFns!.forEach((fn) => {
-            try {
-              fn();
-            } catch (err) {
-              handleError(err);
-            }
-          });
-        });
-      }
-      cleanupFns.push(fn);
-    }
-  };
+  const track = trackFn(task, container);
+  const [cleanup] = cleanupFn(task, (reason: unknown) => container.handleError(reason, host));
 
   const taskApi: TaskCtx = { track, cleanup };
   const result: ValueOrPromise<void> = safeCall(

--- a/packages/qwik/src/core/use/use-task.ts
+++ b/packages/qwik/src/core/use/use-task.ts
@@ -30,8 +30,7 @@ export const enum TaskFlags {
   VISIBLE_TASK = 1 << 0,
   TASK = 1 << 1,
   RESOURCE = 1 << 2,
-  ASYNC_COMPUTED = 1 << 3,
-  DIRTY = 1 << 4,
+  DIRTY = 1 << 3,
 }
 
 // <docs markdown="../readme.md#Tracker">
@@ -286,12 +285,7 @@ export const isTask = (value: any): value is Task => {
  */
 export const scheduleTask = (_event: Event, element: Element) => {
   const [task] = useLexicalScope<[Task]>();
-  let type = ChoreType.TASK;
-  if (task.$flags$ & TaskFlags.VISIBLE_TASK) {
-    type = ChoreType.VISIBLE;
-  } else if (task.$flags$ & TaskFlags.ASYNC_COMPUTED) {
-    type = ChoreType.ASYNC_COMPUTED;
-  }
+  const type = task.$flags$ & TaskFlags.VISIBLE_TASK ? ChoreType.VISIBLE : ChoreType.TASK;
   const container = getDomContainer(element);
   container.$scheduler$(type, task);
 };

--- a/packages/qwik/src/core/use/use-visible-task.ts
+++ b/packages/qwik/src/core/use/use-visible-task.ts
@@ -58,6 +58,5 @@ export const useRunTask = (task: Task, eagerness: VisibleTaskStrategy | undefine
 };
 
 const getTaskHandlerQrl = (task: Task): QRL<EventHandler> => {
-  const taskHandler = createQRL<EventHandler>(null, '_task', scheduleTask, null, null, [task]);
-  return taskHandler;
+  return createQRL<EventHandler>(null, '_task', scheduleTask, null, null, [task]);
 };

--- a/packages/qwik/src/core/use/utils/tracker.ts
+++ b/packages/qwik/src/core/use/utils/tracker.ts
@@ -10,10 +10,12 @@ import { EffectProperty, STORE_ALL_PROPS, type Consumer } from '../../reactive-p
 import { isSignal } from '../../reactive-primitives/utils';
 import { qError, QError } from '../../shared/error/error';
 import type { Container } from '../../shared/types';
-import { noSerialize } from '../../shared/utils/serialize-utils';
+import { noSerialize, type NoSerialize } from '../../shared/utils/serialize-utils';
 import { isFunction, isObject } from '../../shared/utils/types';
 import { invoke, newInvokeContext } from '../use-core';
-import type { Task, Tracker } from '../use-task';
+import type { Tracker } from '../use-task';
+
+export type Destroyable = { $destroy$: NoSerialize<() => void> | null };
 
 export const trackFn =
   (target: Consumer, container: Container | null): Tracker =>
@@ -44,8 +46,8 @@ export const trackFn =
     });
   };
 
-export const cleanupFn = (
-  target: Task,
+export const cleanupFn = <T extends Destroyable>(
+  target: T,
   handleError: (err: unknown) => void
 ): [(callback: () => void) => void, (() => void)[]] => {
   let cleanupFns: (() => void)[] | null = null;

--- a/packages/qwik/src/core/use/utils/tracker.ts
+++ b/packages/qwik/src/core/use/utils/tracker.ts
@@ -11,7 +11,7 @@ import { isSignal } from '../../reactive-primitives/utils';
 import { qError, QError } from '../../shared/error/error';
 import type { Container } from '../../shared/types';
 import { noSerialize } from '../../shared/utils/serialize-utils';
-import { isFunction } from '../../shared/utils/types';
+import { isFunction, isObject } from '../../shared/utils/types';
 import { invoke, newInvokeContext } from '../use-core';
 import type { Task, Tracker } from '../use-task';
 
@@ -29,7 +29,7 @@ export const trackFn =
         return (obj as Record<string, unknown>)[prop];
       } else if (isSignal(obj)) {
         return obj.value;
-      } else if (isStore(obj)) {
+      } else if (isObject(obj) && isStore(obj)) {
         // track whole store
         addStoreEffect(
           getStoreTarget(obj)!,

--- a/packages/qwik/src/core/use/utils/tracker.ts
+++ b/packages/qwik/src/core/use/utils/tracker.ts
@@ -1,0 +1,71 @@
+import {
+  addStoreEffect,
+  getStoreHandler,
+  getStoreTarget,
+  isStore,
+} from '../../reactive-primitives/impl/store';
+import type { Signal } from '../../reactive-primitives/signal.public';
+import { getSubscriber } from '../../reactive-primitives/subscriber';
+import { EffectProperty, STORE_ALL_PROPS, type Consumer } from '../../reactive-primitives/types';
+import { isSignal } from '../../reactive-primitives/utils';
+import { qError, QError } from '../../shared/error/error';
+import type { Container } from '../../shared/types';
+import { noSerialize } from '../../shared/utils/serialize-utils';
+import { isFunction } from '../../shared/utils/types';
+import { invoke, newInvokeContext } from '../use-core';
+import type { Task, Tracker } from '../use-task';
+
+export const trackFn =
+  (target: Consumer, container: Container | null): Tracker =>
+  (obj: (() => unknown) | object | Signal<unknown>, prop?: string) => {
+    const ctx = newInvokeContext();
+    ctx.$effectSubscriber$ = getSubscriber(target, EffectProperty.COMPONENT);
+    ctx.$container$ = container || undefined;
+    return invoke(ctx, () => {
+      if (isFunction(obj)) {
+        return obj();
+      }
+      if (prop) {
+        return (obj as Record<string, unknown>)[prop];
+      } else if (isSignal(obj)) {
+        return obj.value;
+      } else if (isStore(obj)) {
+        // track whole store
+        addStoreEffect(
+          getStoreTarget(obj)!,
+          STORE_ALL_PROPS,
+          getStoreHandler(obj)!,
+          ctx.$effectSubscriber$!
+        );
+        return obj;
+      } else {
+        throw qError(QError.trackObjectWithoutProp);
+      }
+    });
+  };
+
+export const cleanupFn = (
+  target: Task,
+  handleError: (err: unknown) => void
+): [(callback: () => void) => void, (() => void)[]] => {
+  let cleanupFns: (() => void)[] | null = null;
+  const cleanup = (fn: () => void) => {
+    if (typeof fn == 'function') {
+      if (!cleanupFns) {
+        cleanupFns = [];
+        target.$destroy$ = noSerialize(() => {
+          target.$destroy$ = null;
+          cleanupFns!.forEach((fn) => {
+            try {
+              fn();
+            } catch (err) {
+              handleError(err);
+            }
+          });
+        });
+      }
+      cleanupFns.push(fn);
+    }
+  };
+  return [cleanup, cleanupFns ?? []];
+};

--- a/starters/apps/e2e/src/components/async-computed/async-computed.tsx
+++ b/starters/apps/e2e/src/components/async-computed/async-computed.tsx
@@ -1,0 +1,67 @@
+import { component$, useAsyncComputed$, useSignal } from "@qwik.dev/core";
+
+export const AsyncComputedRoot = component$(() => {
+  const rerender = useSignal(0);
+
+  return (
+    <div key={rerender.value}>
+      <button id="rerender" onClick$={() => rerender.value++}>
+        Rerender
+      </button>
+      <span id="render-count">Renders: {rerender.value}</span>
+      <AsyncComputedBasic />
+      <PendingComponent />
+    </div>
+  );
+});
+
+export const AsyncComputedBasic = component$(() => {
+  const count = useSignal(0);
+  const double = useAsyncComputed$(({ track }) =>
+    Promise.resolve(track(count) * 2),
+  );
+  const plus3 = useAsyncComputed$(({ track }) =>
+    Promise.resolve(track(double) + 3),
+  );
+  const triple = useAsyncComputed$(({ track }) =>
+    Promise.resolve(track(plus3) * 3),
+  );
+  const sum = useAsyncComputed$(({ track }) =>
+    Promise.resolve(track(double) + track(plus3) + track(triple)),
+  );
+
+  return (
+    <div>
+      <div class="result">count: {count.value}</div>
+      <div class="result">double: {double.value}</div>
+      <div class="result">plus3: {plus3.value}</div>
+      <div class="result">triple: {triple.value}</div>
+      <div class="result">sum: {sum.value + ""}</div>
+      <button id="increment" onClick$={() => count.value++}>
+        Increment
+      </button>
+    </div>
+  );
+});
+
+export const PendingComponent = component$(() => {
+  const count = useSignal(0);
+  const double = useAsyncComputed$(
+    ({ track }) =>
+      new Promise<number>((resolve) => {
+        setTimeout(() => {
+          resolve(track(count) * 2);
+        }, 5000);
+      }),
+  );
+
+  return (
+    <div>
+      {double.pending ? "pending" : "not pending"}
+      <div class="result">double: {double.value}</div>
+      <button id="increment" onClick$={() => count.value++}>
+        Increment
+      </button>
+    </div>
+  );
+});

--- a/starters/apps/e2e/src/components/async-computed/async-computed.tsx
+++ b/starters/apps/e2e/src/components/async-computed/async-computed.tsx
@@ -51,13 +51,13 @@ export const PendingComponent = component$(() => {
       new Promise<number>((resolve) => {
         setTimeout(() => {
           resolve(track(count) * 2);
-        }, 5000);
+        }, 1000);
       }),
   );
 
   return (
     <div>
-      {/* {double.pending ? "pending" : "not pending"} */}
+      {(double as any).pending ? "pending" : "not pending"}
       <div class="result">double: {double.value}</div>
       <button id="increment" onClick$={() => count.value++}>
         Increment

--- a/starters/apps/e2e/src/components/async-computed/async-computed.tsx
+++ b/starters/apps/e2e/src/components/async-computed/async-computed.tsx
@@ -57,7 +57,7 @@ export const PendingComponent = component$(() => {
 
   return (
     <div>
-      {(double as any).pending ? "pending" : "not pending"}
+      {(double as any).loading ? "loading" : "not loading"}
       <div class="result">double: {double.value}</div>
       <button id="increment" onClick$={() => count.value++}>
         Increment

--- a/starters/apps/e2e/src/components/async-computed/async-computed.tsx
+++ b/starters/apps/e2e/src/components/async-computed/async-computed.tsx
@@ -57,7 +57,7 @@ export const PendingComponent = component$(() => {
 
   return (
     <div>
-      {double.pending ? "pending" : "not pending"}
+      {/* {double.pending ? "pending" : "not pending"} */}
       <div class="result">double: {double.value}</div>
       <button id="increment" onClick$={() => count.value++}>
         Increment

--- a/starters/apps/e2e/src/root.tsx
+++ b/starters/apps/e2e/src/root.tsx
@@ -36,6 +36,7 @@ import { Watch } from "./components/watch/watch";
 
 import "./global.css";
 import { QRL } from "./components/qrl/qrl";
+import { AsyncComputedRoot } from "./components/async-computed/async-computed";
 
 const tests: Record<string, FunctionComponent> = {
   "/e2e/two-listeners": () => <TwoListeners />,
@@ -73,6 +74,7 @@ const tests: Record<string, FunctionComponent> = {
   "/e2e/exception/render": () => <RenderExceptions />,
   "/e2e/exception/use-task": () => <UseTaskExceptions />,
   "/e2e/qrl": () => <QRL />,
+  "/e2e/async-computed": () => <AsyncComputedRoot />,
 };
 
 export const Root = component$<{ pathname: string }>(({ pathname }) => {


### PR DESCRIPTION
The current implementation should be a replacement for `useComputed$` with a promise. The `loading` and `error` fields are implmented, but are hidden and probably not working yet. This should be merged for the v2 beta