### PR TITLE
[Docs] Fix StackBlitz Qwik example app

### DIFF
--- a/packages/docs/src/routes/docs/(qwik)/getting-started/index.mdx
+++ b/packages/docs/src/routes/docs/(qwik)/getting-started/index.mdx
@@ -47,7 +47,8 @@ Qwik is a new kind of framework that is [resumable](../concepts/resumable/index.
 
 To play with it right away, check out Qwik’s in-browser playgrounds:
 
-- [StackBlitz Qwik](https://qwik.new) (Full Qwik + Qwikcity integration)
+<!-- https://qwik.new needed a package.json update (current version errors during build) -->
+- [StackBlitz Qwik](https://stackblitz.com/edit/github-ctwv6s53?file=package.json) (Full Qwik + Qwikcity integration)
 - [Examples playground](/examples/reactivity/counter/) (Qwik only, no routing)
 
 ## Prerequisites


### PR DESCRIPTION
I provided a working package.json. I also had to remove the pnpm-lock file.

# What is it?
- Docs

# Description

The stackblitz example (very first example in the docs) is broken.
