### PR TITLE
docs: fix up repl issue 🥗

### DIFF
--- a/packages/docs/src/repl/repl.tsx
+++ b/packages/docs/src/repl/repl.tsx
@@ -180,6 +180,8 @@ const getDependencies = (input: ReplAppInput) => {
       `${prefix}server.cjs`,
       `/bindings/qwik.wasm.cjs`,
       `/bindings/qwik_wasm_bg.wasm`,
+      `${prefix}qwikloader.js`,
+      `${prefix}preloader.mjs`,
     ]) {
       out[QWIK_PKG_NAME][p] = getNpmCdnUrl(bundled, QWIK_PKG_NAME, input.version, p);
     }


### PR DESCRIPTION
Fix up this issue in the repl

```
Error: No URL given for dep: @builder.io/qwik/dist/preloader.mjs at m
(https://xxxx.dev/repl/repl-sw.js:1:286)
at Object.load (https://xxxx.dev/repl/repl-sw.js:1:3475)
at eval (eval at w (https://xxxx.dev/repl/repl-sw.js:1:626),
<anonymous>:12:372180)
```