### PR TITLE
feat: <DocumentHeadTags />

### DIFF
--- a/.changeset/flat-hounds-burn.md
+++ b/.changeset/flat-hounds-burn.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': minor
+---
+
+feat: add `DocumentHeadTags` component and make the `head.styles` and `head.scripts` types more like the `head.meta` and `head.links` types.

--- a/packages/docs/src/routes/api/qwik-router/api.json
+++ b/packages/docs/src/routes/api/qwik-router/api.json
@@ -143,6 +143,20 @@
       "mdFile": "router.documentheadprops.md"
     },
     {
+      "name": "DocumentHeadTags",
+      "id": "documentheadtags",
+      "hierarchy": [
+        {
+          "name": "DocumentHeadTags",
+          "id": "documentheadtags"
+        }
+      ],
+      "kind": "Variable",
+      "content": "This renders all the tags collected from `head`<!-- -->.\n\nYou can partially override the head, for example if you want to change the title:\n\n```tsx\nimport { DocumentHeadTags, useDocumentHead } from '@qwik.dev/router';\n\nexport default component$(() => {\n  const head = useDocumentHead();\n  return <DocumentHeadTags title={`${head.title} - My App`} />;\n});\n```\nYou don't have to use this component, you can also do it yourself for full control. Just copy the code from this component and modify it to your needs.\n\nNote that this component normally only runs once, during SSR. You can use Signals in your `src/root.tsx` to make runtime changes to `<head>` if needed.\n\n\n```typescript\nDocumentHeadTags: import(\"@qwik.dev/core\").Component<DocumentHeadValue<Record<string, unknown>>>\n```",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/document-head-tags-component.tsx",
+      "mdFile": "router.documentheadtags.md"
+    },
+    {
       "name": "DocumentHeadValue",
       "id": "documentheadvalue",
       "hierarchy": [
@@ -152,7 +166,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface DocumentHeadValue<FrontMatter extends Record<string, any> = Record<string, unknown>> \n```\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n[frontmatter?](./router.documentheadvalue.frontmatter.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nReadonly&lt;FrontMatter&gt;\n\n\n</td><td>\n\n_(Optional)_ Arbitrary object containing custom data. When the document head is created from markdown files, the frontmatter attributes that are not recognized as a well-known meta names (such as title, description, author, etc...), are stored in this property.\n\n\n</td></tr>\n<tr><td>\n\n[links?](./router.documentheadvalue.links.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nreadonly [DocumentLink](#documentlink)<!-- -->\\[\\]\n\n\n</td><td>\n\n_(Optional)_ Used to manually append `<link>` elements to the `<head>`<!-- -->.\n\n\n</td></tr>\n<tr><td>\n\n[meta?](./router.documentheadvalue.meta.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nreadonly [DocumentMeta](#documentmeta)<!-- -->\\[\\]\n\n\n</td><td>\n\n_(Optional)_ Used to manually set meta tags in the head. Additionally, the `data` property could be used to set arbitrary data which the `<head>` component could later use to generate `<meta>` tags.\n\n\n</td></tr>\n<tr><td>\n\n[scripts?](./router.documentheadvalue.scripts.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nreadonly [DocumentScript](#documentscript)<!-- -->\\[\\]\n\n\n</td><td>\n\n_(Optional)_ Used to manually append `<script>` elements to the `<head>`<!-- -->.\n\n\n</td></tr>\n<tr><td>\n\n[styles?](./router.documentheadvalue.styles.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nreadonly [DocumentStyle](#documentstyle)<!-- -->\\[\\]\n\n\n</td><td>\n\n_(Optional)_ Used to manually append `<style>` elements to the `<head>`<!-- -->.\n\n\n</td></tr>\n<tr><td>\n\n[title?](./router.documentheadvalue.title.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_ Sets `document.title`<!-- -->.\n\n\n</td></tr>\n</tbody></table>",
+      "content": "```typescript\nexport interface DocumentHeadValue<FrontMatter extends Record<string, any> = Record<string, unknown>> \n```\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n[frontmatter?](./router.documentheadvalue.frontmatter.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nReadonly&lt;FrontMatter&gt;\n\n\n</td><td>\n\n_(Optional)_ Arbitrary object containing custom data. When the document head is created from markdown files, the frontmatter attributes that are not recognized as a well-known meta names (such as title, description, author, etc...), are stored in this property.\n\n\n</td></tr>\n<tr><td>\n\n[links?](./router.documentheadvalue.links.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nreadonly [DocumentLink](#documentlink)<!-- -->\\[\\]\n\n\n</td><td>\n\n_(Optional)_ Used to manually append `<link>` elements to the `<head>`<!-- -->.\n\n\n</td></tr>\n<tr><td>\n\n[meta?](./router.documentheadvalue.meta.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nreadonly [DocumentMeta](#documentmeta)<!-- -->\\[\\]\n\n\n</td><td>\n\n_(Optional)_ Used to manually set meta tags in the head.\n\n\n</td></tr>\n<tr><td>\n\n[scripts?](./router.documentheadvalue.scripts.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nreadonly [DocumentScript](#documentscript)<!-- -->\\[\\]\n\n\n</td><td>\n\n_(Optional)_ Used to manually append `<script>` elements to the `<head>`<!-- -->.\n\n\n</td></tr>\n<tr><td>\n\n[styles?](./router.documentheadvalue.styles.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nreadonly [DocumentStyle](#documentstyle)<!-- -->\\[\\]\n\n\n</td><td>\n\n_(Optional)_ Used to manually append `<style>` elements to the `<head>`<!-- -->.\n\n\n</td></tr>\n<tr><td>\n\n[title?](./router.documentheadvalue.title.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_ Sets `document.title`<!-- -->.\n\n\n</td></tr>\n</tbody></table>",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts",
       "mdFile": "router.documentheadvalue.md"
     },
@@ -165,8 +179,8 @@
           "id": "documentlink"
         }
       ],
-      "kind": "Interface",
-      "content": "```typescript\nexport interface DocumentLink \n```\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n[as?](./router.documentlink.as.md)\n\n\n</td><td>\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[crossorigin?](./router.documentlink.crossorigin.md)\n\n\n</td><td>\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[disabled?](./router.documentlink.disabled.md)\n\n\n</td><td>\n\n\n</td><td>\n\nboolean\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[href?](./router.documentlink.href.md)\n\n\n</td><td>\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[hreflang?](./router.documentlink.hreflang.md)\n\n\n</td><td>\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[id?](./router.documentlink.id.md)\n\n\n</td><td>\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[imagesizes?](./router.documentlink.imagesizes.md)\n\n\n</td><td>\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[imagesrcset?](./router.documentlink.imagesrcset.md)\n\n\n</td><td>\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[integrity?](./router.documentlink.integrity.md)\n\n\n</td><td>\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[key?](./router.documentlink.key.md)\n\n\n</td><td>\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[media?](./router.documentlink.media.md)\n\n\n</td><td>\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[prefetch?](./router.documentlink.prefetch.md)\n\n\n</td><td>\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[referrerpolicy?](./router.documentlink.referrerpolicy.md)\n\n\n</td><td>\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[rel?](./router.documentlink.rel.md)\n\n\n</td><td>\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[sizes?](./router.documentlink.sizes.md)\n\n\n</td><td>\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[title?](./router.documentlink.title.md)\n\n\n</td><td>\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[type?](./router.documentlink.type.md)\n\n\n</td><td>\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>",
+      "kind": "TypeAlias",
+      "content": "```typescript\nexport type DocumentLink = QwikIntrinsicElements['link'];\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts",
       "mdFile": "router.documentlink.md"
     },
@@ -179,8 +193,8 @@
           "id": "documentmeta"
         }
       ],
