### PR TITLE
fix(docs): correct cloudflare _headers

### DIFF
--- a/packages/docs/public/_headers
+++ b/packages/docs/public/_headers
@@ -1,14 +1,19 @@
+/*
+  Cache-Control: public, max-age=3600, s-maxage=3600
+
 /assets/*
+  ! Cache-Control
   Cache-Control: public, max-age=31536000, s-maxage=31536000, immutable
 
 /build/*
+  ! Cache-Control
   Cache-Control: public, max-age=31536000, s-maxage=31536000, immutable
 
 /*.svg
+  ! Cache-Control
   Cache-Control: public, max-age=86400, s-maxage=86400
 
 /favicon.ico
+  ! Cache-Control
   Cache-Control: public, max-age=604800, s-maxage=604800
 
-/*
-  Cache-Control: public, max-age=3600, s-maxage=3600


### PR DESCRIPTION
order matters when matching multiple times

