### PR TITLE
fix(docs): Content is present in code block in the MDX guide

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/guides/mdx/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/guides/mdx/index.mdx
@@ -195,6 +195,7 @@ export const Tags = component$(() => {
     </ul>
   );
 });
+```
 
 ## `useContent()`
 
@@ -209,4 +210,3 @@ The `headings` array includes data about a markdown file's `<h1>` to `<h6>` [htm
 
 Menus are contextual data declared with `menu.md` files. See [menus file definition](/docs/(qwikcity)/advanced/menu/index.mdx) for more information on the file format and location.
 
-```


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

- Docs: typos

# Description

The [MDX](https://qwik.dev/docs/guides/mdx/) guide has some of its markdown content enclosed within a code block, looks like someone typed some content in within a code block.

![image](https://github.com/user-attachments/assets/75413ae1-a5c1-46fc-99fa-4aa4c470a1e1)

This PR fixes this.

# Checklist

(I've removed some of the checkboxes because this is a simple doc change)

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I made corresponding changes to the Qwik docs
