### PR TITLE
fix: removed version from docs-e2e

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -11,8 +11,7 @@
     "@qwik.dev/dom": "2.1.19",
     "@qwik.dev/react": "2.0.0-0",
     "supabase-auth-helpers-qwik": "0.0.3",
-    "qwik-cli-e2e": "0.0.0",
-    "docs-e2e": "1.0.0"
+    "qwik-cli-e2e": "0.0.0"
   },
   "branch": "build/v2",
   "changesets": [

--- a/e2e/docs-e2e/package.json
+++ b/e2e/docs-e2e/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs-e2e",
   "description": "",
-  "version": "1.0.0",
+  "private": true,
   "author": "",
   "devDependencies": {
     "@playwright/test": "1.54.1",


### PR DESCRIPTION
This fixes the release automation that was broken by trying to release a private package. 


Note for next time (for PR reviewers) - notice that there's no version for private packages. 