### PR TITLE
fix(build): make types rolldown-vite compatible

### DIFF
--- a/packages/qwik/src/optimizer/src/manifest.ts
+++ b/packages/qwik/src/optimizer/src/manifest.ts
@@ -1,4 +1,4 @@
-import type { OutputBundle } from 'rollup';
+import type { Rollup } from 'vite';
 import { type NormalizedQwikPluginOptions } from './plugins/plugin';
 import type { GlobalInjections, Path, QwikBundle, QwikManifest, SegmentAnalysis } from './types';
 
@@ -392,7 +392,7 @@ export function generateManifestFromBundles(
   path: Path,
   segments: SegmentAnalysis[],
   injections: GlobalInjections[],
-  outputBundles: OutputBundle,
+  outputBundles: Rollup.OutputBundle,
   opts: NormalizedQwikPluginOptions,
   debug: (...args: any[]) => void,
   canonPath: (p: string) => string

--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -20,7 +20,6 @@ import type {
   ServerQwikManifest,
 } from '../types';
 import { createLinter, type QwikLinter } from './eslint-plugin';
-import type { LoadResult, OutputBundle, ResolveIdResult, TransformResult } from 'rollup';
 import { isWin, parseId } from './vite-utils';
 import type { BundleGraphAdder } from '..';
 import { convertManifestToBundleGraph } from './bundle-graph';
@@ -465,7 +464,7 @@ export function createQwikPlugin(optimizerOptions: OptimizerOptions = {}) {
     const parsedId = parseId(id);
     const pathId = normalizePath(parsedId.pathId);
 
-    let result: ResolveIdResult;
+    let result: Rollup.ResolveIdResult;
 
     /** At this point, the request has been normalized. */
 
@@ -576,7 +575,7 @@ export function createQwikPlugin(optimizerOptions: OptimizerOptions = {}) {
     ctx: Rollup.PluginContext,
     id: string,
     loadOpts?: Parameters<Extract<Plugin['load'], Function>>[1]
-  ): Promise<LoadResult> => {
+  ): Promise<Rollup.LoadResult> => {
     if (id.startsWith('\0') || id.startsWith('/@fs/')) {
       return;
     }
@@ -641,8 +640,8 @@ export function createQwikPlugin(optimizerOptions: OptimizerOptions = {}) {
     ctx: Rollup.PluginContext,
     code: string,
     id: string,
-    transformOpts: Parameters<Extract<Plugin['transform'], Function>>[2] = {}
-  ): Promise<TransformResult> {
+    transformOpts = {} as Parameters<Extract<Plugin['transform'], Function>>[2]
+  ): Promise<Rollup.TransformResult> {
     if (id.startsWith('\0')) {
       return;
     }
@@ -787,7 +786,7 @@ export function createQwikPlugin(optimizerOptions: OptimizerOptions = {}) {
     canonPath: (p: string) => string;
   };
 
-  const createOutputAnalyzer = (rollupBundle: OutputBundle) => {
+  const createOutputAnalyzer = (rollupBundle: Rollup.OutputBundle) => {
     const injections: GlobalInjections[] = [];
 
     const outputAnalyzer: OutputAnalyzer = {
@@ -927,7 +926,10 @@ export const manifest = ${JSON.stringify(serverManifest)};\n`;
     }
   }
 
-  function manualChunks(id: string, { getModuleInfo }: Rollup.ManualChunkMeta) {
+  function manualChunks(
+    id: string,
+    { getModuleInfo }: Parameters<Extract<Rollup.OutputOptions['manualChunks'], Function>>[1]
+  ) {
     if (opts.target === 'client') {
       if (
         // The preloader has to stay in a separate chunk if it's a client build
@@ -956,7 +958,7 @@ export const manifest = ${JSON.stringify(serverManifest)};\n`;
 
   async function generateManifest(
     ctx: Rollup.PluginContext,
-    rollupBundle: OutputBundle,
+    rollupBundle: Rollup.OutputBundle,
     bundleGraphAdders?: Set<BundleGraphAdder>,
     manifestExtra?: Partial<QwikManifest>
   ) {

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -1,4 +1,4 @@
-import type { UserConfig, ViteDevServer, Plugin as VitePlugin } from 'vite';
+import type { UserConfig, ViteDevServer, Plugin as VitePlugin, BuildOptions } from 'vite';
 import { QWIK_LOADER_DEFAULT_DEBUG, QWIK_LOADER_DEFAULT_MINIFIED } from '../scripts';
 import type {
   EntryStrategy,
@@ -326,7 +326,8 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
             output: {
               manualChunks: qwikPlugin.manualChunks,
             },
-          },
+            // temporary fix for rolldown-vite types
+          } as BuildOptions['rollupOptions'],
         },
         define: {
           [qDevKey]: qDev,

--- a/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.unit.ts
@@ -7,28 +7,20 @@ import { qwikVite, type QwikVitePlugin, type QwikVitePluginOptions } from './vit
 
 const cwd = process.cwd();
 
-const chunkInfoMocks: Rollup.PreRenderedChunk[] = [
+const chunkInfoMocks = [
   {
     exports: [''],
     name: 'chunk.tsx',
     facadeModuleId: 'chunk.tsx',
-    isDynamicEntry: false,
-    isEntry: false,
-    isImplicitEntry: false,
     moduleIds: ['chunk.tsx'],
-    type: 'chunk',
   },
   {
     exports: [''],
     name: cwd + '/app/chunk.tsx',
     facadeModuleId: cwd + '/app/chunk.tsx',
-    isDynamicEntry: false,
-    isEntry: false,
-    isImplicitEntry: false,
     moduleIds: [cwd + '/app/chunk.tsx'],
-    type: 'chunk',
   },
-];
+] as Rollup.PreRenderedChunk[];
 
 function mockOptimizerOptions(): OptimizerOptions {
   return {


### PR DESCRIPTION
I overrode vite with rolldown-vite and then fixed the types. It doesn't manage to build docs though, but at least the types won't impede progress.