### PR TITLE
feat: expose loading and error fields of async computed signal

### DIFF
--- a/.changeset/mean-tires-cover.md
+++ b/.changeset/mean-tires-cover.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': minor
+---
+
+feat: expose `loading` and `error` fields of async computed signal

--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -244,7 +244,7 @@
         }
       ],
       "kind": "Interface",
-      "content": "```typescript\nexport interface AsyncComputedReadonlySignal<T = unknown> extends ComputedSignal<T> \n```\n**Extends:** [ComputedSignal](#computedsignal)<!-- -->&lt;T&gt;",
+      "content": "```typescript\nexport interface AsyncComputedReadonlySignal<T = unknown> extends ComputedSignal<T> \n```\n**Extends:** [ComputedSignal](#computedsignal)<!-- -->&lt;T&gt;\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n[error](#)\n\n\n</td><td>\n\n\n</td><td>\n\nError \\| null\n\n\n</td><td>\n\nThe error that occurred while computing the signal.\n\n\n</td></tr>\n<tr><td>\n\n[loading](#)\n\n\n</td><td>\n\n\n</td><td>\n\nboolean\n\n\n</td><td>\n\nWhether the signal is currently loading.\n\n\n</td></tr>\n</tbody></table>",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/reactive-primitives/signal.public.ts",
       "mdFile": "core.asynccomputedreadonlysignal.md"
     },

--- a/packages/docs/src/routes/api/qwik/index.mdx
+++ b/packages/docs/src/routes/api/qwik/index.mdx
@@ -136,6 +136,55 @@ export interface AsyncComputedReadonlySignal<T = unknown> extends ComputedSignal
 
 **Extends:** [ComputedSignal](#computedsignal)&lt;T&gt;
 
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+[error](#)
+
+</td><td>
+
+</td><td>
+
+Error \| null
+
+</td><td>
+
+The error that occurred while computing the signal.
+
+</td></tr>
+<tr><td>
+
+[loading](#)
+
+</td><td>
+
+</td><td>
+
+boolean
+
+</td><td>
+
+Whether the signal is currently loading.
+
+</td></tr>
+</tbody></table>
+
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/reactive-primitives/signal.public.ts)
 
 ## AsyncComputedReturnType

--- a/packages/qwik/src/core/qwik.core.api.md
+++ b/packages/qwik/src/core/qwik.core.api.md
@@ -22,6 +22,8 @@ export type AsyncComputedFn<T> = (ctx: AsyncComputedCtx) => Promise<T>;
 
 // @public (undocumented)
 export interface AsyncComputedReadonlySignal<T = unknown> extends ComputedSignal<T> {
+    error: Error | null;
+    loading: boolean;
 }
 
 // @public (undocumented)

--- a/packages/qwik/src/core/reactive-primitives/signal.public.ts
+++ b/packages/qwik/src/core/reactive-primitives/signal.public.ts
@@ -17,9 +17,10 @@ export interface ReadonlySignal<T = unknown> {
 
 /** @public */
 export interface AsyncComputedReadonlySignal<T = unknown> extends ComputedSignal<T> {
-  // TODO: enable later this, after the scheduler changes for "streaming" signals values
-  // loading: boolean;
-  // error: Error | null;
+  /** Whether the signal is currently loading. */
+  loading: boolean;
+  /** The error that occurred while computing the signal. */
+  error: Error | null;
 }
 
 /**

--- a/packages/qwik/src/testing/rendering.unit-util.tsx
+++ b/packages/qwik/src/testing/rendering.unit-util.tsx
@@ -137,7 +137,6 @@ export async function ssrRenderToDom(
   const containerElement = document.querySelector(QContainerSelector) as _ContainerElement;
   emulateExecutionOfQwikFuncs(document);
   const container = _getDomContainer(containerElement) as _DomContainer;
-  await getTestPlatform().flush();
   const getStyles = getStylesFactory(document);
   if (opts.debug) {
     console.log('========================================================');


### PR DESCRIPTION
Expose (hidden until now) `loading` and `error` fields of async computed signal