### PR TITLE
docs: fixed @modular-forms/qwik installation guide

### DIFF
--- a/packages/docs/src/routes/docs/integrations/modular-forms/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/modular-forms/index.mdx
@@ -8,7 +8,8 @@ contributors:
   - uceumice
   - Benny-Nottonson
   - mrhoodz
-updated_at: '2023-10-03T18:53:59Z'
+  - extrordinaire
+updated_at: '2025-06-21T22:03:36.397Z'
 created_at: '2023-04-28T22:00:03Z'
 ---
 
@@ -21,25 +22,29 @@ import PackageManagerTabs from '~/components/package-manager-tabs/index.tsx';
 
 To get started, install the `@modular-forms/qwik` package:
 
+>⚠️ Warning:  
+>Make sure to install @modular-forms/qwik as a devDependency, since it only runs at build/SSR time.
+>Putting it in your regular dependencies will trigger Vite plugin errors.
+
 <PackageManagerTabs>
 <span q:slot="pnpm">
 ```shell
-pnpm install @modular-forms/qwik
+pnpm add -D @modular-forms/qwik
 ```
 </span>
 <span q:slot="npm">
 ```shell
-npm install @modular-forms/qwik
+npm install -D @modular-forms/qwik
 ```
 </span>
 <span q:slot="yarn">
 ```shell
-yarn add @modular-forms/qwik
+yarn add -D @modular-forms/qwik
 ```
 </span>
 <span q:slot="bun">
 ```shell
-bun install @modular-forms/qwik
+bun install -D @modular-forms/qwik
 ```
 </span>
 </PackageManagerTabs>


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Docs / tests / types / typos

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

The integration guide for `@modular-forms/qwik` had a wrong detail on the installation step.
Modified them and added a warning for the users to look out for installing the dependancy as a devDependancy, or else they will get a Vite plugin warning.

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] I made corresponding changes to the Qwik docs