### PR TITLE
fix: invalidate module in createQwikPlugin slows down cypress component tests

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -745,7 +745,7 @@ export function createQwikPlugin(optimizerOptions: OptimizerOptions = {}) {
           parentIds.set(key, id);
           currentOutputs.set(key, [mod, id]);
           deps.add(key);
-          if (opts.target === 'client') {
+          if (opts.target === 'client' && !devServer) {
             // rollup must be told about all entry points
             ctx.emitFile({
               id: key,

--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -746,20 +746,12 @@ export function createQwikPlugin(optimizerOptions: OptimizerOptions = {}) {
           currentOutputs.set(key, [mod, id]);
           deps.add(key);
           if (opts.target === 'client') {
-            if (devServer) {
-              // invalidate the segment so that the client will pick it up
-              const rollupModule = devServer.moduleGraph.getModuleById(key);
-              if (rollupModule) {
-                devServer.moduleGraph.invalidateModule(rollupModule);
-              }
-            } else {
-              // rollup must be told about all entry points
-              ctx.emitFile({
-                id: key,
-                type: 'chunk',
-                preserveSignature: 'allow-extension',
-              });
-            }
+            // rollup must be told about all entry points
+            ctx.emitFile({
+              id: key,
+              type: 'chunk',
+              preserveSignature: 'allow-extension',
+            });
           }
         }
       }


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Bug

# Description

`invalidateModule` is used for HMR in Vite `handleHotUpdate` hook. It was added in https://github.com/QwikDev/qwik/commit/a69de93ef5d2ebf1ae3a92c18879fafcb3d86cbd in an attempt to make sure that QRLs also get updated on parent changes.

The problem is that this causes cypress component tests (CCTs) to be 10x slower, eventually leading to CCTs startup timing out with a "Error: Code(5): You can render over a existing q:container. Skipping render()." message.

I tried many possible combinations of updating the child, the parent, the jsx, the useVisibleTask, the useTask, the QRL outside of the component... I haven't been able to trigger a case where the `invalidateModule` in the `transform` hook with the optimizer would ever run.

What seems to happen is that the `handleHotUpdate` hook will invalidate the module, which will then trigger the `transform` hook for the corresponding module and its QRLs.

Here's an example log:
```
invalidating module HMR /Users/maieul/dev/playgrounds/qwik-express/src/components/counter2.tsx
invalidating module HMR /Users/maieul/dev/playgrounds/qwik-express/src/components/counter2.tsx
invalidating module HMR /Users/maieul/dev/playgrounds/qwik-express/src/components/counter2.tsx
invalidating module HMR /Users/maieul/dev/playgrounds/qwik-express/src/components/counter2.tsx
transform /Users/maieul/dev/playgrounds/qwik-express/src/components/counter2.tsx
transform /Users/maieul/dev/playgrounds/qwik-express/src/components/counter2.tsx
transform /Users/maieul/dev/playgrounds/qwik-express/src/components/counter2.tsx_Counter2_component_div_button_onClick_fDhgqdXxNQQ.js
transform /Users/maieul/dev/playgrounds/qwik-express/src/components/counter2.tsx_Counter2_component_yQ6Hre9qSVo.js
transform /Users/maieul/dev/playgrounds/qwik-express/src/components/counter2.tsx_Counter2_component_useVisibleTask_ISI2k8PkKII.js
transform /Users/maieul/dev/playgrounds/qwik-express/src/components/counter2.tsx_Counter2_component_computedCount_useComputed_OKKHalBLW9E.js
transform /Users/maieul/dev/playgrounds/qwik-express/src/components/counter2.tsx_Counter2_component_computedCount_useComputed_OKKHalBLW9E.js
transform /Users/maieul/dev/playgrounds/qwik-express/src/components/counter2.tsx_Counter2_component_useVisibleTask_ISI2k8PkKII.js
```

Conclusion: We should remove the `invalidateModule` in the transform hook because it impacts CCTs and it seems to never run. Even if it runs rare occasions, it's more important to enable CCTs to work rather than HMR in rare circumstances.

If someone can give me a reproduction of when QRLs don't get updated on parent change, I can reassess and try to find a fix that works both for CCTs and HMR.



<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
