### PR TITLE
fix: hoisted transitive imports mess up the bundle-graph static imports graph

### DIFF
--- a/.changeset/hot-buses-strive.md
+++ b/.changeset/hot-buses-strive.md
@@ -2,4 +2,4 @@
 '@builder.io/qwik': patch
 ---
 
-FIX: Rollup's hoistTranstiveImports is now set to false. The bundle-graph static imports graph is now correct; which means no more over-preloading in some edge-cases.
+FIX: Rollup's hoistTranstiveImports is now set to `false` because the hoisting added unnecessary bundles to be preloaded to the bundle-graph static imports graph. This could lead to a suboptimal preloading experience.

--- a/.changeset/hot-buses-strive.md
+++ b/.changeset/hot-buses-strive.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': patch
+---
+
+FIX: Rollup's hoistTranstiveImports is now set to false. The bundle-graph static imports graph is now correct; which means no more over-preloading in some edge-cases.

--- a/packages/qwik/src/optimizer/src/plugins/rollup.ts
+++ b/packages/qwik/src/optimizer/src/plugins/rollup.ts
@@ -243,6 +243,12 @@ export function normalizeRollupOutputOptionsObject(
     outputOpts.exports = 'auto';
   }
 
+  /**
+   * Transitive imports must not be hoisted. Otherwise, the bundle-graph static imports will be
+   * incorrect; leading to over-preloading.
+   */
+  outputOpts.hoistTransitiveImports = false;
+
   return outputOpts;
 }
 

--- a/packages/qwik/src/optimizer/src/plugins/vite.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite.ts
@@ -323,9 +323,6 @@ export function qwikVite(qwikViteOpts: QwikVitePluginOptions = {}): any {
              * https://github.com/QwikDev/qwik/issues/7226#issuecomment-2647122505
              */
             maxParallelFileOps: 1,
-            output: {
-              manualChunks: qwikPlugin.manualChunks,
-            },
             // temporary fix for rolldown-vite types
           } as BuildOptions['rollupOptions'],
         },


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Feature / enhancement
- Bug
- Docs / tests / types / typos
- Infra

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