-      "kind": "Interface",
-      "content": "```typescript\nexport interface DocumentMeta \n```\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n[content?](./router.documentmeta.content.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[httpEquiv?](./router.documentmeta.httpequiv.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[itemprop?](./router.documentmeta.itemprop.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[key?](./router.documentmeta.key.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[media?](./router.documentmeta.media.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[name?](./router.documentmeta.name.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[property?](./router.documentmeta.property.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>",
+      "kind": "TypeAlias",
+      "content": "```typescript\nexport type DocumentMeta = QwikIntrinsicElements['meta'];\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts",
       "mdFile": "router.documentmeta.md"
     },
@@ -193,8 +207,8 @@
           "id": "documentscript"
         }
       ],
-      "kind": "Interface",
-      "content": "> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.\n> \n\n\n\n```typescript\nexport interface DocumentScript \n```\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n[key?](./router.documentscript.key.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n**_(BETA)_** _(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[props?](./router.documentscript.props.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nReadonly&lt;QwikIntrinsicElements\\['script'\\]&gt;\n\n\n</td><td>\n\n**_(BETA)_** _(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[script?](./router.documentscript.script.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n**_(BETA)_** _(Optional)_\n\n\n</td></tr>\n</tbody></table>",
+      "kind": "TypeAlias",
+      "content": "```typescript\nexport type DocumentScript = ((Omit<QwikIntrinsicElements['script'], 'dangerouslySetInnerHTML'> & {\n    props?: never;\n}) | {\n    key?: string;\n    props: Readonly<QwikIntrinsicElements['script']>;\n}) & ({\n    script?: string;\n    dangerouslySetInnerHTML?: never;\n} | {\n    dangerouslySetInnerHTML?: string;\n    script?: never;\n});\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts",
       "mdFile": "router.documentscript.md"
     },
@@ -207,8 +221,8 @@
           "id": "documentstyle"
         }
       ],
