### PR TITLE
test: pass context to config hook for Vite 7

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
@@ -69,12 +69,19 @@ const excludeDeps = [
 const getPlugin = (opts: QwikVitePluginOptions | undefined) =>
   (qwikVite(opts) as any)[0] as QwikVitePlugin;
 
+// undefined for Vite 5 - 6, an object for Vite 7
+const configHookPluginContext = undefined as any;
+
 test('command: serve, mode: development', async () => {
   const initOpts = {
     optimizerOptions: mockOptimizerOptions(),
   };
   const plugin = getPlugin(initOpts);
-  const c = (await plugin.config({}, { command: 'serve', mode: 'development' }))!;
+  const c = (await plugin.config.call(
+    configHookPluginContext,
+    {},
+    { command: 'serve', mode: 'development' }
+  ))!;
   const opts = await plugin.api?.getOptions();
   const build = c.build!;
   const rollupOptions = build!.rollupOptions!;
@@ -117,7 +124,11 @@ test('command: serve, mode: production', async () => {
     optimizerOptions: mockOptimizerOptions(),
   };
   const plugin = getPlugin(initOpts);
-  const c = (await plugin.config({}, { command: 'serve', mode: 'production' }))!;
+  const c = (await plugin.config.call(
+    configHookPluginContext,
+    {},
+    { command: 'serve', mode: 'production' }
+  ))!;
   const opts = await plugin.api?.getOptions();
   const build = c.build!;
   const rollupOptions = build!.rollupOptions!;
@@ -152,7 +163,11 @@ test('command: build, mode: development', async () => {
     optimizerOptions: mockOptimizerOptions(),
   };
   const plugin = getPlugin(initOpts);
-  const c = (await plugin.config({}, { command: 'build', mode: 'development' }))!;
+  const c = (await plugin.config.call(
+    configHookPluginContext,
+    {},
+    { command: 'build', mode: 'development' }
+  ))!;
   const opts = await plugin.api?.getOptions();
   const build = c.build!;
   const rollupOptions = build!.rollupOptions!;
@@ -199,7 +214,11 @@ test('command: build, mode: production', async () => {
     optimizerOptions: mockOptimizerOptions(),
   };
   const plugin = getPlugin(initOpts);
-  const c = (await plugin.config({}, { command: 'build', mode: 'production' }))!;
+  const c = (await plugin.config.call(
+    configHookPluginContext,
+    {},
+    { command: 'build', mode: 'production' }
+  ))!;
   const opts = await plugin.api?.getOptions();
   const build = c.build!;
   const rollupOptions = build!.rollupOptions!;
@@ -244,7 +263,11 @@ test('command: build, --mode production (client)', async () => {
   };
 
   const plugin = getPlugin(initOpts);
-  const c: any = (await plugin.config({}, { command: 'build', mode: 'production' }))!;
+  const c: any = (await plugin.config.call(
+    configHookPluginContext,
+    {},
+    { command: 'build', mode: 'production' }
+  ))!;
   const opts = await plugin.api?.getOptions();
   const build = c.build!;
   const rollupOptions = build!.rollupOptions!;
@@ -262,7 +285,8 @@ test('command: build, --ssr entry.server.tsx', async () => {
     optimizerOptions: mockOptimizerOptions(),
   };
   const plugin = getPlugin(initOpts);
-  const c = (await plugin.config(
+  const c = (await plugin.config.call(
+    configHookPluginContext,
     { build: { ssr: resolve(cwd, 'src', 'entry.server.tsx') } },
     { command: 'build', mode: '' }
   ))!;
@@ -307,7 +331,8 @@ test('command: serve, --mode ssr', async () => {
     },
   };
   const plugin = getPlugin(initOpts);
-  const c: any = (await plugin.config(
+  const c: any = (await plugin.config.call(
+    configHookPluginContext,
     { build: { emptyOutDir: true } },
     { command: 'serve', mode: 'ssr' }
   ))!;
@@ -335,7 +360,8 @@ test('command: serve, --mode ssr with build.assetsDir', async () => {
     },
   };
   const plugin = getPlugin(initOpts);
-  const c: any = (await plugin.config(
+  const c: any = (await plugin.config.call(
+    configHookPluginContext,
     { build: { emptyOutDir: true, assetsDir: 'my-assets-dir' } },
     { command: 'serve', mode: 'ssr' }
   ))!;
@@ -359,7 +385,8 @@ test('should use the dist/ fallback with client target', async () => {
     optimizerOptions: mockOptimizerOptions(),
   };
   const plugin = getPlugin(initOpts);
-  const c: any = (await plugin.config(
+  const c: any = (await plugin.config.call(
+    configHookPluginContext,
     { build: { assetsDir: 'my-assets-dir/' } },
     { command: 'serve', mode: 'development' }
   ))!;
@@ -372,7 +399,8 @@ test('should use build.outDir config with client target', async () => {
     optimizerOptions: mockOptimizerOptions(),
   };
   const plugin = getPlugin(initOpts);
-  const c: any = (await plugin.config(
+  const c: any = (await plugin.config.call(
+    configHookPluginContext,
     { build: { outDir: 'my-dist/', assetsDir: 'my-assets-dir' } },
     { command: 'serve', mode: 'development' }
   ))!;
@@ -388,7 +416,8 @@ test('should use build.outDir config when assetsDir is _astro', async () => {
   const plugin = getPlugin(initOpts);
 
   // Astro sets a build.assetsDir of _astro, but we don't want to change that
-  const c: any = (await plugin.config(
+  const c: any = (await plugin.config.call(
+    configHookPluginContext,
     { build: { assetsDir: '_astro' } },
     { command: 'serve', mode: 'development' }
   ))!;
@@ -401,7 +430,8 @@ test('command: build, --mode lib', async () => {
     optimizerOptions: mockOptimizerOptions(),
   };
   const plugin = getPlugin(initOpts);
-  const c: any = (await plugin.config(
+  const c: any = (await plugin.config.call(
+    configHookPluginContext,
     {
       build: {
         lib: {
@@ -436,7 +466,8 @@ test('command: build, --mode lib with multiple outputs', async () => {
     optimizerOptions: mockOptimizerOptions(),
   };
   const plugin = getPlugin(initOpts);
-  const c: any = (await plugin.config(
+  const c: any = (await plugin.config.call(
+    configHookPluginContext,
     {
       build: {
         lib: {


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Docs / tests / types / typos

# Description

Vite 7+ will pass the context (https://github.com/vitejs/vite/pull/19936) to `config` hook and the current test code does not pass it and a type error was happening.
This PR fixes that.

This PR should fix the ecosystem-ci failure.
https://github.com/vitejs/vite-ecosystem-ci/actions/runs/15291891294/job/43012757752#step:8:1008

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
