### PR TITLE
fix: service-worker.js and qwik-prefetch-service-worker.js unregistering

### DIFF
--- a/.changeset/early-eels-listen.md
+++ b/.changeset/early-eels-listen.md
@@ -1,0 +1,6 @@
+---
+'@builder.io/qwik': patch
+'@builder.io/qwik-city': patch
+---
+
+PATCH: Keeping the service worker components now properly unregisters them.

--- a/packages/qwik-city/src/runtime/src/sw-register.ts
+++ b/packages/qwik-city/src/runtime/src/sw-register.ts
@@ -2,7 +2,14 @@
 
 (() => {
   if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.register('__url').catch((e) => console.error(e));
+    navigator.serviceWorker.getRegistrations().then((regs) => {
+      for (const reg of regs) {
+        const url = '__url'.split('/').pop();
+        if (reg.active?.scriptURL.endsWith(url || 'service-worker.js')) {
+          reg.unregister().catch(console.error);
+        }
+      }
+    });
   } else {
     // eslint-disable-next-line no-console
     console.log('Service worker not supported in this browser.');

--- a/packages/qwik/src/core/components/prefetch.ts
+++ b/packages/qwik/src/core/components/prefetch.ts
@@ -42,7 +42,7 @@ export const PrefetchServiceWorker = (opts: {
     // the file 'qwik-prefetch-service-worker.js' is not located in /build/
     resolvedOpts.path = baseUrl + resolvedOpts.path;
   }
-  let code = PREFETCH_CODE.replace("'_URL_'", JSON.stringify(resolvedOpts.path));
+  let code = PREFETCH_CODE.replace('"_URL_"', JSON.stringify(resolvedOpts.path.split('/').pop()));
   if (!isDev) {
     // consecutive spaces are indentation
     code = code.replaceAll(/\s\s+/gm, '');


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Bug

# Description

The service-workers components were not unregistering.

I checked that this works for both on a small repro.

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
