### PR TITLE
fix: ensure store updates go through scheduler during SPA navigation

### DIFF
--- a/packages/qwik-city/src/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/src/runtime/src/qwik-city-component.tsx
@@ -392,33 +392,22 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
         }
 
         // Update route location
-        if (!isSamePath(trackUrl, prevUrl)) {
-          untrack(() => {
+        untrack(() => {
+          if (!isSamePath(trackUrl, prevUrl)) {
             routeLocation.prevUrl = prevUrl;
-          });
-        }
-
-        untrack(() => {
+          }
           routeLocation.url = trackUrl;
-        });
-        untrack(() => {
           routeLocation.params = { ...params };
-        });
 
-        (routeInternal as any).untrackedValue = { type: navType, dest: trackUrl };
+          // Needs to be done after routeLocation is updated
+          const resolvedHead = resolveHead(clientPageData!, routeLocation, contentModules, locale);
 
-        // Needs to be done after routeLocation is updated
-        const resolvedHead = resolveHead(clientPageData!, routeLocation, contentModules, locale);
-
-        // Update content
-        untrack(() => {
+          // Update content
           content.headings = pageModule.headings;
           content.menu = menu;
           contentInternal.value = noSerialize(contentModules);
-        });
 
-        // Update document head
-        untrack(() => {
+          // Update document head
           documentHead.links = resolvedHead.links;
           documentHead.meta = resolvedHead.meta;
           documentHead.styles = resolvedHead.styles;
@@ -426,6 +415,11 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
           documentHead.title = resolvedHead.title;
           documentHead.frontmatter = resolvedHead.frontmatter;
         });
+
+        (routeInternal as any).untrackedValue = { type: navType, dest: trackUrl };
+
+        // Needs to be done after routeLocation is updated
+        const resolvedHead = resolveHead(clientPageData!, routeLocation, contentModules, locale);
 
         if (isBrowser) {
           if (props.viewTransition !== false) {

--- a/packages/qwik-city/src/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/src/runtime/src/qwik-city-component.tsx
@@ -13,6 +13,7 @@ import {
   _weakSerialize,
   useStyles$,
   _waitUntilRendered,
+  untrack,
   type QRL,
 } from '@builder.io/qwik';
 import { isBrowser, isDev, isServer } from '@builder.io/qwik';
@@ -291,7 +292,9 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
     }
 
     actionState.value = undefined;
-    routeLocation.isNavigating = true;
+    untrack(() => {
+      routeLocation.isNavigating = true;
+    });
 
     return new Promise<void>((resolve) => {
       navResolver.r = resolve;
@@ -390,11 +393,17 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
 
         // Update route location
         if (!isSamePath(trackUrl, prevUrl)) {
-          routeLocation.prevUrl = prevUrl;
+          untrack(() => {
+            routeLocation.prevUrl = prevUrl;
+          });
         }
 
-        routeLocation.url = trackUrl;
-        routeLocation.params = { ...params };
+        untrack(() => {
+          routeLocation.url = trackUrl;
+        });
+        untrack(() => {
+          routeLocation.params = { ...params };
+        });
 
         (routeInternal as any).untrackedValue = { type: navType, dest: trackUrl };
 
@@ -402,17 +411,21 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
         const resolvedHead = resolveHead(clientPageData!, routeLocation, contentModules, locale);
 
         // Update content
-        content.headings = pageModule.headings;
-        content.menu = menu;
-        contentInternal.value = noSerialize(contentModules);
+        untrack(() => {
+          content.headings = pageModule.headings;
+          content.menu = menu;
+          contentInternal.value = noSerialize(contentModules);
+        });
 
         // Update document head
-        documentHead.links = resolvedHead.links;
-        documentHead.meta = resolvedHead.meta;
-        documentHead.styles = resolvedHead.styles;
-        documentHead.scripts = resolvedHead.scripts;
-        documentHead.title = resolvedHead.title;
-        documentHead.frontmatter = resolvedHead.frontmatter;
+        untrack(() => {
+          documentHead.links = resolvedHead.links;
+          documentHead.meta = resolvedHead.meta;
+          documentHead.styles = resolvedHead.styles;
+          documentHead.scripts = resolvedHead.scripts;
+          documentHead.title = resolvedHead.title;
+          documentHead.frontmatter = resolvedHead.frontmatter;
+        });
 
         if (isBrowser) {
           if (props.viewTransition !== false) {
@@ -617,7 +630,9 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
             saveScrollHistory(scrollState);
             win._qCityScrollEnabled = true;
 
-            routeLocation.isNavigating = false;
+            untrack(() => {
+              routeLocation.isNavigating = false;
+            });
             navResolver.r?.();
           });
         }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

#7720

# What is it?

- Bug

# Description

Fixes useTask being executed for wrong path after SPA navigation due to store updates not going through scheduler properly. Added untrack() around store mutations in QwikCityProvider to ensure correct scheduling.


- Solution

-  Added untrack() around all store mutations to ensure they go through Qwik's scheduler properly
- Fixed store updates for:

- routeLocation (url, params, isNavigating)
- content (headings, menu)
- documentHead (links, meta, styles, etc.)

Testing:

- The fix can be verified by:
- Creating a component that uses useTask$ with useLocation()
- Performing SPA navigation between routes
- Verifying that the task executes with the correct path