### PR TITLE
fix: adding popstate and scroll event for SPA navigation

### DIFF
--- a/.changeset/better-shrimps-sin.md
+++ b/.changeset/better-shrimps-sin.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: adding popstate and scroll event for SPA navigation

--- a/packages/qwik-router/src/runtime/src/spa-init.ts
+++ b/packages/qwik-router/src/runtime/src/spa-init.ts
@@ -198,8 +198,8 @@ export default event$((_: Event, el: Element) => {
     win[scrollEnabled] = true;
 
     setTimeout(() => {
-      addEventListener('popstate', win[initPopstate]!);
-      addEventListener('scroll', win[initScroll]!, { passive: true });
+      win.addEventListener('popstate', win[initPopstate]!);
+      win.addEventListener('scroll', win[initScroll]!, { passive: true });
       document.body.addEventListener('click', win[initAnchors]!);
 
       if (!(win as any).navigation) {

--- a/packages/qwik/src/core/tests/render-api.spec.tsx
+++ b/packages/qwik/src/core/tests/render-api.spec.tsx
@@ -699,7 +699,9 @@ describe('render api', () => {
           containerTagName: 'div',
           debug: true,
         });
-        expect(cleanupAttrs(result.html)).toContain('<script id="qwikloader" async>debug</script>');
+        expect(cleanupAttrs(result.html)).toContain(
+          '<script id="qwikloader" async type="module">debug</script>'
+        );
       });
 
       it('should emit qwik loader without debug mode', async () => {
@@ -707,7 +709,9 @@ describe('render api', () => {
           containerTagName: 'div',
           debug: false,
         });
-        expect(cleanupAttrs(result.html)).toContain('<script id="qwikloader" async>min</script>');
+        expect(cleanupAttrs(result.html)).toContain(
+          '<script id="qwikloader" async type="module">min</script>'
+        );
       });
     });
     describe('snapshotResult', () => {

--- a/packages/qwik/src/server/ssr-container.ts
+++ b/packages/qwik/src/server/ssr-container.ts
@@ -835,7 +835,7 @@ class SSRContainer extends _SharedContainer implements ISSRContainer {
           debug: this.renderOptions.debug,
         });
         // async allows executing while the DOM is being handled
-        const scriptAttrs = ['id', 'qwikloader', 'async', true];
+        const scriptAttrs = ['id', 'qwikloader', 'async', true, 'type', 'module'];
         const nonce = this.renderOptions.serverData?.nonce;
         if (nonce) {
           scriptAttrs.push('nonce', nonce);


### PR DESCRIPTION
For some reason sometimes addEventListener was calling qwik-loader function instead of native one