### PR TITLE
refactor(router): improve plugin retrieval logic in Vite adapter

### DIFF
--- a/packages/qwik-router/src/adapters/shared/vite/index.ts
+++ b/packages/qwik-router/src/adapters/shared/vite/index.ts
@@ -48,9 +48,8 @@ export function viteAdapter(opts: ViteAdapterPluginOptions) {
         if (!qwikRouterPlugin) {
           throw new Error('Missing vite-plugin-qwik-router');
         }
-        qwikVitePlugin = config.plugins.find(
-          (p) => p.name === 'vite-plugin-qwik'
-        ) as QwikVitePlugin;
+        const foundQwikPlugin = config.plugins.find((p) => p.name === 'vite-plugin-qwik');
+        qwikVitePlugin = foundQwikPlugin as QwikVitePlugin;
         if (!qwikVitePlugin) {
           throw new Error('Missing vite-plugin-qwik');
         }

--- a/packages/qwik-router/src/buildtime/vite/plugin.ts
+++ b/packages/qwik-router/src/buildtime/vite/plugin.ts
@@ -134,7 +134,8 @@ function qwikRouterPlugin(userOpts?: QwikRouterVitePluginOptions): any {
 
       mdxTransform = await createMdxTransformer(ctx);
 
-      qwikPlugin = config.plugins.find((p) => p.name === 'vite-plugin-qwik') as QwikVitePlugin;
+      const foundPlugin = config.plugins.find((p) => p.name === 'vite-plugin-qwik');
+      qwikPlugin = foundPlugin as QwikVitePlugin;
       if (!qwikPlugin) {
         throw new Error('Missing vite-plugin-qwik');
       }


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Feature / enhancement
- Bug
- Docs / tests / types / typos
- Infra

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

 error TS2321: Excessive stack depth comparing types 'QwikVitePlugin' and 'Plugin$1<any>'.

137       qwikPlugin = config.plugins.find((p) => p.name === 'vite-plugin-qwik') as QwikVitePlugin;
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error in packages/qwik-router/src/buildtime/vite/plugin.ts:137


❌  Error: Command failed with exit code 2: tsc -p /Users/gwm/Desktop/github/qwik/packages/qwik-router/tsconfig.json
    at makeError (file:///Users/gwm/Desktop/github/qwik/node_modules/.pnpm/execa@8.0.1/node_modules/execa/lib/error.js:60:11)
    at handlePromise (file:///Users/gwm/Desktop/github/qwik/node_modules/.pnpm/execa@8.0.1/node_modules/execa/index.js:124:26)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async tscQwikRouter (/Users/gwm/Desktop/github/qwik/scripts/tsc.ts:18:18)
    at async build (/Users/gwm/Desktop/github/qwik/scripts/build.ts:110:7) {
  shortMessage: 'Command failed with exit code 2: tsc -p /Users/gwm/Desktop/github/qwik/packages/qwik-router/tsconfig.json',
  command: 'tsc -p /Users/gwm/Desktop/github/qwik/packages/qwik-router/tsconfig.json',
  escapedCommand: 'tsc -p "/Users/gwm/Desktop/github/qwik/packages/qwik-router/tsconfig.json"',
  exitCode: 2,
  signal: undefined,
  signalDescription: undefined,
  stdout: undefined,
  stderr: '',
  cwd: '/Users/gwm/Desktop/github/qwik',
  failed: true,
  timedOut: false,
  isCanceled: false,
  killed: false
}

fixed this type error

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