-      "kind": "Interface",
-      "content": "```typescript\nexport interface DocumentStyle \n```\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n[key?](./router.documentstyle.key.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[props?](./router.documentstyle.props.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nReadonly&lt;QwikIntrinsicElements\\['style'\\]&gt;\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n<tr><td>\n\n[style](./router.documentstyle.style.md)\n\n\n</td><td>\n\n`readonly`\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>",
+      "kind": "TypeAlias",
+      "content": "```typescript\nexport type DocumentStyle = Readonly<((Omit<QwikIntrinsicElements['style'], 'dangerouslySetInnerHTML'> & {\n    props?: never;\n}) | {\n    key?: string;\n    props: Readonly<QwikIntrinsicElements['style']>;\n}) & ({\n    style?: string;\n    dangerouslySetInnerHTML?: never;\n} | {\n    dangerouslySetInnerHTML?: string;\n    style?: never;\n})>;\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts",
       "mdFile": "router.documentstyle.md"
     },

--- a/packages/docs/src/routes/api/qwik-router/index.mdx
+++ b/packages/docs/src/routes/api/qwik-router/index.mdx
@@ -483,6 +483,33 @@ ResolveSyncValue
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts)
 
+## DocumentHeadTags
+
+This renders all the tags collected from `head`.
+
+You can partially override the head, for example if you want to change the title:
+
+```tsx
+import { DocumentHeadTags, useDocumentHead } from "@qwik.dev/router";
+
+export default component$(() => {
+  const head = useDocumentHead();
+  return <DocumentHeadTags title={`${head.title} - My App`} />;
+});
+```
+
+You don't have to use this component, you can also do it yourself for full control. Just copy the code from this component and modify it to your needs.
+
+Note that this component normally only runs once, during SSR. You can use Signals in your `src/root.tsx` to make runtime changes to `<head>` if needed.
+
+```typescript
+DocumentHeadTags: import("@qwik.dev/core").Component<
+  DocumentHeadValue<Record<string, unknown>>
+>;
+```
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/document-head-tags-component.tsx)
+
 ## DocumentHeadValue
 
 ```typescript
@@ -554,7 +581,7 @@ readonly [DocumentMeta](#documentmeta)[]
 
 </td><td>
 
-_(Optional)_ Used to manually set meta tags in the head. Additionally, the `data` property could be used to set arbitrary data which the `<head>` component could later use to generate `<meta>` tags.
+_(Optional)_ Used to manually set meta tags in the head.
 
 </td></tr>
 <tr><td>
@@ -615,584 +642,70 @@ _(Optional)_ Sets `document.title`.
 ## DocumentLink
 
 ```typescript
-export interface DocumentLink
+export type DocumentLink = QwikIntrinsicElements["link"];
 ```
-
-<table><thead><tr><th>
-
-Property
-
-</th><th>
-
-Modifiers
-
-</th><th>
-
-Type
-
-</th><th>
-
-Description
-
-</th></tr></thead>
-<tbody><tr><td>
-
-[as?](./router.documentlink.as.md)
-
-</td><td>
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[crossorigin?](./router.documentlink.crossorigin.md)
-
-</td><td>
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[disabled?](./router.documentlink.disabled.md)
-
-</td><td>
-
-</td><td>
-
-boolean
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[href?](./router.documentlink.href.md)
-
-</td><td>
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[hreflang?](./router.documentlink.hreflang.md)
-
-</td><td>
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[id?](./router.documentlink.id.md)
-
-</td><td>
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[imagesizes?](./router.documentlink.imagesizes.md)
-
-</td><td>
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[imagesrcset?](./router.documentlink.imagesrcset.md)
-
-</td><td>
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[integrity?](./router.documentlink.integrity.md)
-
-</td><td>
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[key?](./router.documentlink.key.md)
-
-</td><td>
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[media?](./router.documentlink.media.md)
-
-</td><td>
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[prefetch?](./router.documentlink.prefetch.md)
-
-</td><td>
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[referrerpolicy?](./router.documentlink.referrerpolicy.md)
-
-</td><td>
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[rel?](./router.documentlink.rel.md)
-
-</td><td>
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[sizes?](./router.documentlink.sizes.md)
-
-</td><td>
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[title?](./router.documentlink.title.md)
-
-</td><td>
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[type?](./router.documentlink.type.md)
-
-</td><td>
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-</tbody></table>
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts)
 
 ## DocumentMeta
 
 ```typescript
-export interface DocumentMeta
+export type DocumentMeta = QwikIntrinsicElements["meta"];
 ```
-
-<table><thead><tr><th>
-
-Property
-
-</th><th>
-
-Modifiers
-
-</th><th>
-
-Type
-
-</th><th>
-
-Description
-
-</th></tr></thead>
-<tbody><tr><td>
-
-[content?](./router.documentmeta.content.md)
-
-</td><td>
-
-`readonly`
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[httpEquiv?](./router.documentmeta.httpequiv.md)
-
-</td><td>
-
-`readonly`
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[itemprop?](./router.documentmeta.itemprop.md)
-
-</td><td>
-
-`readonly`
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[key?](./router.documentmeta.key.md)
-
-</td><td>
-
-`readonly`
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[media?](./router.documentmeta.media.md)
-
-</td><td>
-
-`readonly`
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[name?](./router.documentmeta.name.md)
-
-</td><td>
-
-`readonly`
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[property?](./router.documentmeta.property.md)
-
-</td><td>
-
-`readonly`
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-</tbody></table>
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts)
 
 ## DocumentScript
 
-> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
-
 ```typescript
