### PR TITLE
fix(qwik-city): custom service-worker.ts code is also being unregistered

### DIFF
--- a/.changeset/thin-horses-bake.md
+++ b/.changeset/thin-horses-bake.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik-city': patch
+---
+
+patch: FIX: Your service-worker.js won't be unregistered anymore if you added custom logic.

--- a/.changeset/thin-horses-bake.md
+++ b/.changeset/thin-horses-bake.md
@@ -2,4 +2,6 @@
 '@builder.io/qwik-city': patch
 ---
 
-FIX: Your service-worker.js won't be unregistered anymore if you added custom logic to it.
+FIX: Your service-worker.js won't be unregistered anymore if you added custom logic to it. 
+
+> Note: Qwik 1.14.0 and above now use `<link rel="modulepreload">` by default. If you didn't add custom service-worker logic, you should remove your service-worker.ts file(s) for the `ServiceWorkerRegister` Component to actually unregister the service-worker.js and delete its related cache. Make sure to keep the `ServiceWorkerRegister` Component in your app (without any service-worker.ts file) as long as you want to unregister the service-worker.js for your users.

--- a/.changeset/thin-horses-bake.md
+++ b/.changeset/thin-horses-bake.md
@@ -2,4 +2,4 @@
 '@builder.io/qwik-city': patch
 ---
 
-patch: FIX: Your service-worker.js won't be unregistered anymore if you added custom logic.
+FIX: Your service-worker.js won't be unregistered anymore if you added custom logic to it.

--- a/packages/qwik-city/src/buildtime/runtime-generation/generate-service-worker.ts
+++ b/packages/qwik-city/src/buildtime/runtime-generation/generate-service-worker.ts
@@ -1,15 +1,11 @@
 import type { BuildContext } from '../types';
 
