### PR TITLE
fix(optimizer): remove backdrop-filter from vite-error-overlay for perf

### DIFF
--- a/.changeset/fancy-nights-chew.md
+++ b/.changeset/fancy-nights-chew.md
@@ -1,5 +1,5 @@
 ---
-'@builder.io/qwik': minor
+'@builder.io/qwik': patch
 ---
 
 Removed backdrop-filter of vite-error-overlay to prevent perf issues with multiple errors

--- a/.changeset/fancy-nights-chew.md
+++ b/.changeset/fancy-nights-chew.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': minor
+---
+
+Removed backdrop-filter of vite-error-overlay to prevent perf issues with multiple errors

--- a/packages/qwik/src/optimizer/src/plugins/vite-error.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-error.ts
@@ -19,7 +19,6 @@ vite-error-overlay {
 
 vite-error-overlay::part(backdrop) {
   background: rgb(2 11 17 / 60%);
-  backdrop-filter: blur(20px) brightness(0.4) saturate(3);
 }
 
 vite-error-overlay::part(window) {


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Bug

# Description

Removes the backdrop-filter/blur when an error appears. In the event that you have multiple error overlays, it causes my Super Computer (M4 Max) to absolutely crawl. 

Closes https://github.com/QwikDev/qwik/issues/7675

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
