### PR TITLE
fix(server-functions): only throw SSR guard when 'window' is undefined

### DIFF
--- a/.changeset/lovely-cycles-pay.md
+++ b/.changeset/lovely-cycles-pay.md
@@ -1,0 +1,22 @@
+---
+'@builder.io/qwik-city': patch
+---
+
+FIX: Bug #5874 - SSR guard: only throw in true SSR (when window is undefined), allowing actions to run in Vitest tests
+
+How this change works:
+
+Previously the SSR‐guard in `server-functions.ts` unconditionally threw whenever `isServer` was true,  
+which blocked invocation of `routeAction$` under Vitest+JSDOM (and the QwikCityMockProvider) in user tests.  
+
+Now we narrow the guard to:
+if (isServer && typeof window === 'undefined') {
+  throw …;
+}
+
+This will ensure:
+
+- True SSR (no window) still throws as before.
+- JSDOM/Vitest tests (and browsers) have a global window, skip the throw, and return a Promise.
+
+This change unblocks testing of actions in JSDOM environments without impacting real SSR safety.

--- a/packages/qwik-city/src/runtime/src/server-functions.ts
+++ b/packages/qwik-city/src/runtime/src/server-functions.ts
@@ -88,7 +88,8 @@ export const routeActionQrl = ((
     });
 
     const submit = $((input: unknown | FormData | SubmitEvent = {}) => {
-      if (isServer) {
+      // only throw in true SSR (no mock context)
+      if (isServer && typeof window === 'undefined') {
         throw new Error(`Actions can not be invoked within the server during SSR.
 Action.run() can only be called on the browser, for example when a user clicks a button, or submits a form.`);
       }


### PR DESCRIPTION


<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

- Bug

# Description

Previously the SSR‐guard in `server-functions.ts` unconditionally threw an error whenever `isServer` was true,
which blocked invocation of `routeAction$` under Vitest+JSDOM (and the QwikCityMockProvider) in user tests.

Now we narrow the guard to:

if (isServer && typeof window === 'undefined') {
  throw …;
}

After this fix:

- True SSR(no 'window') still throws an error as before
- JSDOM/Vitest tests(and browsers) have a global 'window', do not throw the error, and returns a promise

This will unblock testing of actions in JSDOM environments without impacting real SSR safety

Closes #5874

# Checklist

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
