### PR TITLE
fix: don't wrap static objects with signal

### DIFF
--- a/.changeset/olive-yaks-prove.md
+++ b/.changeset/olive-yaks-prove.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: don't wrap static objects with signal

--- a/packages/qwik/src/core/reactive-primitives/internal-api.ts
+++ b/packages/qwik/src/core/reactive-primitives/internal-api.ts
@@ -56,8 +56,8 @@ export const _wrapProp = <T extends Record<any, any>, P extends keyof T>(...args
       return wrappedValue;
     }
   }
-  // We need to forward the access to the original object
-  return getWrapped(args);
+  // the object is not reactive, so we can just return the value
+  return obj[prop];
 };
 
 /** @internal */

--- a/packages/qwik/src/core/shared/shared-serialization.unit.ts
+++ b/packages/qwik/src/core/shared/shared-serialization.unit.ts
@@ -415,7 +415,8 @@ describe('shared-serialization', () => {
       `);
     });
     it(title(TypeIds.WrappedSignal), async () => {
-      const propSignal = _wrapProp({ foo: 3 }, 'foo');
+      const foo = createSignal(3);
+      const propSignal = _wrapProp(foo, 'value');
       if (propSignal.value) {
         Math.random();
       }
@@ -437,18 +438,16 @@ describe('shared-serialization', () => {
         1 WrappedSignal [
           Number 1
           Array [
-            Object [
-              String "foo"
+            Signal [
               Number 3
             ]
-            RootRef 2
+            String "value"
           ]
           Constant null
           Number 3
           Constant null
         ]
-        2 RootRef "1 1 0 0"
-        (88 chars)"
+        (74 chars)"
       `);
     });
     it(title(TypeIds.ComputedSignal), async () => {

--- a/packages/qwik/src/core/tests/component.spec.tsx
+++ b/packages/qwik/src/core/tests/component.spec.tsx
@@ -962,7 +962,7 @@ describe.each([
             <Component>
               <div>
                 {'Child '}
-                <Signal ssr-required>{'1'}</Signal>
+                {'1'}
                 {', active: '}
                 <Signal ssr-required>{'false'}</Signal>
               </div>
@@ -970,7 +970,7 @@ describe.each([
             <Component>
               <div>
                 {'Child '}
-                <Signal ssr-required>{'2'}</Signal>
+                {'2'}
                 {', active: '}
                 <Signal ssr-required>{'true'}</Signal>
               </div>
@@ -989,7 +989,7 @@ describe.each([
             <Component>
               <div>
                 {'Child '}
-                <Signal ssr-required>{'1'}</Signal>
+                {'1'}
                 {', active: '}
                 <Signal ssr-required>{'true'}</Signal>
               </div>
@@ -997,7 +997,7 @@ describe.each([
             <Component>
               <div>
                 {'Child '}
-                <Signal ssr-required>{'2'}</Signal>
+                {'2'}
                 {', active: '}
                 <Signal ssr-required>{'false'}</Signal>
               </div>

--- a/packages/qwik/src/core/tests/inline-component.spec.tsx
+++ b/packages/qwik/src/core/tests/inline-component.spec.tsx
@@ -3,7 +3,6 @@ import {
   Fragment,
   Fragment as InlineComponent,
   Fragment as Projection,
-  Fragment as Signal,
   Slot,
   component$,
   useSignal,
@@ -262,19 +261,13 @@ describe.each([
         <footer>
           <button></button>
           <InlineComponent>
-            <div>
-              <Signal ssr-required>qwik</Signal>
-            </div>
+            <div>qwik</div>
           </InlineComponent>
           <InlineComponent>
-            <div>
-              <Signal ssr-required>foo</Signal>
-            </div>
+            <div>foo</div>
           </InlineComponent>
           <InlineComponent>
-            <div>
-              <Signal ssr-required>bar</Signal>
-            </div>
+            <div>bar</div>
           </InlineComponent>
         </footer>
       </Component>
@@ -287,19 +280,13 @@ describe.each([
         <footer>
           <button></button>
           <InlineComponent>
-            <div>
-              <Signal ssr-required>bar</Signal>
-            </div>
+            <div>bar</div>
           </InlineComponent>
           <InlineComponent>
-            <div>
-              <Signal ssr-required>foo</Signal>
-            </div>
+            <div>foo</div>
           </InlineComponent>
           <InlineComponent>
-            <div>
-              <Signal ssr-required>qwik</Signal>
-            </div>
+            <div>qwik</div>
           </InlineComponent>
         </footer>
       </Component>
@@ -566,7 +553,7 @@ describe.each([
       <InlineComponent>
         <Component>
           <div>
-            <Signal>aaa</Signal>
+            aaa
             {': '}
             <Projection>
               <div>
@@ -620,12 +607,12 @@ describe.each([
       <InlineComponent>
         <Component>
           <div>
-            <Signal>{'bar'}</Signal>
+            {'bar'}
             {': '}
             <Projection>Test</Projection>
             <Component>
               <div>
-                <Signal>{'bbb'}</Signal>
+                {'bbb'}
                 {': '}
                 <Projection>Test2</Projection>
               </div>

--- a/packages/qwik/src/core/tests/projection.spec.tsx
+++ b/packages/qwik/src/core/tests/projection.spec.tsx
@@ -2,7 +2,7 @@ import {
   Fragment as Component,
   component$,
   createContextId,
-  Fragment as DerivedSignal,
+  Fragment as WrappedSignal,
   Fragment,
   Fragment as InlineComponent,
   jsx,
@@ -474,7 +474,7 @@ describe.each([
         <span>
           <Projection />
           {'('}
-          <DerivedSignal>render-content</DerivedSignal>
+          render-content
           {')'}
         </span>
       </InlineComponent>
@@ -491,7 +491,7 @@ describe.each([
           <span>
             <Projection>{'parent-content'}</Projection>
             {'('}
-            <DerivedSignal>child-content</DerivedSignal>
+            child-content
             {')'}
           </span>
         </InlineComponent>
@@ -831,7 +831,7 @@ describe.each([
               <Projection ssr-required>
                 <Fragment ssr-required>
                   {'DEFAULT '}
-                  <DerivedSignal ssr-required>{'0'}</DerivedSignal>
+                  <WrappedSignal ssr-required>{'0'}</WrappedSignal>
                 </Fragment>
               </Projection>
               <Projection ssr-required>{render === ssrRenderToDom ? '' : null}</Projection>
@@ -842,14 +842,14 @@ describe.each([
               <Projection ssr-required>
                 <span q:slot="start">
                   {'START '}
-                  <DerivedSignal ssr-required>{'0'}</DerivedSignal>
+                  <WrappedSignal ssr-required>{'0'}</WrappedSignal>
                 </span>
               </Projection>
               <Projection ssr-required>{render === ssrRenderToDom ? '' : null}</Projection>
               <Projection ssr-required>
                 <span q:slot="end">
                   {'END '}
-                  <DerivedSignal ssr-required>{'0'}</DerivedSignal>
+                  <WrappedSignal ssr-required>{'0'}</WrappedSignal>
                 </span>
               </Projection>
             </div>
@@ -896,7 +896,7 @@ describe.each([
               <Projection ssr-required>
                 <Fragment ssr-required>
                   {'DEFAULT '}
-                  <DerivedSignal ssr-required>{'1'}</DerivedSignal>
+                  <WrappedSignal ssr-required>{'1'}</WrappedSignal>
                 </Fragment>
               </Projection>
               <Projection ssr-required>{render === ssrRenderToDom ? '' : null}</Projection>
@@ -907,14 +907,14 @@ describe.each([
               <Projection ssr-required>
                 <span q:slot="start">
                   {'START '}
-                  <DerivedSignal ssr-required>{'1'}</DerivedSignal>
+                  <WrappedSignal ssr-required>{'1'}</WrappedSignal>
                 </span>
               </Projection>
               <Projection ssr-required>{render === ssrRenderToDom ? '' : null}</Projection>
               <Projection ssr-required>
                 <span q:slot="end">
                   {'END '}
-                  <DerivedSignal ssr-required>{'1'}</DerivedSignal>
+                  <WrappedSignal ssr-required>{'1'}</WrappedSignal>
                 </span>
               </Projection>
             </div>
@@ -1344,7 +1344,7 @@ describe.each([
             <Component>
               <span class="child">
                 <Projection>
-                  <DerivedSignal>child-content</DerivedSignal>
+                  <WrappedSignal>child-content</WrappedSignal>
                 </Projection>
               </span>
             </Component>
@@ -1359,7 +1359,7 @@ describe.each([
             <Component>
               <span class="child">
                 <Projection>
-                  <DerivedSignal>{''}</DerivedSignal>
+                  <WrappedSignal>{''}</WrappedSignal>
                 </Projection>
               </span>
             </Component>
@@ -1378,7 +1378,7 @@ describe.each([
             <Component>
               <span class="child">
                 <Projection>
-                  <DerivedSignal>child-content</DerivedSignal>
+                  <WrappedSignal>child-content</WrappedSignal>
                 </Projection>
               </span>
             </Component>
@@ -1439,7 +1439,7 @@ describe.each([
             <Component>
               <span class="child">
                 <Projection>
-                  <DerivedSignal>{''}</DerivedSignal>
+                  <WrappedSignal>{''}</WrappedSignal>
                 </Projection>
               </span>
             </Component>
@@ -1462,7 +1462,7 @@ describe.each([
             <Component>
               <span class="child">
                 <Projection>
-                  <DerivedSignal>child-content</DerivedSignal>
+                  <WrappedSignal>child-content</WrappedSignal>
                 </Projection>
               </span>
             </Component>
@@ -1480,7 +1480,7 @@ describe.each([
             <Component>
               <span class="child">
                 <Projection>
-                  <DerivedSignal>{''}</DerivedSignal>
+                  <WrappedSignal>{''}</WrappedSignal>
                 </Projection>
               </span>
             </Component>
@@ -1495,7 +1495,7 @@ describe.each([
             <Component>
               <span class="child">
                 <Projection>
-                  <DerivedSignal>{'child-content'}</DerivedSignal>
+                  <WrappedSignal>{'child-content'}</WrappedSignal>
                 </Projection>
               </span>
             </Component>
@@ -1525,7 +1525,7 @@ describe.each([
             <Component>
               <span class="child">
                 <Projection>
-                  <DerivedSignal>child-content</DerivedSignal>
+                  <WrappedSignal>child-content</WrappedSignal>
                 </Projection>
               </span>
             </Component>
@@ -2505,7 +2505,7 @@ describe.each([
                   <Component ssr-required>
                     <Projection ssr-required>
                       <div q:slot="a">
-                        Alpha <DerivedSignal ssr-required>{'123'}</DerivedSignal>
+                        Alpha <WrappedSignal ssr-required>{'123'}</WrappedSignal>
                       </div>
                     </Projection>
                   </Component>
@@ -2533,7 +2533,7 @@ describe.each([
                   <Component ssr-required>
                     <Projection ssr-required>
                       <div q:slot="b">
-                        Bravo <DerivedSignal ssr-required>{'124'}</DerivedSignal>
+                        Bravo <WrappedSignal ssr-required>{'124'}</WrappedSignal>
                       </div>
                     </Projection>
                   </Component>
@@ -2593,7 +2593,7 @@ describe.each([
                   <Projection ssr-required>
                     <div q:slot="b">
                       {'Bravo '}
-                      <DerivedSignal ssr-required>1</DerivedSignal>
+                      <WrappedSignal ssr-required>1</WrappedSignal>
                     </div>
                   </Projection>
                 </Component>

--- a/packages/qwik/src/core/tests/render-namespace.spec.tsx
+++ b/packages/qwik/src/core/tests/render-namespace.spec.tsx
@@ -5,7 +5,6 @@ import {
   useSignal,
   Fragment as Component,
   Fragment,
-  Fragment as Signal,
   type JSXOutput,
 } from '@qwik.dev/core';
 import { HTML_NS, MATH_NS, QContainerAttr, SVG_NS } from '../shared/utils/markers';
@@ -206,9 +205,7 @@ describe.each([
             <Component ssr-required>
               <svg key="hi" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
                 <circle cx="15" cy="15" r="50"></circle>
-                <Signal ssr-required>
-                  <Fragment ssr-required></Fragment>
-                </Signal>
+                <Fragment ssr-required></Fragment>
               </svg>
             </Component>
           </button>
@@ -227,9 +224,7 @@ describe.each([
             <Component>
               <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
                 <circle cx="15" cy="15" r="50"></circle>
-                <Signal>
-                  <line x1="0" y1="80" x2="100" y2="20" stroke="black" key="1"></line>
-                </Signal>
+                <line x1="0" y1="80" x2="100" y2="20" stroke="black" key="1"></line>
               </svg>
             </Component>
           </button>
@@ -254,9 +249,7 @@ describe.each([
             <Component>
               <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
                 <circle cx="15" cy="15" r="50"></circle>
-                <Signal>
-                  <Fragment></Fragment>
-                </Signal>
+                <Fragment></Fragment>
               </svg>
             </Component>
           </button>

--- a/packages/qwik/src/core/tests/use-context.spec.tsx
+++ b/packages/qwik/src/core/tests/use-context.spec.tsx
@@ -69,9 +69,7 @@ describe.each([
     expect(vNode).toMatchVDOM(
       <Component ssr-required>
         <Component ssr-required>
-          <span>
-            <WrappedSignal ssr-required>CONTEXT_VALUE</WrappedSignal>
-          </span>
+          <span>CONTEXT_VALUE</span>
         </Component>
       </Component>
     );
@@ -93,9 +91,7 @@ describe.each([
     expect(vNode).toMatchVDOM(
       <Component ssr-required>
         <Component ssr-required>
-          <span>
-            <WrappedSignal ssr-required>CONTEXT_VALUE</WrappedSignal>
-          </span>
+          <span>CONTEXT_VALUE</span>
         </Component>
       </Component>
     );
@@ -251,9 +247,7 @@ describe.each([
                 <Awaited ssr-required>
                   <Component ssr-required>
                     <Fragment ssr-required>
-                      <p>
-                        <WrappedSignal ssr-required>1</WrappedSignal>
-                      </p>
+                      <p>1</p>
                       <p>
                         <Awaited>0</Awaited>
                       </p>
@@ -279,9 +273,7 @@ describe.each([
                 <Awaited ssr-required>
                   <Component ssr-required>
                     <Fragment ssr-required>
-                      <p>
-                        <WrappedSignal ssr-required>1</WrappedSignal>
-                      </p>
+                      <p>1</p>
                       <p>
                         <Awaited ssr-required>2</Awaited>
                       </p>
@@ -352,7 +344,7 @@ describe.each([
                 <Component ssr-required>
                   <div id="issue-5270-div">
                     {'Ctx: '}
-                    <WrappedSignal ssr-required>{'hello'}</WrappedSignal>
+                    {'hello'}
                   </div>
                 </Component>
               </Projection>

--- a/packages/qwik/src/core/tests/use-store.spec.tsx
+++ b/packages/qwik/src/core/tests/use-store.spec.tsx
@@ -682,9 +682,7 @@ describe.each([
     expect(vNode).toMatchVDOM(
       <Component>
         <Fragment>
-          <div key="0">
-            <Signal>0</Signal>
-          </div>
+          <div key="0">0</div>
         </Fragment>
       </Component>
     );


### PR DESCRIPTION
Static/const objects should not be wrapped with WrappedSignal, they are static and cannot change