### PR TITLE
fix(qwik-city): SPA link prefetching on subsequent navigations

### DIFF
--- a/.changeset/thick-trams-pay.md
+++ b/.changeset/thick-trams-pay.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik-city': patch
+---
+
+🩹 Link SPA subsequent navigation now properly prefetch the next routes.

--- a/packages/qwik-city/src/runtime/src/link-component.tsx
+++ b/packages/qwik-city/src/runtime/src/link-component.tsx
@@ -1,5 +1,15 @@
-import { component$, Slot, type QwikIntrinsicElements, untrack, $, sync$ } from '@builder.io/qwik';
-import { getClientNavPath, shouldPrefetchData, shouldPrefetchSymbols } from './utils';
+import {
+  component$,
+  Slot,
+  type QwikIntrinsicElements,
+  $,
+  sync$,
+  useSignal,
+  useVisibleTask$,
+  type QwikVisibleEvent,
+  untrack,
+} from '@builder.io/qwik';
+import { getClientNavPath, shouldPreload } from './utils';
 import { loadClientData } from './use-endpoint';
 import { useLocation, useNavigate } from './use-functions';
 import { prefetchSymbols } from './client-navigate';
@@ -10,6 +20,7 @@ export const Link = component$<LinkProps>((props) => {
   const nav = useNavigate();
   const loc = useLocation();
   const originalHref = props.href;
+  const anchorRef = useSignal<HTMLAnchorElement>();
   const {
     onClick$,
     prefetch: prefetchProp,
@@ -22,18 +33,13 @@ export const Link = component$<LinkProps>((props) => {
   linkProps.href = clientNavPath || originalHref;
 
   const prefetchData = untrack(
-    () =>
-      (!!clientNavPath &&
-        prefetchProp !== false &&
-        prefetchProp !== 'js' &&
-        shouldPrefetchData(clientNavPath, loc)) ||
-      undefined
+    () => (!!clientNavPath && prefetchProp !== false && prefetchProp !== 'js') || undefined
   );
 
   const prefetch = untrack(
     () =>
       prefetchData ||
-      (!!clientNavPath && prefetchProp !== false && shouldPrefetchSymbols(clientNavPath, loc))
+      (!!clientNavPath && prefetchProp !== false && shouldPreload(clientNavPath, loc))
   );
 
   const handlePrefetch = prefetch
@@ -77,8 +83,29 @@ export const Link = component$<LinkProps>((props) => {
         }
       })
     : undefined;
+
+  useVisibleTask$(({ track }) => {
+    track(() => loc.url.pathname);
+    if (linkProps.onQVisible$) {
+      const event = new CustomEvent('qvisible') as QwikVisibleEvent;
+
+      if (Array.isArray(linkProps.onQVisible$)) {
+        linkProps.onQVisible$
+          .flat(10)
+          .forEach((handler) => (handler as any)?.(event, anchorRef.value));
+      } else {
+        linkProps.onQVisible$?.(event, anchorRef.value!);
+      }
+    }
+    // Don't prefetch on visible in dev mode
+    if (!isDev && anchorRef.value) {
+      handlePrefetch?.(undefined, anchorRef.value!);
+    }
+  });
+
   return (
     <a
+      ref={anchorRef}
       // Attr 'q:link' is used as a selector for bootstrapping into spa after context loss
       {...{ 'q:link': !!clientNavPath }}
       {...linkProps}
@@ -86,8 +113,6 @@ export const Link = component$<LinkProps>((props) => {
       data-prefetch={prefetchData}
       onMouseOver$={[linkProps.onMouseOver$, handlePrefetch]}
       onFocus$={[linkProps.onFocus$, handlePrefetch]}
-      // Don't prefetch on visible in dev mode
-      onQVisible$={[linkProps.onQVisible$, !isDev ? handlePrefetch : undefined]}
     >
       <Slot />
     </a>

--- a/packages/qwik-city/src/runtime/src/utils.ts
+++ b/packages/qwik-city/src/runtime/src/utils.ts
@@ -58,16 +58,7 @@ export const getClientNavPath = (props: Record<string, any>, baseUrl: { url: URL
   return null;
 };
 
-export const shouldPrefetchData = (clientNavPath: string | null, currentLoc: { url: URL }) => {
-  if (clientNavPath) {
-    const prefetchUrl = toUrl(clientNavPath, currentLoc.url);
-    const currentUrl = toUrl('', currentLoc.url);
-    return !isSamePath(prefetchUrl, currentUrl);
-  }
-  return false;
-};
-
-export const shouldPrefetchSymbols = (clientNavPath: string | null, currentLoc: { url: URL }) => {
+export const shouldPreload = (clientNavPath: string | null, currentLoc: { url: URL }) => {
   if (clientNavPath) {
     const prefetchUrl = toUrl(clientNavPath, currentLoc.url);
     const currentUrl = toUrl('', currentLoc.url);

--- a/packages/qwik-city/src/runtime/src/utils.unit.ts
+++ b/packages/qwik-city/src/runtime/src/utils.unit.ts
@@ -2,8 +2,7 @@ import { assert, test } from 'vitest';
 import {
   getClientDataPath,
   getClientNavPath,
-  shouldPrefetchData,
-  shouldPrefetchSymbols,
+  shouldPreload,
   isSameOrigin,
   isSameOriginDifferentPathname,
   isSamePath,
@@ -189,94 +188,45 @@ test(`isSameOrigin`, () => {
   });
 });
 
-test('missing clientNavPath', () => {
-  const clientNavPath = null;
-  const currentLoc = new URL('https://qwik.dev/contact');
-  assert.equal(shouldPrefetchData(clientNavPath, { url: currentLoc }), false);
-});
-
-test('path and current path the same, has different querystring and hash', () => {
-  const clientNavPath = '/about?qs#hash';
-  const currentLoc = new URL('https://qwik.dev/about');
-  assert.equal(shouldPrefetchData(clientNavPath, { url: currentLoc }), true);
-});
-
-test('path and current path the same, querystring the same', () => {
-  const clientNavPath = '/about?qs';
-  const currentLoc = new URL('https://qwik.dev/about?qs');
-  assert.equal(shouldPrefetchData(clientNavPath, { url: currentLoc }), false);
-});
-
-test('path and current path the same', () => {
-  const clientNavPath = '/about';
-  const currentLoc = new URL('https://qwik.dev/about');
-  assert.equal(shouldPrefetchData(clientNavPath, { url: currentLoc }), false);
-});
-
-test('path and current path the same, different trailing slash', () => {
-  const clientNavPath = '/about/';
-  const currentLoc = new URL('https://qwik.dev/about');
-  assert.equal(shouldPrefetchData(clientNavPath, { url: currentLoc }), false);
-});
-
-test('valid prefetchUrl, has querystring and hash', () => {
-  const clientNavPath = '/about?qs#hash';
-  const currentLoc = new URL('https://qwik.dev/contact');
-  assert.equal(shouldPrefetchData(clientNavPath, { url: currentLoc }), true);
-});
-
-test('valid prefetchUrl, trailing slash', () => {
-  const clientNavPath = '/about/';
-  const currentLoc = new URL('https://qwik.dev/contact');
-  assert.equal(shouldPrefetchData(clientNavPath, { url: currentLoc }), true);
-});
-
-test('valid prefetchUrl', () => {
-  const clientNavPath = '/about';
-  const currentLoc = new URL('https://qwik.dev/contact');
-  assert.equal(shouldPrefetchData(clientNavPath, { url: currentLoc }), true);
-});
-
-// shouldPrefetchSymbols.
 // ======================
 test('missing clientNavPath', () => {
   const clientNavPath = null;
   const currentLoc = new URL('https://qwik.dev/contact');
-  assert.equal(shouldPrefetchSymbols(clientNavPath, { url: currentLoc }), false);
+  assert.equal(shouldPreload(clientNavPath, { url: currentLoc }), false);
 });
 
 test('path and current path the same, has different querystring and hash', () => {
   const clientNavPath = '/about?qs#hash';
   const currentLoc = new URL('https://qwik.dev/about');
-  assert.equal(shouldPrefetchSymbols(clientNavPath, { url: currentLoc }), false);
+  assert.equal(shouldPreload(clientNavPath, { url: currentLoc }), false);
 });
 
 test('path and current path the same, different trailing slash', () => {
   const clientNavPath = '/about/';
   const currentLoc = new URL('https://qwik.dev/about');
-  assert.equal(shouldPrefetchSymbols(clientNavPath, { url: currentLoc }), false);
+  assert.equal(shouldPreload(clientNavPath, { url: currentLoc }), false);
 });
 
 test('path and current path the same', () => {
   const clientNavPath = '/about';
   const currentLoc = new URL('https://qwik.dev/about');
-  assert.equal(shouldPrefetchSymbols(clientNavPath, { url: currentLoc }), false);
+  assert.equal(shouldPreload(clientNavPath, { url: currentLoc }), false);
 });
 
 test('valid prefetchUrl, has querystring and hash', () => {
   const clientNavPath = '/about?qs#hash';
   const currentLoc = new URL('https://qwik.dev/contact');
-  assert.equal(shouldPrefetchSymbols(clientNavPath, { url: currentLoc }), true);
+  assert.equal(shouldPreload(clientNavPath, { url: currentLoc }), true);
 });
 
 test('valid prefetchUrl, trailing slash', () => {
   const clientNavPath = '/about/';
   const currentLoc = new URL('https://qwik.dev/contact');
-  assert.equal(shouldPrefetchSymbols(clientNavPath, { url: currentLoc }), true);
+  assert.equal(shouldPreload(clientNavPath, { url: currentLoc }), true);
 });
 
 test('valid prefetchUrl', () => {
   const clientNavPath = '/about';
   const currentLoc = new URL('https://qwik.dev/contact');
-  assert.equal(shouldPrefetchSymbols(clientNavPath, { url: currentLoc }), true);
+  assert.equal(shouldPreload(clientNavPath, { url: currentLoc }), true);
 });


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?


<!-- pick one and remove the others -->

- Bug

# Description

SPA would previously only prefetch the visible Link components on first page load. Subsequent navigation wouldn't prefetch and would therefore include a delay when clicked.

Also the first route to be loaded would never be prefetched again (e.g. /home -> /about wouldn't prefetch /home anymore, even though the routeLoaders might return updated data). This PR also fixes that.
<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
