### PR TITLE
perf(preloader): start preloading slightly earlier

### DIFF
--- a/packages/qwik/src/server/preload-impl.ts
+++ b/packages/qwik/src/server/preload-impl.ts
@@ -160,6 +160,11 @@ export const includePreloader = (
       jsx('script', {
         type: 'module',
         'q:type': 'preload',
+        /**
+         * This async allows the preloader to be executed before the DOM is fully parsed even though
+         * it's at the bottom of the body
+         */
+        async: true,
         dangerouslySetInnerHTML: script,
         nonce,
       })


### PR DESCRIPTION
I just learned that async scripts can be run earlier than their DOM order, so let's use that.