### PR TITLE
FIX: cover OpenInEditor windows edge cases once and for all

### DIFF
--- a/.changeset/tangy-islands-return.md
+++ b/.changeset/tangy-islands-return.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': minor
+---
+
+cover edge cases for windows with vite OpenInEditor

--- a/.changeset/thirty-monkeys-knock.md
+++ b/.changeset/thirty-monkeys-knock.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': patch
+---
+
+FIX: fix up open in editor feature

--- a/packages/qwik/src/optimizer/src/plugins/click-to-component.html
+++ b/packages/qwik/src/optimizer/src/plugins/click-to-component.html
@@ -149,22 +149,60 @@
 
     globalThis.qwikOpenInEditor = function (path) {
       const isWindows = navigator.platform.includes('Win');
-      const resolvedURL = new URL(path, isWindows ? origin : srcDir);
-      const prefix = isWindows ? srcDir : srcDir.replace('http://local.local', '');
-      const params = new URLSearchParams();
-      const filePath =
-        resolvedURL.protocol === 'file:' && resolvedURL.pathname.startsWith('/')
-          ? resolvedURL.pathname.slice(1)
-          : resolvedURL.pathname;
-      let finalPath;
-      if (filePath.startsWith(prefix)) {
-        finalPath = filePath;
-      } else {
-        // remove the extra src from filePath as prefix already contains it
-        const cleaned = filePath.replace(/^[/\\]?src[/\\]/, '');
-        const sep = isWindows ? '\\' : '/';
-        finalPath = prefix.endsWith(sep) ? prefix + cleaned : prefix + sep + cleaned;
+      const baseForURL = isWindows ? origin : srcDir;
+      const resolvedURL = new URL(path, baseForURL);
+
+      let pathname = resolvedURL.pathname || '';
+      if (resolvedURL.protocol === 'file:' && pathname.startsWith('/')) {
+        pathname = pathname.slice(1);
       }
+      if (pathname.startsWith('/@fs')) {
+        pathname = pathname.slice(4);
+      }
+
+      // Normalize slashes and sanitize to lowercase for consistency
+      let normalizedPath = pathname.replace(/\\/g, '/');
+      normalizedPath = normalizedPath.toLowerCase();
+
+      // Extract everything after 'src/'
+      let relativeFromSrc = normalizedPath;
+      const idx = normalizedPath.indexOf('/src/');
+      if (idx !== -1) {
+        relativeFromSrc = normalizedPath.slice(idx + 5);
+      } else if (normalizedPath.startsWith('src/')) {
+        relativeFromSrc = normalizedPath.slice(4);
+      } else if (normalizedPath.startsWith('/src/')) {
+        relativeFromSrc = normalizedPath.slice(5);
+      }
+      relativeFromSrc = relativeFromSrc.replace(/^\/+/, '');
+
+      const isValid =
+        relativeFromSrc.length > 0 &&
+        !relativeFromSrc.includes('..') &&
+        !relativeFromSrc.endsWith('/');
+      if (!isValid) {
+        console.warn('Qwik Click-to-Source: invalid resolved path', {
+          input: path,
+          href: resolvedURL.href,
+          pathname,
+          normalizedPath,
+          relativeFromSrc,
+        });
+        return;
+      }
+
+      let prefix = srcDir;
+      if (!isWindows) {
+        prefix = srcDir.replace('http://local.local', '');
+      }
+      prefix = prefix.replace(/\\/g, '/');
+      if (!prefix.endsWith('/')) {
+        prefix += '/';
+      }
+
+      let finalPath = (prefix + relativeFromSrc).replace(/\\/g, '/').toLowerCase();
+
+      const params = new URLSearchParams();
       params.set('file', finalPath);
       fetch('/__open-in-editor?' + params.toString());
     };

--- a/packages/qwik/src/optimizer/src/plugins/click-to-component.html
+++ b/packages/qwik/src/optimizer/src/plugins/click-to-component.html
@@ -10,6 +10,7 @@
     cursor: pointer;
     z-index: 999999;
   }
+
   #qwik-inspector-info-popup {
     position: fixed;
     bottom: 10px;
@@ -28,13 +29,16 @@
     z-index: 999999;
     contain: layout;
   }
+
   #qwik-inspector-info-popup p {
     margin: 0px;
   }
