### PR TITLE
Fix cli test

### DIFF
--- a/.changeset/fancy-eagles-guess.md
+++ b/.changeset/fancy-eagles-guess.md
@@ -1,0 +1,5 @@
+---
+'create-qwik': patch
+---
+
+FIX: starter app missing package and added preview cli test

--- a/e2e/qwik-cli-e2e/tests/serve.spec.ts
+++ b/e2e/qwik-cli-e2e/tests/serve.spec.ts
@@ -1,66 +1,117 @@
-import { assert, test, beforeAll, expect } from 'vitest';
-import {
-  assertHostUnused,
-  getPageHtml,
-  promisifiedTreeKill,
-  killAllRegisteredProcesses,
-  runCommandUntil,
-  scaffoldQwikProject,
-  DEFAULT_TIMEOUT,
-} from '../utils';
+/* eslint-disable no-console */
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
+import { assert, beforeAll, beforeEach, describe, expect, test } from 'vitest';
+import {
+  assertHostUnused,
+  DEFAULT_TIMEOUT,
+  getPageHtml,
+  killAllRegisteredProcesses,
+  log,
+  promisifiedTreeKill,
+  runCommandUntil,
+  scaffoldQwikProject,
+  type QwikProjectType,
+} from '../utils';
 
 let SERVE_PORT = 3535;
