### PR TITLE
removed qwik-react from changesets ignore

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,7 +11,6 @@
     "qwik-docs",
     "@builder.io/qwik-labs",
     "insights",
-    "@builder.io/qwik-react",
     "@builder.io/qwik-worker",
     "qwik-cli-e2e",
     "qwik-react-test-app",

--- a/.changeset/real-chefs-teach.md
+++ b/.changeset/real-chefs-teach.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik-react': patch
+---
+
+FIX: unmount qwikify react root alongside with qwik component (done by @shashkashishka in #7864)


### PR DESCRIPTION

# What is it?

<!-- pick one and remove the others -->

- Bug
- Infra

# Description
qwik-react was in the ignore list of changesets, making it impossible to select in the changeset menu when generating a new change. 

This fixes it and also redo the changeset from #7865 to make sure the qwik-react package gets properly released with the new updates. 

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`