+
   @-webkit-keyframes fadeOut {
     0% {
       opacity: 1;
     }
+
     100% {
       opacity: 0;
     }
@@ -44,6 +48,7 @@
     0% {
       opacity: 1;
     }
+
     100% {
       opacity: 0;
       visibility: hidden;
@@ -144,28 +149,24 @@
 
     globalThis.qwikOpenInEditor = function (path) {
       const isWindows = navigator.platform.includes('Win');
-      const isMac = navigator.platform.includes('Mac');
       const resolvedURL = new URL(path, isWindows ? origin : srcDir);
-      const prefix = isWindows ? srcDir : '';
-      if (isWindows || isMac) {
-        let finalPath;
-        const params = new URLSearchParams();
-        const filePath =
-          resolvedURL.protocol === 'file:' && resolvedURL.pathname.startsWith('/')
-            ? resolvedURL.pathname.slice(1)
-            : resolvedURL.pathname;
-        if (filePath.startsWith(prefix)) {
-          finalPath = filePath;
-        } else {
-          const cleaned = filePath.replace(/^[/\\]?src[/\\]/, '');
-          const sep = '\\';
-          finalPath = prefix.endsWith(sep) ? prefix + cleaned : prefix + sep + cleaned;
-        }
-        params.set('file', finalPath);
-        fetch('/__open-in-editor?' + params.toString());
+      const prefix = isWindows ? srcDir : srcDir.replace('http://local.local', '');
+      const params = new URLSearchParams();
+      const filePath =
+        resolvedURL.protocol === 'file:' && resolvedURL.pathname.startsWith('/')
+          ? resolvedURL.pathname.slice(1)
+          : resolvedURL.pathname;
+      let finalPath;
+      if (filePath.startsWith(prefix)) {
+        finalPath = filePath;
       } else {
-        location.href = resolvedURL.href;
+        // remove the extra src from filePath as prefix already contains it
+        const cleaned = filePath.replace(/^[/\\]?src[/\\]/, '');
+        const sep = isWindows ? '\\' : '/';
+        finalPath = prefix.endsWith(sep) ? prefix + cleaned : prefix + sep + cleaned;
       }
+      params.set('file', finalPath);
+      fetch('/__open-in-editor?' + params.toString());
     };
     document.addEventListener(
       'contextmenu',

--- a/packages/qwik/src/optimizer/src/plugins/click-to-component.html
+++ b/packages/qwik/src/optimizer/src/plugins/click-to-component.html
@@ -146,13 +146,22 @@
       const isWindows = navigator.platform.includes('Win');
       const isMac = navigator.platform.includes('Mac');
       const resolvedURL = new URL(path, isWindows ? origin : srcDir);
+      const prefix = isWindows ? srcDir : '';
       if (isWindows || isMac) {
+        let finalPath;
         const params = new URLSearchParams();
         const filePath =
           resolvedURL.protocol === 'file:' && resolvedURL.pathname.startsWith('/')
             ? resolvedURL.pathname.slice(1)
             : resolvedURL.pathname;
-        params.set('file', filePath);
+        if (filePath.startsWith(prefix)) {
+          finalPath = filePath;
+        } else {
+          const cleaned = filePath.replace(/^[/\\]?src[/\\]/, '');
+          const sep = '\\';
+          finalPath = prefix.endsWith(sep) ? prefix + cleaned : prefix + sep + cleaned;
+        }
+        params.set('file', finalPath);
         fetch('/__open-in-editor?' + params.toString());
       } else {
         location.href = resolvedURL.href;

--- a/packages/qwik/src/optimizer/src/plugins/click-to-component.html
+++ b/packages/qwik/src/optimizer/src/plugins/click-to-component.html
@@ -145,10 +145,13 @@
     globalThis.qwikOpenInEditor = function (path) {
       const isWindows = navigator.platform.includes('Win');
       const resolvedURL = new URL(path, isWindows ? origin : srcDir);
-      if (resolvedURL.origin === origin) {
+      if (isWindows) {
         const params = new URLSearchParams();
-        const prefix = isWindows ? srcDir : '';
-        params.set('file', prefix + resolvedURL.pathname);
+        const filePath =
+          resolvedURL.protocol === 'file:' && resolvedURL.pathname.startsWith('/')
+            ? resolvedURL.pathname.slice(1)
+            : resolvedURL.pathname;
+        params.set('file', filePath);
         fetch('/__open-in-editor?' + params.toString());
       } else {
         location.href = resolvedURL.href;

--- a/packages/qwik/src/optimizer/src/plugins/click-to-component.html
+++ b/packages/qwik/src/optimizer/src/plugins/click-to-component.html
@@ -144,8 +144,9 @@
 
     globalThis.qwikOpenInEditor = function (path) {
       const isWindows = navigator.platform.includes('Win');
+      const isMac = navigator.platform.includes('Mac');
       const resolvedURL = new URL(path, isWindows ? origin : srcDir);
-      if (isWindows) {
+      if (isWindows || isMac) {
         const params = new URLSearchParams();
         const filePath =
           resolvedURL.protocol === 'file:' && resolvedURL.pathname.startsWith('/')


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Feature / enhancement
- Bug
- Docs / tests / types / typos
- Infra

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
