### PR TITLE
Add a catch to nativeStream.write(..) to avoid server crash.

### DIFF
--- a/.changeset/angry-snails-try.md
+++ b/.changeset/angry-snails-try.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': patch
+---
+
+Add a catch to the flush's write invocation to avoid server crash

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -243,7 +243,7 @@ const renderGenerator = async (
   let value: AsyncGenerator;
   if (isFunction(generator)) {
     const v = generator({
-      write(chunk) {
+      async write(chunk) {
         stream.write(chunk);
         stream.write(FLUSH_COMMENT);
       },

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -57,7 +57,7 @@ const FLUSH_COMMENT = '<!--qkssr-f-->';
 
 /** @public */
 export type StreamWriter = {
-  write: (chunk: string) => void;
+  write: (chunk: string) => Promise<void>;
 };
 
 /** @public */

--- a/packages/qwik/src/server/render.ts
+++ b/packages/qwik/src/server/render.ts
@@ -50,7 +50,10 @@ export async function renderToStream(
   const resolvedManifest = resolveManifest(opts.manifest);
   function flush() {
     if (buffer) {
-      nativeStream.write(buffer);
+      nativeStream.write(buffer).catch((e) => {
+        console.error(`Could not write buffer: ${buffer.slice(0, 200)}...`);
+        console.error(e);
+      });
       buffer = '';
       bufferSize = 0;
       networkFlushes++;


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Bug
- Infra

# Description

There is an edge case as part of ssr rendering, where the server gotten an error after the headers are sent, the async nature of write(..) could trigger an error and if uncaught the process crashes.

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
