### PR TITLE
Fix Alt+Click "open in editor" whe a  custom `srcDir` is defined.

### DIFF
--- a/packages/qwik/src/optimizer/src/plugins/click-to-component.html
+++ b/packages/qwik/src/optimizer/src/plugins/click-to-component.html
@@ -60,7 +60,7 @@
   (function () {
     const inspectAttribute = 'data-qwik-inspector';
     const hotKeys = globalThis.qwikdevtools.hotKeys;
-    const srcDir = globalThis.qwikdevtools.srcDir;
+    const rootDir = globalThis.qwikdevtools.rootDir;
     document.querySelector('#qwik-inspector-info-popup').textContent =
       `Click-to-Source: ${hotKeys.join(' + ')}`;
     console.debug(
@@ -148,20 +148,9 @@
     );
 
     globalThis.qwikOpenInEditor = function (path) {
-      const isWindows = navigator.platform.includes('Win');
-      const resolvedURL = new URL(path, isWindows ? origin : srcDir);
-      let filePath =
-        resolvedURL.protocol === 'file:' && resolvedURL.pathname.startsWith('/')
-          ? resolvedURL.pathname.slice(1)
-          : resolvedURL.pathname.startsWith('/@fs/')
-            ? resolvedURL.pathname.slice(isWindows ? 5 : 4)
-            : resolvedURL.pathname;
-      if (filePath.startsWith('/src/')) {
-        const prefix = isWindows ? srcDir : srcDir.replace('http://local.local', '');
-        filePath = prefix + filePath.slice(4);
-      }
+      const fullPath = `${rootDir}/${path.replace(/^\//, '')}`;
       const params = new URLSearchParams();
-      params.set('file', filePath);
+      params.set('file', fullPath);
       fetch('/__open-in-editor?' + params.toString());
     };
     document.addEventListener(

--- a/packages/qwik/src/optimizer/src/plugins/vite-dev-server.ts
+++ b/packages/qwik/src/optimizer/src/plugins/vite-dev-server.ts
@@ -269,7 +269,11 @@ export async function configureDevServer(
           });
 
           res.write(
-            END_SSR_SCRIPT(opts, opts.srcDir ? opts.srcDir : path.join(opts.rootDir, 'src'))
+            END_SSR_SCRIPT(
+              opts,
+              opts.srcDir ? opts.srcDir : path.join(opts.rootDir, 'src'),
+              opts.rootDir
+            )
           );
           res.end();
         } else {
@@ -435,10 +439,15 @@ function relativeURL(url: string, base: string) {
   return url;
 }
 
-const DEV_QWIK_INSPECTOR = (opts: NormalizedQwikPluginOptions['devTools'], srcDir: string) => {
+const DEV_QWIK_INSPECTOR = (
+  opts: NormalizedQwikPluginOptions['devTools'],
+  srcDir: string,
+  rootDir: string
+) => {
   const qwikdevtools = {
     hotKeys: opts.clickToSource ?? [],
     srcDir: new URL(srcDir + '/', 'http://local.local').href,
+    rootDir: rootDir,
   };
   return (
     `<script>
@@ -449,12 +458,12 @@ const DEV_QWIK_INSPECTOR = (opts: NormalizedQwikPluginOptions['devTools'], srcDi
   );
 };
 
-const END_SSR_SCRIPT = (opts: NormalizedQwikPluginOptions, srcDir: string) => `
+const END_SSR_SCRIPT = (opts: NormalizedQwikPluginOptions, srcDir: string, rootDir: string) => `
 <style>${VITE_ERROR_OVERLAY_STYLES}</style>
 <script type="module" src="/@vite/client"></script>
 ${errorHost}
 ${perfWarning}
-${DEV_QWIK_INSPECTOR(opts.devTools, srcDir)}
+${DEV_QWIK_INSPECTOR(opts.devTools, srcDir, rootDir)}
 `;
 
 function getViteDevIndexHtml(entryUrl: string, serverData: Record<string, any>) {


### PR DESCRIPTION
# What is it?

- Bug

# Description

Problem with the Alt+Click "open in editor" feature when using custom `srcDir` option. see https://github.com/QwikDev/qwik/pull/7785#issuecomment-3239670388 for more detail related to the issue.

# Checklist

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
