### PR TITLE
fix: finding parent dom element from projected content

### DIFF
--- a/.changeset/shy-shirts-glow.md
+++ b/.changeset/shy-shirts-glow.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: finding parent dom element from projected content

--- a/packages/qwik/src/core/client/dom-container.ts
+++ b/packages/qwik/src/core/client/dom-container.ts
@@ -95,7 +95,7 @@ export function getDomContainerFromQContainerElement(qContainerElement: Element)
 /** @internal */
 export function _getQContainerElement(element: Element | VNode): Element | null {
   const qContainerElement: Element | null = Array.isArray(element)
-    ? (vnode_getDomParent(element) as Element)
+    ? (vnode_getDomParent(element, true) as Element)
     : element;
   return qContainerElement.closest(QContainerSelector);
 }
@@ -282,7 +282,9 @@ export class DomContainer extends _SharedContainer implements IClientContainer {
         if (isSlotProp(prop)) {
           const value = props[i + 1];
           if (typeof value == 'string') {
-            props[i + 1] = this.vNodeLocate(value);
+            const projection = this.vNodeLocate(value);
+            props[i + 1] = projection;
+            vnode_getProp(projection, QSlotParent, (id) => this.vNodeLocate(id));
           }
         }
       }

--- a/packages/qwik/src/core/tests/projection.spec.tsx
+++ b/packages/qwik/src/core/tests/projection.spec.tsx
@@ -2427,6 +2427,48 @@ describe.each([
     );
   });
 
+  it('should toggle text content projection', async () => {
+    const Parent = component$(() => {
+      return <Slot />;
+    });
+
+    const Cmp = component$(() => {
+      const show = useSignal(false);
+      return (
+        <>
+          <button onClick$={() => (show.value = !show.value)}></button>
+          {show.value && (
+            <Parent>
+              <Slot />
+            </Parent>
+          )}
+        </>
+      );
+    });
+    const { vNode, document } = await render(<Cmp>content</Cmp>, { debug: DEBUG });
+    expect(vNode).toMatchVDOM(
+      <Component ssr-required>
+        <Fragment ssr-required>
+          <button></button>
+          {''}
+        </Fragment>
+      </Component>
+    );
+    await trigger(document.body, 'button', 'click');
+    expect(vNode).toMatchVDOM(
+      <Component ssr-required>
+        <Fragment ssr-required>
+          <button></button>
+          <Component ssr-required>
+            <Projection ssr-required>
+              <Projection ssr-required>content</Projection>
+            </Projection>
+          </Component>
+        </Fragment>
+      </Component>
+    );
+  });
+
   describe('regression', () => {
     it('#1630', async () => {
       const Child = component$(() => <b>CHILD</b>);


### PR DESCRIPTION
Find the correct parent dom element from projected content