### PR TITLE
chore: deprecate preloadProbability

### DIFF
--- a/packages/docs/src/entry.ssr.tsx
+++ b/packages/docs/src/entry.ssr.tsx
@@ -3,12 +3,7 @@ import { renderToStream } from '@builder.io/qwik/server';
 import Root from './root';
 
 // You can pass these as query parameters, as well as `preloadDebug`
-const preloaderSettings = [
-  'ssrPreloads',
-  'ssrPreloadProbability',
-  'maxIdlePreloads',
-  'preloadProbability',
-] as const;
+const preloaderSettings = ['ssrPreloads', 'ssrPreloadProbability', 'maxIdlePreloads'] as const;
 
 export default function (opts: RenderToStreamOptions) {
   const { serverData } = opts;

--- a/packages/qwik/src/core/preloader/queue.ts
+++ b/packages/qwik/src/core/preloader/queue.ts
@@ -204,10 +204,7 @@ export const adjustProbabilities = (
        * too.
        */
       let newInverseProbability: number;
-      if (
-        dep.$importProbability$ > 0.5 &&
-        (probability === 1 || (probability >= 0.99 && depsCount < 100))
-      ) {
+      if (probability === 1 || (probability >= 0.99 && depsCount < 100)) {
         depsCount++;
         // we're loaded at max probability, so elevate dynamic imports to 99% sure
         newInverseProbability = Math.min(0.01, 1 - dep.$importProbability$);

--- a/packages/qwik/src/server/preload-impl.ts
+++ b/packages/qwik/src/server/preload-impl.ts
@@ -240,5 +240,5 @@ const PreLoaderOptionsDefault: Required<PreloaderOptions> = {
   ssrPreloadProbability: 0.5,
   debug: false,
   maxIdlePreloads: 25,
-  preloadProbability: 0.35,
+  preloadProbability: 0.35, // deprecated
 };

--- a/packages/qwik/src/server/types.ts
+++ b/packages/qwik/src/server/types.ts
@@ -37,6 +37,8 @@ export interface PreloaderOptions {
    * The minimum probability for a bundle to be added as a preload link during SSR.
    *
    * Defaults to `0.7` (70% probability)
+   *
+   * This makes sure that the most likely bundles are preloaded ahead of time.
    */
   ssrPreloadProbability?: number;
   /**
@@ -58,9 +60,12 @@ export interface PreloaderOptions {
    */
   maxIdlePreloads?: number;
   /**
-   * The minimum probability for a bundle to be added to the preload queue.
+   * @deprecated The minimum probability for a bundle to be added to the preload queue.
    *
-   * Defaults to `0.35` (35% probability)
+   *   Defaulted to `0.35` (35% probability).
+   *
+   *   Deprecated because this could cause performance issues with bundles fetched on on click instead
+   *   of being preloaded ahead of time.
    */
   preloadProbability?: number;
 }


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Feature / enhancement
- Bug
- Docs / tests / types / typos
- Infra

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
