### PR TITLE
fix: qwikloader.cjs missing in non esm environments

### DIFF
--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -111,7 +111,8 @@
       "require": "./dist/optimizer.cjs"
     },
     "./preloader": {
-      "import": "./dist/preloader.mjs"
+      "import": "./dist/preloader.mjs",
+      "require": "./dist/preloader.cjs"
     },
     "./server.cjs": "./dist/server.cjs",
     "./server.mjs": "./dist/server.mjs",

--- a/packages/qwik/src/optimizer/src/manifest.ts
+++ b/packages/qwik/src/optimizer/src/manifest.ts
@@ -1,5 +1,5 @@
 import type { OutputBundle } from 'rollup';
-import { QWIK_PRELOADER_REAL_ID, type NormalizedQwikPluginOptions } from './plugins/plugin';
+import { type NormalizedQwikPluginOptions } from './plugins/plugin';
 import type { GlobalInjections, Path, QwikBundle, QwikManifest, SegmentAnalysis } from './types';
 
 // This is just the initial prioritization of the symbols and entries
@@ -482,7 +482,7 @@ export function generateManifestFromBundles(
       .map((m) => path.relative(opts.rootDir, m));
     if (modulePaths.length > 0) {
       bundle.origins = modulePaths;
-      if (modulePaths.some((m) => m.endsWith(QWIK_PRELOADER_REAL_ID))) {
+      if (modulePaths.some((m) => /[/\\]qwik[/\\]dist[/\\]preloader\.[cm]js$/.test(m))) {
         manifest.preloader = bundleFileName;
       } else if (modulePaths.some((m) => /[/\\]qwik[/\\]dist[/\\]core\.[^/]*js$/.test(m))) {
         manifest.core = bundleFileName;

--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -936,10 +936,14 @@ export const manifest = ${JSON.stringify(serverManifest)};\n`;
   }
 
   function manualChunks(id: string, { getModuleInfo }: Rollup.ManualChunkMeta) {
-    // The preloader has to stay in a separate chunk if it's a client build
-    // the vite preload helper must be included or to prevent breaking circular dependencies
     if (opts.target === 'client') {
-      if (id.endsWith(QWIK_PRELOADER_REAL_ID) || id === '\0vite/preload-helper.js') {
+      if (
+        // The preloader has to stay in a separate chunk if it's a client build
+        // the vite preload helper must be included to prevent breaking circular dependencies
+        id.endsWith('@builder.io/qwik/build') ||
+        /[/\\]qwik[/\\]dist[/\\]preloader\.[cm]js$/.test(id) ||
+        id === '\0vite/preload-helper.js'
+      ) {
         return 'qwik-preloader';
       } else if (/qwik[\\/]dist[\\/]qwikloader\.js$/.test(id)) {
         return 'qwik-loader';
@@ -1090,7 +1094,6 @@ export const QWIK_CORE_SERVER = '@builder.io/qwik/server';
 export const QWIK_CLIENT_MANIFEST_ID = '@qwik-client-manifest';
 
 export const QWIK_PRELOADER_ID = '@builder.io/qwik/preloader';
-export const QWIK_PRELOADER_REAL_ID = 'qwik/dist/preloader.mjs';
 
 export const SRC_DIR_DEFAULT = 'src';
 

--- a/scripts/submodule-preloader.ts
+++ b/scripts/submodule-preloader.ts
@@ -55,8 +55,8 @@ export async function submodulePreloader(config: BuildConfig) {
       copyPublicDir: false,
       lib: {
         entry: join(config.srcQwikDir, 'core/preloader'),
-        formats: ['es'],
-        fileName: () => 'preloader.mjs',
+        formats: ['es', 'cjs'],
+        fileName: (format) => (format === 'es' ? 'preloader.mjs' : 'preloader.cjs'),
       },
       rollupOptions: {
         external: ['@builder.io/qwik/build'],


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Bug

# Description

Certain environements can't use preloader.mjs (e.g. jest 29 and below). So until we decide to officially not support cjs anymore, we need to also output the preloader as `.cjs`.

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
