### PR TITLE
fix(postcss): use ESM syntax for postcss.config.js

### DIFF
--- a/packages/docs/src/routes/docs/integrations/postcss/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/postcss/index.mdx
@@ -54,7 +54,7 @@ This will create a new `postcss.config.js` file at the root of the project with 
 - [PostCSS Preset Env](https://preset-env.cssdb.org/)
 
 ```ts title="postcss.config.js"
-module.exports = {
+export default {
   plugins: {
     autoprefixer: {},
     "postcss-preset-env": {
@@ -64,7 +64,7 @@ module.exports = {
       },
     },
   },
-}
+};
 ```
 
 If you wish to add a new plugin like [CssNano](https://cssnano.co/) run the following command and update the `postcss.config.js`.

--- a/starters/features/postcss/postcss.config.js
+++ b/starters/features/postcss/postcss.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   plugins: {
     autoprefixer: {},
     "postcss-preset-env": {


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Bug

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

I created a project using the `npm create` Qwik City starter.

Then, after following the PostCSS integration guide, trying to run `npm start` will throw an error:

```
[Failed to load PostCSS config: Failed to load PostCSS config (searchPath: /demo): [ReferenceError] module is not defined in ES module scope
This file is being treated as an ES module because it has a '.js' file extension and '\demo\package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
ReferenceError: module is not defined in ES module scope
```

# Changes

- fix(postcss): update `postcss.config.js` to ESM syntax
- docs(postcss): update PostCSS integration docs to reflect ESM config

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I made corresponding changes to the Qwik docs
