### PR TITLE
ci: add qwik react e2e tests run to ci

### DIFF
--- a/.changeset/some-oranges-open.md
+++ b/.changeset/some-oranges-open.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': patch
+---
+
+CI: add qwik react e2e test runs to ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -713,7 +713,8 @@ jobs:
           mv artifact-create-qwik/* packages/create-qwik/dist/
           mkdir -p packages/eslint-plugin-qwik/dist/
           mv artifact-eslint-plugin-qwik/* packages/eslint-plugin-qwik/dist/
-          mv artifact-qwikreact/* packages/qwik-react/
+          mkdir -p packages/qwik-react/lib/
+          mv artifact-qwikreact/lib/* packages/qwik-react/lib/
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -725,6 +725,9 @@ jobs:
       - name: Playwright E2E Integration Tests
         run: pnpm run test.e2e.integrations.${{ matrix.settings.browser }} --timeout 60000 --retries 7 --workers 1
 
+      - name: Playwright E2E Qwik React Tests
+        run: pnpm run test.e2e.qwik-react.${{ matrix.settings.browser }} --timeout 60000 --retries 7 --workers 1
+
       - name: Validate Create Qwik Cli
         if: matrix.settings.host != 'windows-latest'
         run: pnpm cli.validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -713,8 +713,7 @@ jobs:
           mv artifact-create-qwik/* packages/create-qwik/dist/
           mkdir -p packages/eslint-plugin-qwik/dist/
           mv artifact-eslint-plugin-qwik/* packages/eslint-plugin-qwik/dist/
-          mkdir -p packages/qwik-react/lib/
-          mv artifact-qwikreact/* packages/qwik-react/lib/
+          mv artifact-qwikreact/* packages/qwik-react/
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -713,6 +713,8 @@ jobs:
           mv artifact-create-qwik/* packages/create-qwik/dist/
           mkdir -p packages/eslint-plugin-qwik/dist/
           mv artifact-eslint-plugin-qwik/* packages/eslint-plugin-qwik/dist/
+          mkdir -p packages/qwik-react/lib/
+          mv artifact-qwikreact/* packages/qwik-react/lib/
 
       - run: pnpm install --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -245,6 +245,7 @@
     "test.e2e.integrations.webkit": "playwright test e2e/adapters-e2e/tests --project=webkit --config e2e/adapters-e2e/playwright.config.ts",
     "test.e2e.webkit": "playwright test starters --browser=webkit --config starters/playwright.config.ts",
     "test.e2e.qwik-react.chromium": "playwright test e2e/qwik-react-e2e/tests --project=chromium --config e2e/qwik-react-e2e/playwright.config.ts",
+    "test.e2e.qwik-react.webkit": "playwright test e2e/qwik-react-e2e/tests --project=webkit --config e2e/qwik-react-e2e/playwright.config.ts",
     "test.rust": "make test",
     "test.rust.update": "make test-update",
     "test.unit": "vitest packages",


### PR DESCRIPTION


# What is it?

this is a continuation of previos PR https://github.com/QwikDev/qwik/pull/7950 (forgot to add test runs to ci)

# Description

add test runs to ci

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [x] I added new tests to cover the fix / functionality
