### PR TITLE
docs: fix up cookbook debounce typing

### DIFF
--- a/packages/docs/src/routes/docs/cookbook/debouncer/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/debouncer/index.mdx
@@ -31,7 +31,7 @@ The Qwik framework provides unique capabilities for managing state and effects i
 
 <CodeFile src="/src/routes/demo/cookbook/mediaController/index.tsx">
 ```tsx
-export const useDebouncer = <A extends readonly unknown[], R>(
+export const useDebouncer = <A extends unknown[], R>(
   fn: QRL<(...args: A) => R>,
   delay: number,
 ): QRL<(...args: A) => void> => {
@@ -98,7 +98,7 @@ We can leverage Qwik's `implicit$FirstArg` function to create a `useDebouncer$` 
 This is how Qwik actually implements all of its built-in $ hooks.
 
 ```tsx
-export const useDebouncerQrl = <A extends readonly unknown[], R>(
+export const useDebouncerQrl = <A extends unknown[], R>(
   fn: QRL<(...args: A) => R>,
   delay: number,
 ): QRL<(...args: A) => void> => {


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Docs / tests / types / typos

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

## Summary
This PR addresses a TypeScript error related to the use of readonly tuple types in conjunction with QRL.

## Problem
Using a readonly tuple type A extends readonly unknown[] caused the following TypeScript diagnostic when invoking a QRL:

```txt
Argument of type '[...A]' is not assignable to parameter of type 'QrlArgs<(...args: A) => R>'. [2345]
```

## Root Cause
This appears to be a type compatibility issue between the readonly tuple spread ([...A]) and the expected QrlArgs type in the QRL function signature. It's possible there's an edge case or mismatch in how QrlArgs<(...args: A) => R> resolves in the presence of readonly tuples, or perhaps recent TypeScript updates introduced stricter rules around readonly spreads.

## Solution
The fix involves removing the readonly modifier from the generic tuple constraint:

```diff
- A extends readonly unknown[]
+ A extends unknown[]
```

This ensures compatibility with the QRL's expected argument types while preserving type safety.

### Notes
Further investigation might be warranted to confirm whether this is a TypeScript typing nuance or a limitation in the Qwik QRL typings themselves.

Tested on TypeScript 5.4.5

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] I made corresponding changes to the Qwik docs