### PR TITLE
fix(vite): deadlock in rolldown-vite

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -759,9 +759,8 @@ export function createQwikPlugin(optimizerOptions: OptimizerOptions = {}) {
       // unchanged imports are not missing in our internal transform cache
       // This can happen in the repl when the plugin is re-initialized
       // and possibly in other places
-      for (const id of deps.values()) {
-        await ctx.load({ id });
-      }
+      // NOTE: this should be Promise.all to avoid deadlocks
+      await Promise.all([...deps.values()].map((id) => ctx.load({ id })));
 
       ctx.addWatchFile(id);
 

--- a/starters/e2e/qwikcity/nav.spec.ts
+++ b/starters/e2e/qwikcity/nav.spec.ts
@@ -1,4 +1,3 @@
-import { $ } from "bun";
 import {
   assertPage,
   getScrollHeight,


### PR DESCRIPTION
when overriding vite with npm:rolldown-vite, dev mode hangs

thanks to @sapphi-red 