### PR TITLE
docs: fix up search results 🍇

### DIFF
--- a/packages/docs/src/components/docsearch/snippet.tsx
+++ b/packages/docs/src/components/docsearch/snippet.tsx
@@ -20,9 +20,18 @@ interface SnippetProps<TItem> {
 
 export const Snippet = component$(
   ({ hit, attribute, tagName = 'span', ...rest }: SnippetProps<any>) => {
-    const data =
+    let data =
       getPropertyByPath(hit, `_snippetResult.${attribute ?? `hierarchy.${hit.type}`}.value`) ||
-      getPropertyByPath(hit, attribute ?? `hierarchy.${hit.type}`);
+      getPropertyByPath(hit, attribute ?? `hierarchy.${hit.type}`) ||
+      getPropertyByPath(hit, 'hierarchy.lvl0') + ' ' + getPropertyByPath(hit, 'hierarchy.lvl2');
+
+    const cleanedData = data.replace('<mark>', '').replace('</mark>', '').toLowerCase();
+    if (cleanedData === 'runtime-less') {
+      const paths = hit.url.split('/');
+      paths.pop();
+      data = `example: ${paths.pop()}`;
+    }
+
     return <span {...rest} dangerouslySetInnerHTML={data} />;
   }
 );


### PR DESCRIPTION
Close #7437 

Before

<img width="668" height="807" alt="image" src="https://github.com/user-attachments/assets/7d05e780-8542-4b26-96bc-89967b1e34d2" />


After

<img width="668" height="807" alt="image" src="https://github.com/user-attachments/assets/ed02f880-d3ce-49eb-8668-6e42b69c4435" />


