### PR TITLE
fix(zod): locale in use for Zod validator messages

### DIFF
--- a/.changeset/common-breads-wait.md
+++ b/.changeset/common-breads-wait.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+FIX: Zod validator uses defined locale for the current request

--- a/packages/qwik-router/src/runtime/src/server-functions.ts
+++ b/packages/qwik-router/src/runtime/src/server-functions.ts
@@ -6,6 +6,7 @@ import {
   noSerialize,
   untrack,
   useStore,
+  withLocale,
   type QRL,
   type ValueOrPromise,
 } from '@qwik.dev/core';
@@ -367,7 +368,7 @@ export const zodQrl: ZodConstructorQRL = (
           }
         });
         const data = inputData ?? (await ev.parseBody());
-        const result = await schema.safeParseAsync(data);
+        const result = await withLocale(ev.locale(), () => schema.safeParseAsync(data));
         if (result.success) {
           return result;
         } else {


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Bug

# Description

Runs the Zod validator inside a `withLocale` so error messages use the correct language when configured via the `setErrorMap` method of the zod library.

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [x] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