-export interface DocumentScript
+export type DocumentScript = (
+  | (Omit<QwikIntrinsicElements["script"], "dangerouslySetInnerHTML"> & {
+      props?: never;
+    })
+  | {
+      key?: string;
+      props: Readonly<QwikIntrinsicElements["script"]>;
+    }
+) &
+  (
+    | {
+        script?: string;
+        dangerouslySetInnerHTML?: never;
+      }
+    | {
+        dangerouslySetInnerHTML?: string;
+        script?: never;
+      }
+  );
 ```
-
-<table><thead><tr><th>
-
-Property
-
-</th><th>
-
-Modifiers
-
-</th><th>
-
-Type
-
-</th><th>
-
-Description
-
-</th></tr></thead>
-<tbody><tr><td>
-
-[key?](./router.documentscript.key.md)
-
-</td><td>
-
-`readonly`
-
-</td><td>
-
-string
-
-</td><td>
-
-**_(BETA)_** _(Optional)_
-
-</td></tr>
-<tr><td>
-
-[props?](./router.documentscript.props.md)
-
-</td><td>
-
-`readonly`
-
-</td><td>
-
-Readonly&lt;QwikIntrinsicElements['script']&gt;
-
-</td><td>
-
-**_(BETA)_** _(Optional)_
-
-</td></tr>
-<tr><td>
-
-[script?](./router.documentscript.script.md)
-
-</td><td>
-
-`readonly`
-
-</td><td>
-
-string
-
-</td><td>
-
-**_(BETA)_** _(Optional)_
-
-</td></tr>
-</tbody></table>
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts)
 
 ## DocumentStyle
 
 ```typescript
-export interface DocumentStyle
+export type DocumentStyle = Readonly<
+  (
+    | (Omit<QwikIntrinsicElements["style"], "dangerouslySetInnerHTML"> & {
+        props?: never;
+      })
+    | {
+        key?: string;
+        props: Readonly<QwikIntrinsicElements["style"]>;
+      }
+  ) &
+    (
+      | {
+          style?: string;
+          dangerouslySetInnerHTML?: never;
+        }
+      | {
+          dangerouslySetInnerHTML?: string;
+          style?: never;
+        }
+    )
+>;
 ```
-
-<table><thead><tr><th>
-
-Property
-
-</th><th>
-
-Modifiers
-
-</th><th>
-
-Type
-
-</th><th>
-
-Description
-
-</th></tr></thead>
-<tbody><tr><td>
-
-[key?](./router.documentstyle.key.md)
-
-</td><td>
-
-`readonly`
-
-</td><td>
-
-string
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[props?](./router.documentstyle.props.md)
-
-</td><td>
-
-`readonly`
-
-</td><td>
-
-Readonly&lt;QwikIntrinsicElements['style']&gt;
-
-</td><td>
-
-_(Optional)_
-
-</td></tr>
-<tr><td>
-
-[style](./router.documentstyle.style.md)
-
-</td><td>
-
-`readonly`
-
-</td><td>
-
-string
-
-</td><td>
-
-</td></tr>
-</tbody></table>
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts)
 

--- a/packages/docs/src/routes/docs/(qwikrouter)/api/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikrouter)/api/index.mdx
@@ -44,73 +44,115 @@ Menus are contextual data declared with `menu.md` files. See [menus file definit
 
 ## `useDocumentHead()`
 
-Use the `useDocumentHead()` function to read the document [head metadata](/docs/(qwikrouter)/pages/index.mdx#head-export).
+Use the `useDocumentHead()` function to read the document [head metadata](/docs/(qwikrouter)/pages/index.mdx#head-export) that is generated from `head` exports and markdown files.
 
-`useDocumentHead()` retrieves a readonly `DocumentHead` object that includes:
+`useDocumentHead()` retrieves a readonly `DocumentHeadValue` object:
 
 ```ts
