### PR TITLE
docs: fix up select color

### DIFF
--- a/packages/docs/src/repl/repl.css
+++ b/packages/docs/src/repl/repl.css
@@ -335,6 +335,7 @@
 }
 
 .detail-options select {
+  background-color: var(--repl-tab-bg-color);
   border: 1px solid var(--repl-tab-bg-color);
   border-radius: 3px;
 }


### PR DESCRIPTION
## The issue is with dark mode

## Before

<img width="1017" height="580" alt="error" src="https://github.com/user-attachments/assets/42c0ce7a-cd48-4db5-b195-251cfcdb6b99" />

### After

Dark 

<img width="1030" height="614" alt="ok" src="https://github.com/user-attachments/assets/611c9b5d-2ab1-433a-837b-3698e39a45fb" />

light

<img width="624" height="514" alt="image" src="https://github.com/user-attachments/assets/4f6e35ef-0f2e-4c5b-81a9-8e709c9567f3" />