### PR TITLE
fix: compare URLs without protocols with checkOrigin: lax-proto 

### DIFF
--- a/.changeset/curvy-glasses-wash.md
+++ b/.changeset/curvy-glasses-wash.md
@@ -2,4 +2,4 @@
 '@builder.io/qwik-city': patch
 ---
 
-fix behaviour of checkOrigin: "lax-proto" in createQwikCity
+FIX: fix behaviour of checkOrigin: "lax-proto" in createQwikCity

--- a/.changeset/curvy-glasses-wash.md
+++ b/.changeset/curvy-glasses-wash.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik-city': patch
+---
+
+fix behaviour of checkOrigin: "lax-proto" in createQwikCity

--- a/packages/qwik-city/src/middleware/request-handler/resolve-request-handlers.ts
+++ b/packages/qwik-city/src/middleware/request-handler/resolve-request-handlers.ts
@@ -450,7 +450,7 @@ function checkCSRF(requestEv: RequestEvent, laxProto?: 'lax-proto') {
     if (
       forbidden &&
       laxProto &&
-      inputOrigin?.replace(/http(s)?/g, '') === origin.replace(/http(s)?/g, '')
+      inputOrigin?.replace(/^http(s)?/g, '') === origin.replace(/^http(s)?/g, '')
     ) {
       forbidden = false;
     }

--- a/packages/qwik-city/src/middleware/request-handler/resolve-request-handlers.ts
+++ b/packages/qwik-city/src/middleware/request-handler/resolve-request-handlers.ts
@@ -66,10 +66,10 @@ export const resolveRequestHandlers = (
       checkOrigin &&
       (method === 'POST' || method === 'PUT' || method === 'PATCH' || method === 'DELETE')
     ) {
-      requestHandlers.unshift(csrfCheckMiddleware);
-
       if (checkOrigin === 'lax-proto') {
-        requestHandlers.push(csrfLaxProtoCheckMiddleware);
+        requestHandlers.unshift(csrfLaxProtoCheckMiddleware);
+      } else {
+        requestHandlers.unshift(csrfCheckMiddleware);
       }
     }
     if (isPageRoute) {

--- a/packages/qwik-city/src/middleware/request-handler/resolve-request-handlers.ts
+++ b/packages/qwik-city/src/middleware/request-handler/resolve-request-handlers.ts
@@ -450,8 +450,7 @@ function checkCSRF(requestEv: RequestEvent, laxProto?: 'lax-proto') {
     if (
       forbidden &&
       laxProto &&
-      origin.startsWith('https://') &&
-      inputOrigin?.slice(4) === origin.slice(5)
+      inputOrigin?.replace(/http(s)?/g, '') === origin.replace(/http(s)?/g, '')
     ) {
       forbidden = false;
     }


### PR DESCRIPTION
Previously, two CSRF middlewares were added for lax-proto requests: one at the beginning and one at the end. This change replaces them with a single middleware placed at the beginning. Non-lax-proto cases remain unchanged.

<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Bug

# Description

fix behaviour of checkOrigin: "lax-proto" in createQwikCity

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
