### PR TITLE
chore(docs): cleaner prism importing for rolldown

### DIFF
--- a/packages/docs/src/components/code-block/code-block.tsx
+++ b/packages/docs/src/components/code-block/code-block.tsx
@@ -1,7 +1,11 @@
-import { component$, useStyles$, type QRL, useVisibleTask$, useSignal } from '@builder.io/qwik';
-import prismjs from 'prismjs'; // provides the Prism global
-import 'prismjs/components/prism-jsx'; // needs Prism global
-import 'prismjs/components/prism-tsx'; // needs Prism global
+import {
+  component$,
+  useStyles$,
+  type QRL,
+  useVisibleTask$,
+  useSignal,
+  useTask$,
+} from '@builder.io/qwik';
 
 import styles from './code-block.css?inline';
 import { CopyCode } from '../copy-code/copy-code-block';
@@ -13,9 +17,26 @@ interface CodeBlockProps {
   observerRootId?: string;
 }
 
+const holder: { prismjs?: typeof import('prismjs') } = {};
+
 export const CodeBlock = component$((props: CodeBlockProps) => {
   const listSig = useSignal<Element>();
   useStyles$(styles);
+
+  useTask$(() => {
+    if (!holder.prismjs) {
+      return import('prismjs').then(async (prism) => {
+        holder.prismjs = prism;
+
+        // These need the Prism global that prismjs provides
+        // We lazy import so we're sure about the order of the imports
+        await Promise.all([
+          import('prismjs/components/prism-jsx'),
+          import('prismjs/components/prism-tsx'),
+        ]);
+      });
+    }
+  });
 
   useVisibleTask$(async () => {
     const { pathInView$, path, observerRootId } = props;


### PR DESCRIPTION
with this change, everything seems to work when you use rolldown-vite instead of vite.

The previous code was triggering a [bug in rolldown](https://github.com/rolldown/rolldown/issues/5731) and this way is cleaner anyway.