-export function generateServiceWorkerRegister(
-  ctx: BuildContext,
-  swRegister: string,
-  didNotAddCustomCode: boolean
-) {
+export function generateServiceWorkerRegister(ctx: BuildContext, swRegister: string) {
   let swReg: string;
   let swUrl = '/service-worker.js';
 
-  // Also unregister if the developer removed the service-worker.ts file or did not add custom code to it; since Qwik 1.14.0 and above now use modulepreload by default
-  if (ctx.isDevServer || didNotAddCustomCode || ctx.serviceWorkers.length === 0) {
+  // Also unregister if the developer removed the service-worker.ts file since Qwik 1.14.0 and above now use modulepreload by default
+  if (ctx.isDevServer || ctx.serviceWorkers.length === 0) {
     swReg = SW_UNREGISTER;
   } else {
     swReg = swRegister;

--- a/packages/qwik-city/src/buildtime/runtime-generation/generate-service-worker.ts
+++ b/packages/qwik-city/src/buildtime/runtime-generation/generate-service-worker.ts
@@ -8,18 +8,16 @@ export function generateServiceWorkerRegister(
   let swReg: string;
   let swUrl = '/service-worker.js';
 
-  // Also unregister if the developer did not add custom code to the service worker since Qwik 1.14.0 and above now use modulepreload by default
-  if (ctx.isDevServer || didNotAddCustomCode) {
+  // Also unregister if the developer removed the service-worker.ts file or did not add custom code to it; since Qwik 1.14.0 and above now use modulepreload by default
+  if (ctx.isDevServer || didNotAddCustomCode || ctx.serviceWorkers.length === 0) {
     swReg = SW_UNREGISTER;
   } else {
     swReg = swRegister;
 
-    if (ctx.serviceWorkers.length > 0) {
-      const sw = ctx.serviceWorkers.sort((a, b) =>
-        a.chunkFileName.length < b.chunkFileName.length ? -1 : 1
-      )[0];
-      swUrl = ctx.opts.basePathname + sw.chunkFileName;
-    }
+    const sw = ctx.serviceWorkers.sort((a, b) =>
+      a.chunkFileName.length < b.chunkFileName.length ? -1 : 1
+    )[0];
+    swUrl = ctx.opts.basePathname + sw.chunkFileName;
   }
   swReg = swReg.replace('__url', swUrl);
 
@@ -27,27 +25,29 @@ export function generateServiceWorkerRegister(
 }
 
 const SW_UNREGISTER = `
-(() => {
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.getRegistrations().then((regs) => {
-      for (const reg of regs) {
-        const url = '__url'.split('/').pop();
-        if (reg.active?.scriptURL.endsWith(url || 'service-worker.js')) {
-          reg.unregister().catch(console.error);
-        }
-      }
-    });
-  }
-  if ('caches' in window) {
-    caches
-      .keys()
-      .then((names) => {
-        const cacheName = names.find((name) => name.startsWith('QwikBuild'));
-        if (cacheName) {
-          caches.delete(cacheName).catch(console.error);
-        }
-      })
-      .catch(console.error);
-  }
-})();
+"serviceWorker"in navigator&&navigator.serviceWorker.getRegistrations().then(r=>{for(const e of r){const c='__url'.split("/").pop();e.active?.scriptURL.endsWith(c||"service-worker.js")&&e.unregister().catch(console.error)}}),"caches"in window&&caches.keys().then(r=>{const e=r.find(c=>c.startsWith("QwikBuild"));e&&caches.delete(e).catch(console.error)}).catch(console.error)
 `;
+// Code in SW_UNREGISTER unregisters the service worker and deletes the cache; it is the minified version of the following:
+// (() => {
+//   if ('serviceWorker' in navigator) {
+//     navigator.serviceWorker.getRegistrations().then((regs) => {
+//       for (const reg of regs) {
+//         const url = '__url'.split('/').pop();
+//         if (reg.active?.scriptURL.endsWith(url || 'service-worker.js')) {
+//           reg.unregister().catch(console.error);
+//         }
+//       }
+//     });
+//   }
+//   if ('caches' in window) {
+//     caches
+//       .keys()
+//       .then((names) => {
+//         const cacheName = names.find((name) => name.startsWith('QwikBuild'));
+//         if (cacheName) {
+//           caches.delete(cacheName).catch(console.error);
+//         }
+//       })
+//       .catch(console.error);
+//   }
+// })();

--- a/packages/qwik-city/src/buildtime/runtime-generation/generate-service-worker.ts
+++ b/packages/qwik-city/src/buildtime/runtime-generation/generate-service-worker.ts
@@ -1,31 +1,53 @@
 import type { BuildContext } from '../types';
 
-export function generateServiceWorkerRegister(ctx: BuildContext, swRegister: string) {
+export function generateServiceWorkerRegister(
+  ctx: BuildContext,
+  swRegister: string,
+  didNotAddCustomCode: boolean
+) {
   let swReg: string;
+  let swUrl = '/service-worker.js';
 
-  if (ctx.isDevServer) {
+  // Also unregister if the developer did not add custom code to the service worker since Qwik 1.14.0 and above now use modulepreload by default
+  if (ctx.isDevServer || didNotAddCustomCode) {
     swReg = SW_UNREGISTER;
   } else {
     swReg = swRegister;
 
-    let swUrl = '/service-worker.js';
     if (ctx.serviceWorkers.length > 0) {
       const sw = ctx.serviceWorkers.sort((a, b) =>
         a.chunkFileName.length < b.chunkFileName.length ? -1 : 1
       )[0];
       swUrl = ctx.opts.basePathname + sw.chunkFileName;
     }
-
-    swReg = swReg.replace('__url', swUrl);
   }
+  swReg = swReg.replace('__url', swUrl);
 
   return `export default ${JSON.stringify(swReg)};`;
 }
 
 const SW_UNREGISTER = `
-navigator.serviceWorker?.getRegistrations().then((regs) => {
-  for (const reg of regs) {
-    reg.unregister();
+(() => {
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.getRegistrations().then((regs) => {
+      for (const reg of regs) {
+        const url = '__url'.split('/').pop();
+        if (reg.active?.scriptURL.endsWith(url || 'service-worker.js')) {
+          reg.unregister().catch(console.error);
+        }
+      }
+    });
   }
-});
+  if ('caches' in window) {
+    caches
+      .keys()
+      .then((names) => {
+        const cacheName = names.find((name) => name.startsWith('QwikBuild'));
+        if (cacheName) {
+          caches.delete(cacheName).catch(console.error);
+        }
+      })
+      .catch(console.error);
+  }
+})();
 `;

--- a/packages/qwik-city/src/buildtime/vite/plugin.ts
+++ b/packages/qwik-city/src/buildtime/vite/plugin.ts
@@ -186,8 +186,30 @@ function qwikCityPlugin(userOpts?: QwikCityVitePluginOptions): any {
           }
 
           if (isSwRegister) {
+            // Detect if the developer added custom code in their service-worker.ts file
+            let didNotAddCustomCode = false;
+            const clientOutDir = qwikPlugin!.api.getClientOutDir();
+            const basePathRelDir = api.getBasePathname().replace(/^\/|\/$/, '');
+            const clientOutBaseDir = join(clientOutDir, basePathRelDir);
+            for (const swEntry of ctx.serviceWorkers) {
+              try {
+                const swClientDistPath = join(clientOutBaseDir, swEntry.chunkFileName);
+                const swCode = await fs.promises.readFile(swClientDistPath, 'utf-8');
+                const swCodeTrimmed = swCode.replace(/\s+/g, '');
+                if (
+                  swCodeTrimmed ===
+                    'addEventListener("install",()=>self.skipWaiting());addEventListener("activate",()=>self.clients.claim());' ||
+                  swCodeTrimmed ===
+                    'self.addEventListener("install",()=>self.skipWaiting());self.addEventListener("activate",()=>self.clients.claim());'
+                ) {
+                  didNotAddCustomCode = true;
+                }
+              } catch (e) {
+                console.error('Error reading service worker file', e);
+              }
+            }
             // @qwik-city-sw-register
-            return generateServiceWorkerRegister(ctx, swRegister);
+            return generateServiceWorkerRegister(ctx, swRegister, didNotAddCustomCode);
           }
         }
       }

--- a/packages/qwik-city/src/buildtime/vite/plugin.ts
+++ b/packages/qwik-city/src/buildtime/vite/plugin.ts
@@ -186,35 +186,12 @@ function qwikCityPlugin(userOpts?: QwikCityVitePluginOptions): any {
           }
 
           if (isSwRegister) {
-            // Detect if the developer added custom code in their service-worker.ts file
-            let didNotAddCustomCode = false;
-            const clientOutDir = qwikPlugin!.api.getClientOutDir();
-            if (clientOutDir) {
-              const basePathRelDir = api.getBasePathname().replace(/^\/|\/$/, '');
-              const clientOutBaseDir = join(clientOutDir, basePathRelDir);
-              for (const swEntry of ctx.serviceWorkers) {
-                try {
-                  const swClientDistPath = join(clientOutBaseDir, swEntry.chunkFileName);
-                  const swCode = await fs.promises.readFile(swClientDistPath, 'utf-8');
-                  const swCodeTrimmed = swCode.replace(/\s+/g, '');
-                  if (
-                    swCodeTrimmed ===
-                      'addEventListener("install",()=>self.skipWaiting());addEventListener("activate",()=>self.clients.claim());' ||
-                    swCodeTrimmed ===
-                      'self.addEventListener("install",()=>self.skipWaiting());self.addEventListener("activate",()=>self.clients.claim());'
-                  ) {
-                    didNotAddCustomCode = true;
-                  }
-                } catch (e) {
-                  console.error('Error reading service worker file', e);
-                }
-              }
-            }
             // @qwik-city-sw-register
-            return generateServiceWorkerRegister(ctx, swRegister, didNotAddCustomCode);
+            return generateServiceWorkerRegister(ctx, swRegister);
           }
         }
       }
+
       return null;
     },
 

--- a/packages/qwik-city/src/buildtime/vite/plugin.ts
+++ b/packages/qwik-city/src/buildtime/vite/plugin.ts
@@ -189,23 +189,25 @@ function qwikCityPlugin(userOpts?: QwikCityVitePluginOptions): any {
             // Detect if the developer added custom code in their service-worker.ts file
             let didNotAddCustomCode = false;
             const clientOutDir = qwikPlugin!.api.getClientOutDir();
-            const basePathRelDir = api.getBasePathname().replace(/^\/|\/$/, '');
-            const clientOutBaseDir = join(clientOutDir, basePathRelDir);
-            for (const swEntry of ctx.serviceWorkers) {
-              try {
-                const swClientDistPath = join(clientOutBaseDir, swEntry.chunkFileName);
-                const swCode = await fs.promises.readFile(swClientDistPath, 'utf-8');
-                const swCodeTrimmed = swCode.replace(/\s+/g, '');
-                if (
-                  swCodeTrimmed ===
-                    'addEventListener("install",()=>self.skipWaiting());addEventListener("activate",()=>self.clients.claim());' ||
-                  swCodeTrimmed ===
-                    'self.addEventListener("install",()=>self.skipWaiting());self.addEventListener("activate",()=>self.clients.claim());'
-                ) {
-                  didNotAddCustomCode = true;
+            if (clientOutDir) {
+              const basePathRelDir = api.getBasePathname().replace(/^\/|\/$/, '');
+              const clientOutBaseDir = join(clientOutDir, basePathRelDir);
+              for (const swEntry of ctx.serviceWorkers) {
+                try {
+                  const swClientDistPath = join(clientOutBaseDir, swEntry.chunkFileName);
+                  const swCode = await fs.promises.readFile(swClientDistPath, 'utf-8');
+                  const swCodeTrimmed = swCode.replace(/\s+/g, '');
+                  if (
+                    swCodeTrimmed ===
+                      'addEventListener("install",()=>self.skipWaiting());addEventListener("activate",()=>self.clients.claim());' ||
+                    swCodeTrimmed ===
+                      'self.addEventListener("install",()=>self.skipWaiting());self.addEventListener("activate",()=>self.clients.claim());'
+                  ) {
+                    didNotAddCustomCode = true;
+                  }
+                } catch (e) {
+                  console.error('Error reading service worker file', e);
                 }
-              } catch (e) {
-                console.error('Error reading service worker file', e);
               }
             }
             // @qwik-city-sw-register

--- a/packages/qwik-city/src/runtime/src/sw-component.tsx
+++ b/packages/qwik-city/src/runtime/src/sw-component.tsx
@@ -5,6 +5,12 @@ import type { JSXOutput } from '@builder.io/qwik';
  * JS extensions are allowed) will be picked up, bundled into a separate file, and registered as a
  * service worker.
  *
+ * Qwik 1.14.0 and above now use `<link rel="modulepreload">` by default. If you didn't add custom
+ * service-worker logic, you should remove your service-worker.ts file(s) for the
+ * `ServiceWorkerRegister` Component to actually unregister the service-worker.js and delete its
+ * related cache. Make sure to keep the `ServiceWorkerRegister` Component in your app (without any
+ * service-worker.ts file) as long as you want to unregister the service-worker.js for your users.
+ *
  * @public
  */
 export const ServiceWorkerRegister = (props: { nonce?: string }): JSXOutput => (

--- a/packages/qwik-city/src/runtime/src/sw-register.ts
+++ b/packages/qwik-city/src/runtime/src/sw-register.ts
@@ -3,6 +3,18 @@
 (() => {
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('__url').catch((e) => console.error(e));
+    // We need to delete the cache since we are using modulepreload by default in qwik 1.14 and above
+    if ('caches' in window) {
+      caches
+        .keys()
+        .then((names) => {
+          const cacheName = names.find((name) => name.startsWith('QwikBuild'));
+          if (cacheName) {
+            caches.delete(cacheName).catch(console.error);
+          }
+        })
+        .catch(console.error);
+    }
   } else {
     // eslint-disable-next-line no-console
     console.log('Service worker not supported in this browser.');

--- a/packages/qwik-city/src/runtime/src/sw-register.ts
+++ b/packages/qwik-city/src/runtime/src/sw-register.ts
@@ -2,24 +2,9 @@
 
 (() => {
   if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.getRegistrations().then((regs) => {
-      for (const reg of regs) {
-        const url = '__url'.split('/').pop();
-        if (reg.active?.scriptURL.endsWith(url || 'service-worker.js')) {
-          reg.unregister().catch(console.error);
-        }
-      }
-    });
-  }
-  if ('caches' in window) {
-    caches
-      .keys()
-      .then((names) => {
-        const cacheName = names.find((name) => name.startsWith('QwikBuild'));
-        if (cacheName) {
-          caches.delete(cacheName).catch(console.error);
-        }
-      })
-      .catch(console.error);
+    navigator.serviceWorker.register('__url').catch((e) => console.error(e));
+  } else {
+    // eslint-disable-next-line no-console
+    console.log('Service worker not supported in this browser.');
   }
 })();


### PR DESCRIPTION
Close https://github.com/QwikDev/qwik/issues/7856

<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Bug

# Description

Now custom service-worker implementation will keep working, while projects that removed their service-worker.ts files will unregister their service-worker.js and related cache.

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
