### PR TITLE
fix(qwik-city): link/useNavigate query params override thrown redirect's in loader/middleware

### DIFF
--- a/.changeset/every-socks-beg.md
+++ b/.changeset/every-socks-beg.md
@@ -2,4 +2,4 @@
 '@builder.io/qwik-city': patch
 ---
 
-FIX: link/useNavigate query params don't override thrown redirect's in loader/middleware anymore.
+FIX: link/useNavigate with query params don't override loader/middleware redirect with query params anymore.

--- a/.changeset/every-socks-beg.md
+++ b/.changeset/every-socks-beg.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik-city': patch
+---
+
+FIX: link/useNavigate query params don't override thrown redirect's in loader/middleware anymore.

--- a/packages/qwik-city/src/buildtime/build-layout.unit.ts
+++ b/packages/qwik-city/src/buildtime/build-layout.unit.ts
@@ -3,7 +3,7 @@ import { assert, testAppSuite } from '../utils/test-suite';
 const test = testAppSuite('Build Layout');
 
 test('total layouts', ({ ctx: { layouts } }) => {
-  assert.equal(layouts.length, 11, JSON.stringify(layouts, null, 2));
+  assert.equal(layouts.length, 12, JSON.stringify(layouts, null, 2));
 });
 
 test('nested named layout', ({ assertLayout }) => {

--- a/packages/qwik-city/src/runtime/src/qwik-city-component.tsx
+++ b/packages/qwik-city/src/runtime/src/qwik-city-component.tsx
@@ -383,8 +383,7 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
         const pageModule = contentModules[contentModules.length - 1] as PageModule;
 
         // Restore search params unless it's a redirect
-        const isRedirect = navType === 'form' && !isSamePath(trackUrl, prevUrl);
-        if (navigation.dest.search && !isRedirect) {
+        if (navigation.dest.search && !!isSamePath(trackUrl, prevUrl)) {
           trackUrl.search = navigation.dest.search;
         }
 
@@ -430,7 +429,8 @@ export const QwikCityProvider = component$<QwikCityProps>((props) => {
             (navigation.scroll &&
               (!navigation.forceReload || !isSamePath(trackUrl, prevUrl)) &&
               (navType === 'link' || navType === 'popstate')) ||
-            isRedirect
+            // Action might have responded with a redirect.
+            (navType === 'form' && !isSamePath(trackUrl, prevUrl))
           ) {
             // Mark next DOM render to scroll.
             (document as any).__q_scroll_restore__ = () =>

--- a/starters/apps/qwikcity-test/src/routes/issue-route-with-search-params-and-action-redirect-without-search-params/action-redirect-without-search-params-target/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/issue-route-with-search-params-and-action-redirect-without-search-params/action-redirect-without-search-params-target/index.tsx
@@ -1,0 +1,15 @@
+import { useLocation } from "@builder.io/qwik-city";
+import { component$ } from "@builder.io/qwik";
+
+export default component$(() => {
+  const location = useLocation();
+
+  return (
+    <div>
+      <h1>
+        Should <strong>not</strong> have searchParams
+      </h1>
+      <pre>{JSON.stringify(location.url.searchParams.get("id"))}</pre>
+    </div>
+  );
+});

--- a/starters/apps/qwikcity-test/src/routes/issue-route-with-search-params-and-action-redirect-without-search-params/action-redirect-without-search-params/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/issue-route-with-search-params-and-action-redirect-without-search-params/action-redirect-without-search-params/index.tsx
@@ -1,0 +1,20 @@
+import { routeAction$, Form } from "@builder.io/qwik-city";
+import { component$ } from "@builder.io/qwik";
+
+export const useAction = routeAction$((_, event) => {
+  throw event.redirect(
+    302,
+    "/qwikcity-test/action-redirect-without-search-params-target/",
+  );
+});
+
+export default component$(() => {
+  const action = useAction();
+
+  return (
+    <Form action={action}>
+      <h1>Should have searchParams on the url</h1>
+      <button type="submit">Submit</button>
+    </Form>
+  );
+});

--- a/starters/apps/qwikcity-test/src/routes/issue7732/a/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/issue7732/a/index.tsx
@@ -1,0 +1,5 @@
+import { component$ } from "@builder.io/qwik";
+
+export default component$(() => {
+  return <div>empty default route A</div>;
+});

--- a/starters/apps/qwikcity-test/src/routes/issue7732/b/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/issue7732/b/index.tsx
@@ -1,0 +1,10 @@
+import { component$ } from "@builder.io/qwik";
+import type { RequestHandler } from "@builder.io/qwik-city";
+
+export const onGet: RequestHandler<void> = ({ redirect }) => {
+  throw redirect(302, `/qwikcity-test/issue7732/c/?redirected=true`);
+};
+
+export default component$(() => {
+  return <div>B route with redirect</div>;
+});

--- a/starters/apps/qwikcity-test/src/routes/issue7732/c/index.tsx
+++ b/starters/apps/qwikcity-test/src/routes/issue7732/c/index.tsx
@@ -1,0 +1,5 @@
+import { component$ } from "@builder.io/qwik";
+
+export default component$(() => {
+  return <div>route C should have redirected=true params</div>;
+});

--- a/starters/apps/qwikcity-test/src/routes/issue7732/layout.tsx
+++ b/starters/apps/qwikcity-test/src/routes/issue7732/layout.tsx
@@ -1,0 +1,25 @@
+import { component$, Slot } from "@builder.io/qwik";
+import { Link } from "@builder.io/qwik-city";
+
+export default component$(() => {
+  return (
+    <>
+      <div style={{ display: "flex", gap: "10px" }}>
+        <Link href="/issue7732/a/" id="issue7732-link-a">
+          A
+        </Link>
+
+        <Link
+          href="/qwikcity-test/issue7732/b/?shouldOverrideRedirect=no"
+          id="issue7732-link-b"
+        >
+          B
+        </Link>
+        <Link href="/issue7732/c/" id="issue7732-link-c">
+          C
+        </Link>
+      </div>
+      <Slot />
+    </>
+  );
+});

--- a/starters/e2e/qwikcity/nav.spec.ts
+++ b/starters/e2e/qwikcity/nav.spec.ts
@@ -448,7 +448,7 @@ test.describe("actions", () => {
         await expect(result).toHaveText("3");
       }
     });
-    test("issue7732 link/useNavigate should not override loader/middleware redirect", async ({
+    test("issue7732 link/useNavigate with query params should not override loader/middleware redirect with query params", async ({
       page,
     }) => {
       await page.goto("/qwikcity-test/issue7732/a/");

--- a/starters/e2e/qwikcity/nav.spec.ts
+++ b/starters/e2e/qwikcity/nav.spec.ts
@@ -459,16 +459,19 @@ test.describe("actions", () => {
       );
     });
     // TODO: Fix this test (currently not working because the action redirect adds a `/q-data.json` at the end of the path)
-    // test("action with redirect without query params in a route with query param should redirect to route without query params", async ({
-    //   page,
-    // }) => {
-    //   await page.goto("/qwikcity-test/action-redirect-without-search-params/?test=test");
-    //   const button = page.locator("button");
-    //   await button.click();
-    //   await page.waitForURL(
-    //     "/qwikcity-test/action-redirect-without-search-params-target/",
-    //   );
-    // });
+    test.fixme(
+      "action with redirect without query params in a route with query param should redirect to route without query params",
+      async ({ page }) => {
+        await page.goto(
+          "/qwikcity-test/action-redirect-without-search-params/?test=test",
+        );
+        const button = page.locator("button");
+        await button.click();
+        await page.waitForURL(
+          "/qwikcity-test/action-redirect-without-search-params-target/",
+        );
+      },
+    );
     test("media in home page", async ({ page }) => {
       await page.goto("/qwikcity-test/");
 

--- a/starters/e2e/qwikcity/nav.spec.ts
+++ b/starters/e2e/qwikcity/nav.spec.ts
@@ -1,3 +1,4 @@
+import { $ } from "bun";
 import {
   assertPage,
   getScrollHeight,
@@ -447,7 +448,27 @@ test.describe("actions", () => {
         await expect(result).toHaveText("3");
       }
     });
-
+    test("issue7732 link/useNavigate should not override loader/middleware redirect", async ({
+      page,
+    }) => {
+      await page.goto("/qwikcity-test/issue7732/a/");
+      const link = page.locator("#issue7732-link-b");
+      await link.click();
+      await expect(page).toHaveURL(
+        "/qwikcity-test/issue7732/c/?redirected=true",
+      );
+    });
+    // TODO: Fix this test (currently not working because the action redirect adds a `/q-data.json` at the end of the path)
+    // test("action with redirect without query params in a route with query param should redirect to route without query params", async ({
+    //   page,
+    // }) => {
+    //   await page.goto("/qwikcity-test/action-redirect-without-search-params/?test=test");
+    //   const button = page.locator("button");
+    //   await button.click();
+    //   await page.waitForURL(
+    //     "/qwikcity-test/action-redirect-without-search-params-target/",
+    //   );
+    // });
     test("media in home page", async ({ page }) => {
       await page.goto("/qwikcity-test/");
 


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Bug

# Description

Fixes https://github.com/QwikDev/qwik/issues/7732

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
