### PR TITLE
fix: unmount react root alongside with qwik

### DIFF
--- a/.changeset/short-jeans-speak.md
+++ b/.changeset/short-jeans-speak.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': patch
+---
+
+unmount qwikify react root alongside with qwik component

--- a/packages/qwik-react/src/react/qwikify.tsx
+++ b/packages/qwik-react/src/react/qwikify.tsx
@@ -78,6 +78,16 @@ export function qwikifyQrl<PROPS extends Record<any, any>>(
       }
     });
 
+    useTask$(({ track, cleanup }) => {
+      track(signal);
+
+      if (isBrowser) {
+        cleanup(() => {
+          internalState.value?.root?.unmount();
+        });
+      }
+    });
+
     if (isServer && !isClientOnly) {
       const jsx = renderFromServer(
         TagName,


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

Bug


# Description

There is a bug, while navigating using SPA like approach, the qwikified react components don't call unmount callbacks specified in `useEffect`s hooks.

There is an open issue that mentions such a problem https://github.com/QwikDev/qwik/issues/7542

In this PR the issue is fixed by calling unmount method in react root entity when the qwik wrapper unmounts.

I haven't added unit tests because I haven't found them. If they are needed, please let me know where to write them.

# Checklist

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
