### PR TITLE
fix(rolldown): some fixes for rolldown-vite

### DIFF
--- a/packages/docs/src/components/code-block/code-block.tsx
+++ b/packages/docs/src/components/code-block/code-block.tsx
@@ -1,15 +1,7 @@
 import { component$, useStyles$, type QRL, useVisibleTask$, useSignal } from '@builder.io/qwik';
-import prismjs from 'prismjs';
-// Set to global so that prism language plugins can find it.
-const _global =
-  (typeof globalThis !== 'undefined' && globalThis) ||
-  (typeof global !== 'undefined' && global) ||
-  (typeof self !== 'undefined' && self) ||
-  (typeof this !== 'undefined' && this) ||
-  (typeof window !== 'undefined' && window);
-(_global as any).PRISM = prismjs;
-import 'prismjs/components/prism-jsx'; // needs PRISM global
-import 'prismjs/components/prism-tsx'; // needs PRISM global
+import prismjs from 'prismjs'; // provides the Prism global
+import 'prismjs/components/prism-jsx'; // needs Prism global
+import 'prismjs/components/prism-tsx'; // needs Prism global
 
 import styles from './code-block.css?inline';
 import { CopyCode } from '../copy-code/copy-code-block';

--- a/packages/qwik/src/optimizer/src/manifest.ts
+++ b/packages/qwik/src/optimizer/src/manifest.ts
@@ -388,6 +388,9 @@ export function computeTotals(graph: QwikManifest['bundles']): void {
   }
 }
 
+const preloaderRegex = /[/\\]qwik[/\\]dist[/\\]preloader\.[cm]js$/;
+const coreRegex = /[/\\]qwik[/\\]dist[/\\]core\.[^/]*js$/;
+const qwikLoaderRegex = /[/\\]qwik[/\\]dist[/\\]qwikloader(\.debug)?\.[^/]*js$/;
 export function generateManifestFromBundles(
   path: Path,
   segments: SegmentAnalysis[],
@@ -475,6 +478,16 @@ export function generateManifestFromBundles(
       bundle.dynamicImports = bundleDynamicImports;
     }
 
+    // It can happen that our modules end up in facades, not nice but needs handling
+    if (outputBundle.facadeModuleId) {
+      if (preloaderRegex.test(outputBundle.facadeModuleId)) {
+        manifest.preloader = bundleFileName;
+      } else if (coreRegex.test(outputBundle.facadeModuleId)) {
+        manifest.core = bundleFileName;
+      } else if (qwikLoaderRegex.test(outputBundle.facadeModuleId)) {
+        manifest.qwikLoader = bundleFileName;
+      }
+    }
     // Rollup doesn't provide the moduleIds in the outputBundle but Vite does
     const ids = outputBundle.moduleIds || Object.keys(outputBundle.modules);
     const modulePaths = ids
@@ -483,15 +496,13 @@ export function generateManifestFromBundles(
     if (modulePaths.length > 0) {
       bundle.origins = modulePaths;
       // keep these if statements separate so that weird bundling still works
-      if (modulePaths.some((m) => /[/\\]qwik[/\\]dist[/\\]preloader\.[cm]js$/.test(m))) {
+      if (!manifest.preloader && modulePaths.some((m) => preloaderRegex.test(m))) {
         manifest.preloader = bundleFileName;
       }
-      if (modulePaths.some((m) => /[/\\]qwik[/\\]dist[/\\]core\.[^/]*js$/.test(m))) {
+      if (!manifest.core && modulePaths.some((m) => coreRegex.test(m))) {
         manifest.core = bundleFileName;
       }
-      if (
-        modulePaths.some((m) => /[/\\]qwik[/\\]dist[/\\]qwikloader(\.debug)?\.[^/]*js$/.test(m))
-      ) {
+      if (!manifest.qwikLoader && modulePaths.some((m) => qwikLoaderRegex.test(m))) {
         manifest.qwikLoader = bundleFileName;
       }
     }

--- a/packages/qwik/src/optimizer/src/plugins/plugin.ts
+++ b/packages/qwik/src/optimizer/src/plugins/plugin.ts
@@ -943,13 +943,16 @@ export const manifest = ${JSON.stringify(serverManifest)};\n`;
       }
     }
 
-    const module = getModuleInfo(id)!;
-    const segment = module.meta.segment as SegmentAnalysis | undefined;
-    if (segment) {
-      const { hash } = segment;
-      const chunkName = (opts.entryStrategy as SmartEntryStrategy).manual?.[hash] || segment.entry;
-      if (chunkName) {
-        return chunkName;
+    const module = getModuleInfo(id);
+    if (module) {
+      const segment = module.meta.segment as SegmentAnalysis | undefined;
+      if (segment) {
+        const { hash } = segment;
+        const chunkName =
+          (opts.entryStrategy as SmartEntryStrategy).manual?.[hash] || segment.entry;
+        if (chunkName) {
+          return chunkName;
+        }
       }
     }
     return null;


### PR DESCRIPTION
make it possible to run docs with rolldown-vite

However, editor still breaks on Prism missing from imports

