### PR TITLE
feat(qwik-city): Link SPA – preload route bundles with max probability on click

### DIFF
--- a/.changeset/sixty-rockets-clean.md
+++ b/.changeset/sixty-rockets-clean.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik-city': patch
+---
+
+FEAT: SPA Link navigation now preloads the next route bundles on click with maximum probability, speeding up SPA navigation.

--- a/packages/qwik-city/src/runtime/src/client-navigate.ts
+++ b/packages/qwik-city/src/runtime/src/client-navigate.ts
@@ -41,10 +41,10 @@ export const newScrollState = (): ScrollState => {
   };
 };
 
-export const prefetchSymbols = (path: string) => {
+export const preloadRouteBundles = (path: string, probability: number = 0.8) => {
   if (isBrowser) {
     path = path.endsWith('/') ? path : path + '/';
     path = path.length > 1 && path.startsWith('/') ? path.slice(1) : path;
-    preload(path, 0.8);
+    preload(path, probability);
   }
 };

--- a/packages/qwik-city/src/runtime/src/use-endpoint.ts
+++ b/packages/qwik-city/src/runtime/src/use-endpoint.ts
@@ -2,7 +2,7 @@ import { getClientDataPath } from './utils';
 import { CLIENT_DATA_CACHE } from './constants';
 import type { ClientPageData, RouteActionValue } from './types';
 import { _deserializeData } from '@builder.io/qwik';
-import { prefetchSymbols } from './client-navigate';
+import { preloadRouteBundles } from './client-navigate';
 
 export const loadClientData = async (
   url: URL,
@@ -10,7 +10,7 @@ export const loadClientData = async (
   opts?: {
     action?: RouteActionValue;
     clearCache?: boolean;
-    prefetchSymbols?: boolean;
+    preloadRouteBundles?: boolean;
     isPrefetch?: boolean;
   }
 ) => {
@@ -22,8 +22,8 @@ export const loadClientData = async (
     qData = CLIENT_DATA_CACHE.get(clientDataPath);
   }
 
-  if (opts?.prefetchSymbols !== false) {
-    prefetchSymbols(pagePathname);
+  if (opts?.preloadRouteBundles !== false) {
+    preloadRouteBundles(pagePathname, 0.8);
   }
   let resolveFn: () => void | undefined;
 


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Feature / enhancement
- Bug

# Description

Fixes https://github.com/QwikDev/qwik/issues/7834 to some extent. There are still bundling issues leading to over-prefetching on click left.

This speeds up SPA Link navigation by preloading the next route bundles on click.

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
