### PR TITLE
fixed an issue with the example for the "getWritableStream()" method

### DIFF
--- a/packages/docs/src/routes/docs/(qwikcity)/middleware/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikcity)/middleware/index.mdx
@@ -606,6 +606,7 @@ Set stream response.
 import type { RequestHandler } from '@builder.io/qwik-city';
 
 export const onGet: RequestHandler = async (requestEvent) => {
+  requestEvent.headers.set('content-type','text/event-stream')  
   const writableStream = requestEvent.getWritableStream();
   const writer = writableStream.getWriter();
   const encoder = new TextEncoder();


### PR DESCRIPTION
set the "text/event-stream" for the content-type in the headers

# What is it?

<!-- pick one and remove the others -->

- Docs / tests / types / typos

# Description
added the headers configs required for the event streaming to work as expected

# Checklist
- [*] I made corresponding changes to the Qwik docs
