### PR TITLE
🐛 fix(#7697): use correct working directory for Deno environment

### DIFF
--- a/.changeset/dark-experts-scream.md
+++ b/.changeset/dark-experts-scream.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': patch
+---
+
+🐛 Fix(#7697): Use correct working directory for Deno environment

--- a/packages/qwik/src/optimizer/src/platform.ts
+++ b/packages/qwik/src/optimizer/src/platform.ts
@@ -66,6 +66,10 @@ export async function getSystem() {
     sys.path = await sys.dynamicImport('node:path');
     sys.cwd = () => process.cwd();
     sys.os = process.platform;
+  } else if (sysEnv === 'deno') {
+    sys.path = await sys.dynamicImport('node:path');
+    sys.cwd = (): string => Deno.cwd();
+    sys.os = Deno.platform();
   }
 
   return sys;


### PR DESCRIPTION
<!--  
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.
-->

# What is it?

* Bug

# Description

When building a Qwik project using **Deno**, the process fails because the Vite `build.outDir` is resolved to an **absolute path** (`/dist`) rather than a relative one. This happens because the optimizer currently sets `cwd()` to `'/'` by default for platforms other than Node.js and Bun ([source](https://github.com/QwikDev/qwik/blob/main/packages/qwik/src/optimizer/src/platform.ts#L26)).

This causes Deno to attempt writing to the system root directory, which typically fails with a permission error (`EACCES`). This does not occur in Node or Bun environments, where `cwd()` resolves to `process.cwd()`.

In this PR, we fix the issue by using `Deno.cwd()` as the default `cwd()` value when the runtime environment is Deno.

It’s also worth noting that this `cwd()` is used to compute the `rootDir`, which influences Vite’s `outDir` ([see reference](https://github.com/QwikDev/qwik/blob/main/packages/qwik/src/optimizer/src/plugins/plugin.ts#L212-L215)).

### Related Issue

* [https://github.com/QwikDev/qwik/issues/7697](https://github.com/QwikDev/qwik/issues/7697)

# Checklist

* [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
* [x] I performed a self-review of my own code
* [x] I added a changeset with `pnpm change`
* [ ] I made corresponding changes to the Qwik docs
* [ ] I added new tests to cover the fix / functionality