-beforeAll(() => {
-  const config = scaffoldQwikProject();
-  global.tmpDir = config.tmpDir;
-
-  return async () => {
-    await killAllRegisteredProcesses();
-    config.cleanupFn();
-  };
-});
-
-test(
-  'Should serve the app in dev mode and update the content on hot reload',
-  { timeout: DEFAULT_TIMEOUT },
-  async () => {
-    const host = `http://localhost:${SERVE_PORT}/`;
-    await assertHostUnused(host);
-    const p = await runCommandUntil(
-      `npm run dev -- --port ${SERVE_PORT}`,
-      global.tmpDir,
-      (output) => {
-        return output.includes(host);
-      }
-    );
-    assert.equal(existsSync(global.tmpDir), true);
-
-    await expectHtmlOnARootPage(host);
-
-    await promisifiedTreeKill(p.pid!, 'SIGKILL');
-  }
-);
-
-test('Should preview the app', { timeout: DEFAULT_TIMEOUT }, async () => {
+beforeEach(() => {
   // the port doesn't clear immediately after the previous test
   SERVE_PORT++;
-  const host = `http://localhost:${SERVE_PORT}/`;
-  await assertHostUnused(host);
-  const p = await runCommandUntil(
-    `npm run preview -- --port ${SERVE_PORT}`,
-    global.tmpDir,
-    (output) => {
-      return output.includes(host);
-    }
-  );
-  assert.equal(existsSync(global.tmpDir), true);
-
-  await expectHtmlOnARootPage(host);
-
-  await promisifiedTreeKill(p.pid!, 'SIGKILL');
 });
+for (const type of ['empty', 'playground'] as QwikProjectType[]) {
+  describe(`template: ${type}`, () => {
+    beforeAll(() => {
+      console.log('================================================ scaffolding', type);
+      const config = scaffoldQwikProject(type);
+      global.tmpDir = config.tmpDir;
+
+      return async () => {
+        try {
+          await killAllRegisteredProcesses();
+        } catch (e) {
+          log(`Error during process cleanup: ${e.message}`);
+        }
+        config.cleanupFn();
+      };
+    });
+
+    if (type === 'playground') {
+      test(
+        'Should serve the app in dev mode and update the content on hot reload',
+        { timeout: DEFAULT_TIMEOUT },
+        async () => {
+          const host = `http://localhost:${SERVE_PORT}/`;
+          await assertHostUnused(host);
+          const p = await runCommandUntil(
+            `npm run dev -- --port ${SERVE_PORT}`,
+            global.tmpDir,
+            (output) => {
+              return output.includes(host);
+            }
+          );
+          assert.equal(existsSync(global.tmpDir), true);
+
+          await expectHtmlOnARootPage(host);
+
+          // Don't let process termination errors fail the test
+          try {
+            await promisifiedTreeKill(p.pid!, 'SIGKILL');
+          } catch (e) {
+            log(`Error terminating dev server: ${e.message}`);
+          }
+        }
+      );
+    }
+
+    test('Should preview the app', { timeout: DEFAULT_TIMEOUT }, async () => {
+      const host = `http://localhost:${SERVE_PORT}/`;
+      await assertHostUnused(host);
+
+      // First build the app
+      const buildProcess = await runCommandUntil(`npm run build`, global.tmpDir, (output) => {
+        return output.includes('dist/build') || output.includes('built in');
+      });
+
+      try {
+        await promisifiedTreeKill(buildProcess.pid!, 'SIGKILL');
+      } catch (e) {
+        log(`Error terminating build process: ${e.message}`);
+      }
+
+      // Now run the preview
+      const p = await runCommandUntil(
+        `npm run preview -- --no-open --port ${SERVE_PORT}`,
+        global.tmpDir,
+        (output) => {
+          return output.includes(host);
+        }
+      );
+
+      assert.equal(existsSync(global.tmpDir), true);
+
+      // Wait a bit for the server to fully start
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+
+      const res = await fetch(host, { headers: { accept: 'text/html' } }).then((r) => r.text());
+      console.log('** res', res);
+
+      // Check for the appropriate content based on template type
+      if (type === 'playground') {
+        expect(res).toContain('fantastic');
+      } else if (type === 'empty') {
+        expect(res).toContain('Hi');
+        expect(res).toContain('qwik');
+      }
+
+      try {
+        await promisifiedTreeKill(p.pid!, 'SIGKILL');
+      } catch (e) {
+        log(`Error terminating preview server: ${e.message}`);
+      }
+    });
+  });
+}
 
 async function expectHtmlOnARootPage(host: string) {
   expect((await getPageHtml(host)).querySelector('.container h1')?.textContent).toBe(

--- a/e2e/qwik-cli-e2e/utils/index.ts
+++ b/e2e/qwik-cli-e2e/utils/index.ts
@@ -1,10 +1,10 @@
 import { ChildProcess, exec, execSync } from 'child_process';
-import { dirSync } from 'tmp';
-import { existsSync, mkdirSync, readFileSync, rmSync, rmdirSync, writeFileSync } from 'fs';
-import { promisify } from 'util';
-import { resolve, join, dirname } from 'path';
-import treeKill from 'tree-kill';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { yellow } from 'kleur/colors';
+import { dirname, join, resolve } from 'path';
+import { dirSync } from 'tmp';
+import treeKill from 'tree-kill';
+import { promisify } from 'util';
 import { createDocument } from '../../../packages/qwik/src/testing/document';
 
 export function scaffoldQwikProject(): { tmpDir: string; cleanupFn: () => void } {
@@ -106,6 +106,7 @@ export function runCommandUntil(
 
     function checkCriteria(c: any) {
       output += c.toString();
+      console.warn(output);
       if (criteria(stripConsoleColors(output)) && !complete) {
         complete = true;
         res(p);

--- a/e2e/qwik-cli-e2e/utils/index.ts
+++ b/e2e/qwik-cli-e2e/utils/index.ts
@@ -7,8 +7,14 @@ import treeKill from 'tree-kill';
 import { promisify } from 'util';
 import { createDocument } from '../../../packages/qwik/src/testing/document';
 
-export function scaffoldQwikProject(): { tmpDir: string; cleanupFn: () => void } {
-  const tmpHostDirData = getTmpDirSync(process.env.TEMP_E2E_PATH);
+export type QwikProjectType = 'playground' | 'library' | 'empty';
+export function scaffoldQwikProject(type: QwikProjectType): {
+  tmpDir: string;
+  cleanupFn: () => void;
+} {
+  const tmpHostDirData = getTmpDirSync(
+    process.env.TEMP_E2E_PATH ? `${process.env.TEMP_E2E_PATH}/${type}` : undefined
+  );
   const cleanupFn = () => {
     if (!tmpHostDirData.overridden) {
       cleanup(tmpHostDirData.path);
@@ -17,7 +23,7 @@ export function scaffoldQwikProject(): { tmpDir: string; cleanupFn: () => void }
     }
   };
   try {
-    const tmpDir = runCreateQwikCommand(tmpHostDirData.path);
+    const tmpDir = runCreateQwikCommand(tmpHostDirData.path, type);
     log(`Created test application at "${tmpDir}"`);
     replacePackagesWithLocalOnes(tmpDir);
     return { cleanupFn, tmpDir };
@@ -52,10 +58,10 @@ function getTmpDirSync(tmpDirOverride?: string) {
   return { path: dirSync({ prefix: 'qwik_e2e' }).name, overridden: false };
 }
 
-function runCreateQwikCommand(tmpDir: string): string {
+function runCreateQwikCommand(tmpDir: string, type: 'playground' | 'library' | 'empty'): string {
   const appDir = 'e2e-app';
   execSync(
-    `node "${workspaceRoot}/packages/create-qwik/create-qwik.cjs" playground "${join(tmpDir, appDir)}"`
+    `node "${workspaceRoot}/packages/create-qwik/create-qwik.cjs" ${type} "${join(tmpDir, appDir)}"`
   );
   return join(tmpDir, appDir);
 }
@@ -153,11 +159,15 @@ export async function assertHostUnused(host: string): Promise<void> {
 // promisify fails to get the proper type overload, so manually enforcing the type
 const _promisifiedTreeKill = promisify(treeKill) as (pid: number, signal: string) => Promise<void>;
 
-export const promisifiedTreeKill = (pid: number, signal: string) => {
+export const promisifiedTreeKill = async (pid: number, signal: string) => {
   try {
-    return _promisifiedTreeKill(pid, signal);
+    return await _promisifiedTreeKill(pid, signal);
   } catch (error) {
-    console.error('Failed to kill the process ' + pid, error);
+    // Don't treat process termination failures as test failures
+    // This is especially important on Windows where processes may already be gone
+    // or may not be properly terminated with tree-kill
+    log(`Process ${pid} could not be killed, but continuing: ${error.message}`);
+    return Promise.resolve();
   }
 };
 

--- a/e2e/qwik-cli-e2e/utils/setup.ts
+++ b/e2e/qwik-cli-e2e/utils/setup.ts
@@ -28,11 +28,12 @@ function packPackages() {
   const tarballPaths: { name: string; absolutePath: string }[] = [];
   const tarballOutDir = join(workspaceRoot, 'temp', 'tarballs');
   for (const [name, cfg] of Object.entries(packageCfg)) {
-    const out = execSync(`pnpm pack --pack-destination=${tarballOutDir}`, {
+    const out = execSync(`pnpm pack --json --pack-destination=${tarballOutDir}`, {
       cwd: join(workspaceRoot, cfg.packagePath),
       encoding: 'utf-8',
     });
-    tarballPaths.push({ name, absolutePath: out.replace(/(\r\n|\n|\r)/gm, '') });
+    const json = JSON.parse(out);
+    tarballPaths.push({ name, absolutePath: json.filename });
   }
   writeFileSync(join(tarballOutDir, 'paths.json'), JSON.stringify(tarballPaths));
 }

--- a/e2e/qwik-cli-e2e/vite.config.ts
+++ b/e2e/qwik-cli-e2e/vite.config.ts
@@ -1,13 +1,27 @@
-import { defineConfig } from 'vitest/config';
-import tsconfigPaths from 'vite-tsconfig-paths';
+import { existsSync, mkdirSync } from 'fs';
 import { resolve } from 'path';
-import { mkdirSync } from 'fs';
+import tsconfigPaths from 'vite-tsconfig-paths';
+import { defineConfig } from 'vitest/config';
 
 // if we're running in github CI
 if (process.env.CI) {
   // Workaround for npm/pnpm crashing in scaffoldQwikProject because "name is too long"
   const testPath = resolve(process.cwd(), 'e2e-test-tmp');
-  mkdirSync(testPath);
+
+  // Create base directory if it doesn't exist
+  if (!existsSync(testPath)) {
+    mkdirSync(testPath);
+  }
+
+  // Create subdirectories for each template type
+  const templateTypes = ['empty', 'playground'];
+  for (const type of templateTypes) {
+    const templatePath = resolve(testPath, type);
+    if (!existsSync(templatePath)) {
+      mkdirSync(templatePath);
+    }
+  }
+
   process.env.TEMP_E2E_PATH = testPath;
 }
 

--- a/packages/qwik/src/cli/utils/utils.ts
+++ b/packages/qwik/src/cli/utils/utils.ts
@@ -117,7 +117,7 @@ export function limitLength(hint: string, maxLength: number = 50) {
 }
 
 export function getPackageManager() {
-  return detectPackageManager()?.name || 'npm';
+  return detectPackageManager()?.name || 'pnpm';
 }
 
 export function pmRunCmd() {

--- a/starters/apps/base/package.json
+++ b/starters/apps/base/package.json
@@ -23,6 +23,7 @@
     "typescript-eslint": "latest",
     "eslint": "latest",
     "eslint-plugin-qwik": "latest",
+    "globals": "latest",
     "prettier": "latest",
     "typescript": "latest",
     "undici": "latest",

--- a/starters/apps/library/package.json
+++ b/starters/apps/library/package.json
@@ -39,6 +39,7 @@
     "typescript-eslint": "latest",
     "eslint": "latest",
     "eslint-plugin-qwik": "latest",
+    "globals": "latest",
     "np": "^8.0.4",
     "prettier": "latest",
     "typescript": "latest",

--- a/starters/apps/playground/src/routes/layout.tsx
+++ b/starters/apps/playground/src/routes/layout.tsx
@@ -1,6 +1,5 @@
 import { component$, Slot, useStyles$ } from "@builder.io/qwik";
 import { routeLoader$ } from "@builder.io/qwik-city";
-import type { RequestHandler } from "@builder.io/qwik-city";
 
 import Header from "../components/starter/header/header";
 import Footer from "../components/starter/footer/footer";


### PR DESCRIPTION
The `globals` package was missing from the starters package.json, so that's fixed. 

Plus, we've added a cli test that prevents this type of bugs to re-appear later on