### PR TITLE
fix: getting invoke context for loaders in production

### DIFF
--- a/.changeset/heavy-maps-wash.md
+++ b/.changeset/heavy-maps-wash.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: getting invoke context for loaders in production

--- a/e2e/adapters-e2e/src/routes/loaders/index.tsx
+++ b/e2e/adapters-e2e/src/routes/loaders/index.tsx
@@ -1,0 +1,12 @@
+import { component$ } from '@qwik.dev/core';
+import { Link } from '@qwik.dev/router';
+
+export default component$(() => {
+  return (
+    <>
+      <Link id="subpage-link" href="/loaders/subpage">
+        Sub page
+      </Link>
+    </>
+  );
+});

--- a/e2e/adapters-e2e/src/routes/loaders/subpage/index.tsx
+++ b/e2e/adapters-e2e/src/routes/loaders/subpage/index.tsx
@@ -1,0 +1,18 @@
+import { component$ } from '@qwik.dev/core';
+import { routeLoader$ } from '@qwik.dev/router';
+
+export const useTest = routeLoader$(async () => {
+  return 42;
+});
+
+export default component$(() => {
+  const loaded = useTest();
+
+  return (
+    <>
+      <h1>Sub page</h1>
+      <p>This is the sub page.</p>
+      <p id="subpage-loader-value">{loaded.value}</p>
+    </>
+  );
+});

--- a/e2e/adapters-e2e/tests/express.spec.ts
+++ b/e2e/adapters-e2e/tests/express.spec.ts
@@ -25,4 +25,15 @@ test.describe('Verifying Express Adapter', () => {
 
     await expect(page.getByRole('heading', { name: 'Profile page' })).toBeVisible();
   });
+
+  test('should load loaders context in minified prod mode', async ({ page }) => {
+    page.goto('/loaders');
+    const subpageLink = page.locator('#subpage-link');
+    await expect(subpageLink).toBeVisible();
+
+    await subpageLink.click();
+
+    await expect(page.getByRole('heading', { name: 'Sub page' })).toBeVisible();
+    await expect(page.locator('#subpage-loader-value')).toHaveText('42');
+  });
 });

--- a/packages/qwik-router/src/runtime/src/server-functions.ts
+++ b/packages/qwik-router/src/runtime/src/server-functions.ts
@@ -15,7 +15,7 @@ import {
   _getContextEvent,
   _serialize,
   _UNINITIALIZED,
-  _useInvokeContext,
+  _resolveContextWithoutSequentialScope,
   type SerializationStrategy,
 } from '@qwik.dev/core/internal';
 
@@ -201,8 +201,7 @@ export const routeLoaderQrl = ((
 ): LoaderInternal => {
   const { id, validators, serializationStrategy } = getValidators(rest, loaderQrl);
   function loader() {
-    const iCtx = _useInvokeContext();
-    const state = iCtx.$container$.resolveContext(iCtx.$hostElement$, RouteStateContext)!;
+    const state = _resolveContextWithoutSequentialScope(RouteStateContext)!;
 
     if (!(id in state)) {
       throw new Error(`routeLoader$ "${loaderQrl.getSymbol()}" was invoked in a route where it was not declared.

--- a/packages/qwik/src/core/internal.ts
+++ b/packages/qwik/src/core/internal.ts
@@ -50,7 +50,7 @@ export {
   _getContextEvent,
   _getContextContainer,
   _jsxBranch,
-  useInvokeContext as _useInvokeContext,
   _waitUntilRendered,
 } from './use/use-core';
 export { scheduleTask as _task } from './use/use-task';
+export { _resolveContextWithoutSequentialScope } from './use/use-context';

--- a/packages/qwik/src/core/qwik.core.api.md
+++ b/packages/qwik/src/core/qwik.core.api.md
@@ -804,6 +804,9 @@ export interface RenderSSROptions {
     stream: StreamWriter;
 }
 
+// @internal (undocumented)
+export const _resolveContextWithoutSequentialScope: <STATE>(context: ContextId<STATE>) => STATE | undefined;
+
 // @public
 export const Resource: <T>(props: ResourceProps<T>) => JSXOutput;
 
@@ -1690,11 +1693,6 @@ export const useErrorBoundary: () => ErrorBoundaryStore;
 
 // @public (undocumented)
 export const useId: () => string;
-
-// Warning: (ae-forgotten-export) The symbol "RenderInvokeContext" needs to be exported by the entry point index.d.ts
-//
-// @internal (undocumented)
-export const _useInvokeContext: () => RenderInvokeContext;
 
 // Warning: (ae-internal-missing-underscore) The name "useLexicalScope" should be prefixed with an underscore because the declaration is marked as @internal
 //

--- a/packages/qwik/src/core/use/use-context.ts
+++ b/packages/qwik/src/core/use/use-context.ts
@@ -3,7 +3,7 @@ import { QError, qError } from '../shared/error/error';
 import { verifySerializable } from '../shared/utils/serialize-utils';
 import { qDev, qSerialize } from '../shared/utils/qdev';
 import { isObject } from '../shared/utils/types';
-import { invoke } from './use-core';
+import { getInvokeContext, invoke } from './use-core';
 import { useSequentialScope } from './use-sequential-scope';
 import { fromCamelToKebabCase } from '../shared/utils/event-names';
 
@@ -283,4 +283,14 @@ export const validateContext = (context: ContextId<any>) => {
   if (!isObject(context) || typeof context.id !== 'string' || context.id.length === 0) {
     throw qError(QError.invalidContext, [context]);
   }
+};
+
+/** @internal */
+export const _resolveContextWithoutSequentialScope = <STATE>(context: ContextId<STATE>) => {
+  const iCtx = getInvokeContext();
+  const hostElement = iCtx.$hostElement$;
+  if (!hostElement) {
+    return undefined;
+  }
+  return iCtx.$container$?.resolveContext(hostElement, context);
 };


### PR DESCRIPTION
We should not use $$ varaibles cross-packages, because they can be minified