### PR TITLE
fix: ensure components are only rendered when necessary

### DIFF
--- a/.changeset/pretty-trees-check.md
+++ b/.changeset/pretty-trees-check.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: ensure components are only rendered when necessary

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -1053,9 +1053,9 @@ export const vnode_diff = (
         } else {
           // We did not find the component, create it.
           insertNewComponent(host, componentQRL, jsxProps);
+          shouldRender = true;
         }
         host = vNewNode as VirtualVNode;
-        shouldRender = true;
       } else if (!hashesAreEqual || !jsxNode.key) {
         insertNewComponent(host, componentQRL, jsxProps);
         host = vNewNode as VirtualVNode;


### PR DESCRIPTION
If we've found the correct component and props are the same don't rerender it