-export interface DocumentHead {
-  /**
-   * Represents the `<title>` element of the document.
-   */
+export interface DocumentHeadValue<
+  FrontMatter extends Record<string, any> = Record<string, unknown>,
+> {
+  /** Sets `document.title`. */
   readonly title?: string;
-  /**
-   * Used to manually set meta tags in the head. Additionally, the `data`
-   * property could be used to set arbitrary data which the `<head>` component
-   * could later use to generate `<meta>` tags.
-   */
+  /** Used to manually set meta tags in the head. */
   readonly meta?: readonly DocumentMeta[];
-  /**
-   * Used to manually append `<link>` elements to the `<head>`.
-   */
+  /** Used to manually append `<link>` elements to the `<head>`. */
   readonly links?: readonly DocumentLink[];
-  /**
-   * Used to manually append `<style>` elements to the `<head>`.
-   */
+  /** Used to manually append `<style>` elements to the `<head>`. */
   readonly styles?: readonly DocumentStyle[];
+  /** Used to manually append `<script>` elements to the `<head>`. */
+  readonly scripts?: readonly DocumentScript[];
   /**
-   * Arbitrary object containing custom data. When the document head is created from
-   * markdown files, the frontmatter attributes that are not recognized as a well-known
-   * meta names (such as title, description, author, etc...), are stored in this property.
+   * Arbitrary object containing custom data. When the document head is created from markdown files,
+   * the frontmatter attributes that are not recognized as a well-known meta names (such as title,
+   * description, author, etc...), are stored in this property.
    */
-  readonly frontmatter?: Readonly<Record<string, any>>;
+  readonly frontmatter?: Readonly<FrontMatter>;
 }
 ```
 
-All starters include a `<RouterHead>` component that is responsible for generating the `<head>` element of the document. It uses the `useDocumentHead()` function to retrieve the current head metadata and render the appropriate `<meta>`, `<link>`, `<style>` and `<title>` elements.
+To get this data into the `<head>` element of the document, you can do it manually, for example:
 
-```tsx title="src/components/router-head/router-head.tsx"
-import { component$ } from '@qwik.dev/core';
-import { useDocumentHead } from '@qwik.dev/router';
+```tsx
+import { component$ } from "@qwik.dev/core";
+import { useDocumentHead } from "@qwik.dev/router";
 
-/**
- * The RouterHead component is placed inside of the document `<head>` element.
- */
+/** Use inside of the `<head>` element in `src/root.tsx` */
 export const RouterHead = component$(() => {
   const head = useDocumentHead();
 
   return (
     <>
-      <title>{head.title}</title>
-
-      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-
+      {head.title && <title>{head.title}</title>}
       {head.meta.map((m) => (
         <meta {...m} />
       ))}
-
       {head.links.map((l) => (
         <link {...l} />
       ))}
-
-      {head.styles.map((s) => (
-        <style {...s.props} dangerouslySetInnerHTML={s.style} />
-      ))}
+      {head.styles.map((s) => {
+        // Support for the old `props` property
+        const props = s.props || s;
+        return (
+          <style
+            {...props}
+            dangerouslySetInnerHTML={s.style || props.dangerouslySetInnerHTML}
+            key={s.key}
+          />
+        );
+      })}
+      {head.scripts.map((s) => {
+        // Support for the old `props` property
+        const props = s.props || s;
+        return (
+          <script
+            {...props}
+            dangerouslySetInnerHTML={s.script || props.dangerouslySetInnerHTML}
+            key={s.key}
+          />
+        );
+      })}
     </>
   );
 });
 ```
+
+You can also use the [`DocumentHeadTags`](#documentheadtags) component to render the head tags.
+
+## `<DocumentHeadTags>`
+
+The `<DocumentHeadTags>` component renders the head tags collected from `head` exports and markdown files.
+
+Place it inside of the `<head>` element in `src/root.tsx`:
+
+```tsx
+// ...
+      <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+        <link rel="canonical" href={loc.url.href} />
+        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+
+        <DocumentHeadTags />
+      </head>
+// ...
+```
+
+You can partially override the head, for example if you want to change the title:
+
+```tsx
+import { DocumentHeadTags, useDocumentHead } from '@qwik.dev/router';
+
+export default component$(() => {
+  const head = useDocumentHead();
+  return <DocumentHeadTags title={`${head.title} - My App`} />;
+});
+```
+
+You don't have to use this component, you can also do it yourself for full control. Just copy the code from this component and modify it to your needs.
+
+Note that this component normally only runs once, during SSR. You can use Signals in your `src/root.tsx` to make runtime changes to `<head>` if needed.
 
 ## `useLocation()`
 

--- a/packages/qwik-router/src/runtime/src/document-head-tags-component.tsx
+++ b/packages/qwik-router/src/runtime/src/document-head-tags-component.tsx
@@ -1,0 +1,66 @@
+import { component$ } from '@qwik.dev/core';
+import { useDocumentHead } from '.';
+import type { DocumentHeadValue } from './types';
+
+/**
+ * This renders all the tags collected from `head`.
+ *
+ * You can partially override the head, for example if you want to change the title:
+ *
+ * ```tsx
+ * import { DocumentHeadTags, useDocumentHead } from '@qwik.dev/router';
+ *
+ * export default component$(() => {
+ *   const head = useDocumentHead();
+ *   return <DocumentHeadTags title={`${head.title} - My App`} />;
+ * });
+ * ```
+ *
+ * You don't have to use this component, you can also do it yourself for full control. Just copy the
+ * code from this component and modify it to your needs.
+ *
+ * Note that this component normally only runs once, during SSR. You can use Signals in your
+ * `src/root.tsx` to make runtime changes to `<head>` if needed.
+ *
+ * @public
+ */
+export const DocumentHeadTags = component$((props: DocumentHeadValue) => {
+  let head = useDocumentHead();
+  if (props) {
+    head = { ...head, ...props };
+  }
+
+  return (
+    <>
+      {head.title && <title>{head.title}</title>}
+      {head.meta.map((m) => (
+        <meta {...m} />
+      ))}
+      {head.links.map((l) => (
+        <link {...l} />
+      ))}
+      {head.styles.map((s) => {
+        // Support for the old `props` property
+        const props = s.props || s;
+        return (
+          <style
+            {...props}
+            dangerouslySetInnerHTML={s.style || props.dangerouslySetInnerHTML}
+            key={s.key}
+          />
+        );
+      })}
+      {head.scripts.map((s) => {
+        // Support for the old `props` property
+        const props = s.props || s;
+        return (
+          <script
+            {...props}
+            dangerouslySetInnerHTML={s.script || props.dangerouslySetInnerHTML}
+            key={s.key}
+          />
+        );
+      })}
+    </>
+  );
+});

--- a/packages/qwik-router/src/runtime/src/head.ts
+++ b/packages/qwik-router/src/runtime/src/head.ts
@@ -76,11 +76,12 @@ const resolveDocumentHead = (
 };
 
 const mergeArray = (
-  existingArr: { key?: string }[],
-  newArr: readonly { key?: string }[] | undefined
+  existingArr: { key?: string | number | null }[],
+  newArr: readonly { key?: string | number | null }[] | undefined
 ) => {
   if (Array.isArray(newArr)) {
     for (const newItem of newArr) {
+      // items with the same string key are replaced
       if (typeof newItem.key === 'string') {
         const existingIndex = existingArr.findIndex((i) => i.key === newItem.key);
         if (existingIndex > -1) {

--- a/packages/qwik-router/src/runtime/src/index.ts
+++ b/packages/qwik-router/src/runtime/src/index.ts
@@ -116,3 +116,5 @@ export {
   type RendererOptions,
   type RendererOutputOptions,
 } from './create-renderer';
+
+export { DocumentHeadTags } from './document-head-tags-component';

--- a/packages/qwik-router/src/runtime/src/qwik-router.runtime.api.md
+++ b/packages/qwik-router/src/runtime/src/qwik-router.runtime.api.md
@@ -127,92 +127,52 @@ export interface DocumentHeadProps extends RouteLocation {
     readonly withLocale: <T>(fn: () => T) => T;
 }
 
+// @public
+export const DocumentHeadTags: Component<DocumentHeadValue<Record<string, unknown>>>;
+
 // @public (undocumented)
 export interface DocumentHeadValue<FrontMatter extends Record<string, any> = Record<string, unknown>> {
     readonly frontmatter?: Readonly<FrontMatter>;
     readonly links?: readonly DocumentLink[];
     readonly meta?: readonly DocumentMeta[];
-    // Warning: (ae-incompatible-release-tags) The symbol "scripts" is marked as @public, but its signature references "DocumentScript" which is marked as @beta
     readonly scripts?: readonly DocumentScript[];
     readonly styles?: readonly DocumentStyle[];
     readonly title?: string;
 }
 
 // @public (undocumented)
-export interface DocumentLink {
-    // (undocumented)
-    as?: string;
-    // (undocumented)
-    crossorigin?: string;
-    // (undocumented)
-    disabled?: boolean;
-    // (undocumented)
-    href?: string;
-    // (undocumented)
-    hreflang?: string;
-    // (undocumented)
-    id?: string;
-    // (undocumented)
-    imagesizes?: string;
-    // (undocumented)
-    imagesrcset?: string;
-    // (undocumented)
-    integrity?: string;
-    // (undocumented)
+export type DocumentLink = QwikIntrinsicElements['link'];
+
+// @public (undocumented)
+export type DocumentMeta = QwikIntrinsicElements['meta'];
+
+// @public (undocumented)
+export type DocumentScript = ((Omit<QwikIntrinsicElements['script'], 'dangerouslySetInnerHTML'> & {
+    props?: never;
+}) | {
     key?: string;
-    // (undocumented)
-    media?: string;
-    // (undocumented)
-    prefetch?: string;
-    // (undocumented)
-    referrerpolicy?: string;
-    // (undocumented)
-    rel?: string;
-    // (undocumented)
-    sizes?: string;
-    // (undocumented)
-    title?: string;
-    // (undocumented)
-    type?: string;
-}
+    props: Readonly<QwikIntrinsicElements['script']>;
+}) & ({
+    script?: string;
+    dangerouslySetInnerHTML?: never;
+} | {
+    dangerouslySetInnerHTML?: string;
+    script?: never;
+});
 
 // @public (undocumented)
-export interface DocumentMeta {
-    // (undocumented)
-    readonly content?: string;
-    // (undocumented)
-    readonly httpEquiv?: string;
-    // (undocumented)
-    readonly itemprop?: string;
-    // (undocumented)
-    readonly key?: string;
-    // (undocumented)
-    readonly media?: string;
-    // (undocumented)
-    readonly name?: string;
-    // (undocumented)
-    readonly property?: string;
-}
-
-// @beta (undocumented)
-export interface DocumentScript {
-    // (undocumented)
-    readonly key?: string;
-    // (undocumented)
-    readonly props?: Readonly<QwikIntrinsicElements['script']>;
-    // (undocumented)
-    readonly script?: string;
-}
-
-// @public (undocumented)
-export interface DocumentStyle {
-    // (undocumented)
-    readonly key?: string;
-    // (undocumented)
-    readonly props?: Readonly<QwikIntrinsicElements['style']>;
-    // (undocumented)
-    readonly style: string;
-}
+export type DocumentStyle = Readonly<((Omit<QwikIntrinsicElements['style'], 'dangerouslySetInnerHTML'> & {
+    props?: never;
+}) | {
+    key?: string;
+    props: Readonly<QwikIntrinsicElements['style']>;
+}) & ({
+    style?: string;
+    dangerouslySetInnerHTML?: never;
+} | {
+    dangerouslySetInnerHTML?: string;
+    style?: never;
+})>;
 
 // Warning: (ae-forgotten-export) The symbol "ErrorBoundaryProps" needs to be exported by the entry point index.d.ts
 //

--- a/packages/qwik-router/src/runtime/src/types.ts
+++ b/packages/qwik-router/src/runtime/src/types.ts
@@ -147,10 +147,7 @@ export interface DocumentHeadValue<
 > {
   /** Sets `document.title`. */
   readonly title?: string;
-  /**
-   * Used to manually set meta tags in the head. Additionally, the `data` property could be used to
-   * set arbitrary data which the `<head>` component could later use to generate `<meta>` tags.
-   */
+  /** Used to manually set meta tags in the head. */
   readonly meta?: readonly DocumentMeta[];
   /** Used to manually append `<link>` elements to the `<head>`. */
   readonly links?: readonly DocumentLink[];
@@ -172,50 +169,54 @@ export type ResolvedDocumentHead<
 > = Required<DocumentHeadValue<FrontMatter>>;
 
 /** @public */
-export interface DocumentMeta {
-  readonly content?: string;
-  readonly httpEquiv?: string;
-  readonly name?: string;
-  readonly property?: string;
-  readonly key?: string;
-  readonly itemprop?: string;
-  readonly media?: string;
-}
+export type DocumentMeta = QwikIntrinsicElements['meta'];
 
 /** @public */
-export interface DocumentLink {
-  as?: string;
-  crossorigin?: string;
-  disabled?: boolean;
-  href?: string;
-  hreflang?: string;
-  id?: string;
-  imagesizes?: string;
-  imagesrcset?: string;
-  integrity?: string;
-  media?: string;
-  prefetch?: string;
-  referrerpolicy?: string;
-  rel?: string;
-  sizes?: string;
-  title?: string;
-  type?: string;
-  key?: string;
-}
+export type DocumentLink = QwikIntrinsicElements['link'];
 
 /** @public */
-export interface DocumentStyle {
-  readonly style: string;
-  readonly props?: Readonly<QwikIntrinsicElements['style']>;
-  readonly key?: string;
-}
+export type DocumentStyle = Readonly<
+  (
+    | (Omit<QwikIntrinsicElements['style'], 'dangerouslySetInnerHTML'> & { props?: never })
+    | {
+        key?: string;
+        /**
+         * The props of the style element. @deprecated Prefer setting the properties directly
+         * instead of using this property.
+         */
+        props: Readonly<QwikIntrinsicElements['style']>;
+      }
+  ) &
+    (
+      | {
+          /** The inline style content. */
+          style?: string;
+          dangerouslySetInnerHTML?: never;
+        }
+      | { dangerouslySetInnerHTML?: string; style?: never }
+    )
+>;
 
-/** @beta */
-export interface DocumentScript {
-  readonly script?: string;
-  readonly props?: Readonly<QwikIntrinsicElements['script']>;
-  readonly key?: string;
-}
+/** @public */
+export type DocumentScript = (
+  | (Omit<QwikIntrinsicElements['script'], 'dangerouslySetInnerHTML'> & { props?: never })
+  | {
+      key?: string;
+      /**
+       * The props of the script element. @deprecated Prefer setting the properties directly instead
+       * of using this property.
+       */
+      props: Readonly<QwikIntrinsicElements['script']>;
+    }
+) &
+  (
+    | {
+        /** The inline script content. */
+        script?: string;
+        dangerouslySetInnerHTML?: never;
+      }
+    | { dangerouslySetInnerHTML?: string; script?: never }
+  );
 
 /** @public */
 export interface DocumentHeadProps extends RouteLocation {

--- a/starters/apps/empty/src/components/router-head/router-head.tsx
+++ b/starters/apps/empty/src/components/router-head/router-head.tsx
@@ -1,32 +1,18 @@
-import { useDocumentHead, useLocation } from "@qwik.dev/router";
 import { component$ } from "@qwik.dev/core";
+import { useLocation } from "@qwik.dev/router";
 
 /**
  * The RouterHead component is placed inside of the document `<head>` element.
  */
 export const RouterHead = component$(() => {
-  const head = useDocumentHead();
   const loc = useLocation();
 
   return (
     <>
-      <title>{head.title}</title>
-
       <link rel="canonical" href={loc.url.href} />
-      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 
-      {head.meta.map((m) => (
-        <meta key={m.key} {...m} />
-      ))}
-
-      {head.links.map((l) => (
-        <link key={l.key} {...l} />
-      ))}
-
-      {head.styles.map((s) => (
-        <style key={s.key} {...s.props} dangerouslySetInnerHTML={s.style} />
-      ))}
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     </>
   );
 });

--- a/starters/apps/empty/src/root.tsx
+++ b/starters/apps/empty/src/root.tsx
@@ -1,5 +1,9 @@
 import { component$, isDev } from "@qwik.dev/core";
-import { QwikRouterProvider, RouterOutlet } from "@qwik.dev/router";
+import {
+  DocumentHeadTags,
+  QwikRouterProvider,
+  RouterOutlet,
+} from "@qwik.dev/router";
 import { RouterHead } from "./components/router-head/router-head";
 
 import "./global.css";
@@ -22,9 +26,10 @@ export default component$(() => {
             href={`${import.meta.env.BASE_URL}manifest.json`}
           />
         )}
+        <DocumentHeadTags />
         <RouterHead />
       </head>
-      <body lang="en">
+      <body>
         <RouterOutlet />
       </body>
     </QwikRouterProvider>

--- a/starters/apps/playground/src/components/router-head/router-head.tsx
+++ b/starters/apps/playground/src/components/router-head/router-head.tsx
@@ -1,37 +1,18 @@
-import { useDocumentHead, useLocation } from "@qwik.dev/router";
-
 import { component$ } from "@qwik.dev/core";
+import { useLocation } from "@qwik.dev/router";
 
 /**
  * The RouterHead component is placed inside of the document `<head>` element.
  */
 export const RouterHead = component$(() => {
-  const head = useDocumentHead();
   const loc = useLocation();
 
   return (
     <>
-      <title>{head.title}</title>
-
       <link rel="canonical" href={loc.url.href} />
-      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 
-      {head.meta.map((m) => (
-        <meta key={m.key} {...m} />
-      ))}
-
-      {head.links.map((l) => (
-        <link key={l.key} {...l} />
-      ))}
-
-      {head.styles.map((s) => (
-        <style key={s.key} {...s.props} dangerouslySetInnerHTML={s.style} />
-      ))}
-
-      {head.scripts.map((s) => (
-        <script key={s.key} {...s.props} dangerouslySetInnerHTML={s.script} />
-      ))}
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     </>
   );
 });

--- a/starters/apps/playground/src/root.tsx
+++ b/starters/apps/playground/src/root.tsx
@@ -1,5 +1,9 @@
 import { component$, isDev } from "@qwik.dev/core";
-import { QwikRouterProvider, RouterOutlet } from "@qwik.dev/router";
+import {
+  DocumentHeadTags,
+  QwikRouterProvider,
+  RouterOutlet,
+} from "@qwik.dev/router";
 import { RouterHead } from "./components/router-head/router-head";
 
 import "./global.css";
@@ -22,9 +26,10 @@ export default component$(() => {
             href={`${import.meta.env.BASE_URL}manifest.json`}
           />
         )}
+        <DocumentHeadTags />
         <RouterHead />
       </head>
-      <body lang="en">
+      <body>
         <RouterOutlet />
       </body>
     </QwikRouterProvider>

--- a/starters/apps/qwikrouter-test/src/components/router-head/router-head.tsx
+++ b/starters/apps/qwikrouter-test/src/components/router-head/router-head.tsx
@@ -1,50 +1,28 @@
-import { useDocumentHead, useLocation } from "@qwik.dev/router";
 import { component$ } from "@qwik.dev/core";
+import {
+  DocumentHeadTags,
+  useDocumentHead,
+  useLocation,
+} from "@qwik.dev/router";
 import { Social } from "./social";
 import { Vendor } from "./vendor";
 
 export const RouterHead = component$(() => {
-  const head = useDocumentHead();
   const loc = useLocation();
+
+  const head = useDocumentHead();
 
   const title = head.title ? `${head.title} - Qwik` : `Qwik`;
   return (
     <>
-      <title>{title}</title>
       <link rel="canonical" href={loc.url.href} />
       <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
       <meta name="viewport" content="width=device-width" />
 
+      <DocumentHeadTags title={title} />
+
       <Social loc={loc} head={head} />
       <Vendor loc={loc} />
-
-      {head.meta.map((m) => (
-        <meta {...m} />
-      ))}
-
-      {head.links.map((l) => (
-        <link {...l} />
-      ))}
-
-      {head.styles.map((s) => (
-        <style
-          key={s.key}
-          {...s.props}
-          {...(s.props?.dangerouslySetInnerHTML
-            ? {}
-            : { dangerouslySetInnerHTML: s.style })}
-        />
-      ))}
-
-      {head.scripts.map((s) => (
-        <script
-          key={s.key}
-          {...s.props}
-          {...(s.props?.dangerouslySetInnerHTML
-            ? {}
-            : { dangerouslySetInnerHTML: s.script })}
-        />
-      ))}
     </>
   );
 });


### PR DESCRIPTION
This component renders the head tags from `head` exports correctly, including the scripts that were added later.

This reduces mistakes and makes the starters cleaner.

Furthermore, the styles and scripts types now allow setting props directly, which is like meta and links.