### PR TITLE
fix(view-transition): rename qwik-router-spa to qwik-navigation

### DIFF
--- a/.changeset/angry-boats-lose.md
+++ b/.changeset/angry-boats-lose.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+Bugfix - rename the view transition type in CSS to prevent default view transition on SPA navigation

--- a/packages/docs/src/routes/docs/cookbook/view-transition/index.mdx
+++ b/packages/docs/src/routes/docs/cookbook/view-transition/index.mdx
@@ -165,7 +165,7 @@ export default component$(() => {
 });
 ```
 
-When listening on the `qviewTransition` we know that
+When listening on the `qviewtransition` we know that
 
 > **Note**: For it to work correctly, we need to **remove the default view transition** animation else it happens on top of the `.animate()`. I'm using `view-transition-class` which is only working with Chrome right now.
 

--- a/packages/qwik-router/src/runtime/src/qwik-router-component.tsx
+++ b/packages/qwik-router/src/runtime/src/qwik-router-component.tsx
@@ -130,7 +130,7 @@ export const QwikRouterProvider = component$<QwikRouterProps>((props) => {
   useStyles$(`
     @layer qwik {
       @supports selector(html:active-view-transition-type(type)) {
-        html:active-view-transition-type(qwik-router-spa) {
+        html:active-view-transition-type(qwik-navigation) {
           :root{view-transition-name:none}
         }
       }


### PR DESCRIPTION
# What is it?
- Bug


# Description
Change the name of the view transition type in the default CSS style to prevent default view transition between pages

# Checklist
- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
