### PR TITLE
refactor: set maxIdlePreloads to be constant over time

### DIFF
--- a/.changeset/twelve-words-jump.md
+++ b/.changeset/twelve-words-jump.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': patch
+---
+
+FEAT: maxIdlePreloads is now constant over time so you know for sure how many bundles will be preloaded concurrently during idle.

--- a/packages/qwik/src/core/preloader/preloader.unit.ts
+++ b/packages/qwik/src/core/preloader/preloader.unit.ts
@@ -21,5 +21,5 @@ test('preloader script', () => {
    * dereference objects etc, but that actually results in worse compression
    */
   const compressed = compress(Buffer.from(preLoader), { mode: 1, quality: 11 });
-  expect([compressed.length, preLoader.length]).toEqual([1817, 5417]);
+  expect([compressed.length, preLoader.length]).toEqual([1818, 5417]);
 });

--- a/packages/qwik/src/core/preloader/preloader.unit.ts
+++ b/packages/qwik/src/core/preloader/preloader.unit.ts
@@ -21,5 +21,5 @@ test('preloader script', () => {
    * dereference objects etc, but that actually results in worse compression
    */
   const compressed = compress(Buffer.from(preLoader), { mode: 1, quality: 11 });
-  expect([compressed.length, preLoader.length]).toEqual([1863, 5533]);
+  expect([compressed.length, preLoader.length]).toEqual([1817, 5417]);
 });

--- a/packages/qwik/src/core/preloader/queue.ts
+++ b/packages/qwik/src/core/preloader/queue.ts
@@ -79,7 +79,7 @@ export const trigger = () => {
     const probability = 1 - inverseProbability;
     const allowedPreloads = graph
       ? config.$maxIdlePreloads$
-      : // While the graph is not available, we limit to 2 preloads
+      : // While the graph is not available, we limit to 5 preloads
         5;
     // When we're 99% sure, everything needs to be queued
     if (probability >= 0.99 || preloadCount < allowedPreloads) {

--- a/packages/qwik/src/core/preloader/queue.ts
+++ b/packages/qwik/src/core/preloader/queue.ts
@@ -78,10 +78,9 @@ export const trigger = () => {
     const inverseProbability = bundle.$inverseProbability$;
     const probability = 1 - inverseProbability;
     const allowedPreloads = graph
-      ? // The more likely the bundle, the more simultaneous preloads we want to allow
-        Math.max(1, config.$maxIdlePreloads$ * probability)
+      ? config.$maxIdlePreloads$
       : // While the graph is not available, we limit to 2 preloads
-        2;
+        5;
     // When we're 99% sure, everything needs to be queued
     if (probability >= 0.99 || preloadCount < allowedPreloads) {
       queue.shift();


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Feature / enhancement

# Description

It's better to have this value be constant, otherwise it is hard for the developer to control it. 

Also increased the ssrPreloads limit (before bundle-graph is loaded) to 5 since 2 seems like it can create a lot of waterfalls no? (I didn't benchmark this ^^)

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
