### PR TITLE
Update index.mdx

### DIFF
--- a/packages/docs/src/routes/docs/cookbook/streaming-deferred-loaders/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/streaming-deferred-loaders/index.mdx
@@ -19,7 +19,7 @@ By returning an asynchronous function from our `routeLoader$` we can stream/defe
 import { Resource, component$ } from '@builder.io/qwik';
 import { routeLoader$ } from '@builder.io/qwik-city';
 
-export const useMyData = routeLoader$(() => {
+export const useMyData = routeLoader$(async () => {
   return async () => {
     await delay(4_000);
     return 'MyData ' + Math.random();


### PR DESCRIPTION
After testing locally, it seems that the routeLoader$'s callback needs to be async as well.

# What is it?

- Docs / tests / types / typos

# Description

Initially I was confused when the on-site provided example didn't work in my browser.
Then tried it locally, didn't work as well(the routeLoader$ still blocked rendering).
Tried it again with both the functions asynced, and it worked as described by the docs.

# Checklist

- [x] I made corresponding changes to the Qwik docs
