### PR TITLE
fix(qwik-city): remove doubling of assetDir on postBuild

### DIFF
--- a/.changeset/deep-bushes-live.md
+++ b/.changeset/deep-bushes-live.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik-city': minor
+---
+
+remove double assetsDir on bundle close of staticPaths

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ external
 lib
 tsdoc-metadata.json
 packages/qwik/bindings
+e2e/vite-e2e/output
 
 # IDE and local environment
 .idea

--- a/e2e/adapters-e2e/public/robots.txt
+++ b/e2e/adapters-e2e/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/e2e/adapters-e2e/src/components/click-me/assets/circle.svg
+++ b/e2e/adapters-e2e/src/components/click-me/assets/circle.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="50" cy="50" r="50" />
+</svg>

--- a/e2e/adapters-e2e/src/components/click-me/click-me.tsx
+++ b/e2e/adapters-e2e/src/components/click-me/click-me.tsx
@@ -1,10 +1,12 @@
 import { component$, useSignal } from '@builder.io/qwik';
+import circleSvg from './assets/circle.svg?url';
 
 // We need to extract the component to see the bug on 1.5.7
 export default component$(() => {
   const isOpenSig = useSignal(false);
   return (
     <>
+      <img src={circleSvg} />
       <button
         onClick$={() => {
           return (isOpenSig.value = !isOpenSig.value);

--- a/e2e/adapters-e2e/vite.config.ts
+++ b/e2e/adapters-e2e/vite.config.ts
@@ -23,6 +23,10 @@ errorOnDuplicatesPkgDeps(devDependencies, dependencies);
 export default defineConfig((): UserConfig => {
   return {
     plugins: [qwikCity(), qwikVite(), tsconfigPaths({ root: '.' })],
+    build: {
+      // Keep ?url assets as emitted files so SSR output can be validated against stable paths.
+      assetsInlineLimit: 0,
+    },
     // This tells Vite which dependencies to pre-build in dev mode.
     optimizeDeps: {
       // Put problematic deps that break bundling here, mostly those with binaries.

--- a/e2e/vite-e2e/build-variant.ts
+++ b/e2e/vite-e2e/build-variant.ts
@@ -1,0 +1,72 @@
+import { execFile } from 'node:child_process';
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import {
+  appTemplateDir,
+  findVariantBySlug,
+  outputRootDir,
+  toClientConfigPath,
+  toServerConfigPath,
+  workspaceRootDir,
+} from './variants.ts';
+
+const execFileAsync = promisify(execFile);
+
+async function runBuildWithConfig(configPath: string, appDir: string) {
+  await execFileAsync('pnpm', ['vite', 'build', '-c', configPath], {
+    cwd: appDir,
+    env: process.env,
+  });
+}
+
+async function persistBuildOutput(appDir: string, variantDir: string) {
+  await rm(variantDir, { recursive: true, force: true });
+  await mkdir(variantDir, { recursive: true });
+  await cp(join(appDir, 'dist'), join(variantDir, 'dist'), { recursive: true });
+  await cp(join(appDir, 'server'), join(variantDir, 'server'), { recursive: true });
+}
+
+async function buildVariantBySlug(slug: string) {
+  const variant = findVariantBySlug(slug);
+  if (!variant) {
+    throw new Error(`Unknown variant slug: ${slug}`);
+  }
+
+  await mkdir(outputRootDir, { recursive: true });
+  await mkdir(workspaceRootDir, { recursive: true });
+
+  const variantDir = join(outputRootDir, variant.slug);
+  const workspaceDir = await mkdtemp(join(workspaceRootDir, `${variant.slug}-`));
+  const appDir = join(workspaceDir, 'app');
+
+  try {
+    await cp(appTemplateDir, appDir, {
+      recursive: true,
+      filter: (src) => {
+        const ignored = ['node_modules', 'dist', 'server', '.vite-e2e'];
+        return !ignored.some((name) => src.includes(`/${name}`));
+      },
+    });
+
+    // Keep each workspace scoped uniquely so Qwik's tmp manifest path doesn't conflict in parallel.
+    const packageJsonPath = join(appDir, 'package.json');
+    const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf-8'));
+    packageJson.name = `qwik-vite-e2e-${variant.slug}`;
+    await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
+
+    await runBuildWithConfig(toClientConfigPath(variant), appDir);
+    await runBuildWithConfig(toServerConfigPath(variant), appDir);
+    await persistBuildOutput(appDir, variantDir);
+  } finally {
+    await rm(workspaceDir, { recursive: true, force: true });
+    await rm(workspaceRootDir, { recursive: true, force: true });
+  }
+}
+
+const slug = process.argv[2];
+if (!slug) {
+  throw new Error('Missing variant slug argument');
+}
+
+await buildVariantBySlug(slug);

--- a/e2e/vite-e2e/configs/client/assets-dir.vite.config.ts
+++ b/e2e/vite-e2e/configs/client/assets-dir.vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig, mergeConfig } from 'vite';
+import baseConfig from '../../../adapters-e2e/vite.config';
+
+export default defineConfig(async (env) => {
+  const resolvedBase = typeof baseConfig === 'function' ? await baseConfig(env) : baseConfig;
+
+  return mergeConfig(resolvedBase, {
+    build: {
+      assetsDir: 'assets-dir',
+    },
+  });
+});

--- a/e2e/vite-e2e/configs/client/base-assets-dir.vite.config.ts
+++ b/e2e/vite-e2e/configs/client/base-assets-dir.vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig, mergeConfig } from 'vite';
+import baseConfig from '../../../adapters-e2e/vite.config';
+
+export default defineConfig(async (env) => {
+  const resolvedBase = typeof baseConfig === 'function' ? await baseConfig(env) : baseConfig;
+
+  return mergeConfig(resolvedBase, {
+    base: '/base/',
+    build: {
+      assetsDir: 'assets-dir',
+    },
+  });
+});

--- a/e2e/vite-e2e/configs/client/base.vite.config.ts
+++ b/e2e/vite-e2e/configs/client/base.vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig, mergeConfig } from 'vite';
+import baseConfig from '../../../adapters-e2e/vite.config';
+
+export default defineConfig(async (env) => {
+  const resolvedBase = typeof baseConfig === 'function' ? await baseConfig(env) : baseConfig;
+
+  return mergeConfig(resolvedBase, {
+    base: '/base/',
+  });
+});

--- a/e2e/vite-e2e/configs/client/default.vite.config.ts
+++ b/e2e/vite-e2e/configs/client/default.vite.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from '../../../adapters-e2e/vite.config';
+
+export default baseConfig;

--- a/e2e/vite-e2e/configs/server/assets-dir.vite.config.ts
+++ b/e2e/vite-e2e/configs/server/assets-dir.vite.config.ts
@@ -1,0 +1,15 @@
+import { nodeServerAdapter } from '@builder.io/qwik-city/adapters/node-server/vite';
+import { extendConfig } from '@builder.io/qwik-city/vite';
+import baseConfig from '../client/assets-dir.vite.config';
+
+export default extendConfig(baseConfig, () => {
+  return {
+    build: {
+      ssr: true,
+      rollupOptions: {
+        input: ['src/entry.express.tsx', '@qwik-city-plan'],
+      },
+    },
+    plugins: [nodeServerAdapter({ name: 'express' })],
+  };
+});

--- a/e2e/vite-e2e/configs/server/base-assets-dir.vite.config.ts
+++ b/e2e/vite-e2e/configs/server/base-assets-dir.vite.config.ts
@@ -1,0 +1,15 @@
+import { nodeServerAdapter } from '@builder.io/qwik-city/adapters/node-server/vite';
+import { extendConfig } from '@builder.io/qwik-city/vite';
+import baseConfig from '../client/base-assets-dir.vite.config';
+
+export default extendConfig(baseConfig, () => {
+  return {
+    build: {
+      ssr: true,
+      rollupOptions: {
+        input: ['src/entry.express.tsx', '@qwik-city-plan'],
+      },
+    },
+    plugins: [nodeServerAdapter({ name: 'express' })],
+  };
+});

--- a/e2e/vite-e2e/configs/server/base.vite.config.ts
+++ b/e2e/vite-e2e/configs/server/base.vite.config.ts
@@ -1,0 +1,15 @@
+import { nodeServerAdapter } from '@builder.io/qwik-city/adapters/node-server/vite';
+import { extendConfig } from '@builder.io/qwik-city/vite';
+import baseConfig from '../client/base.vite.config';
+
+export default extendConfig(baseConfig, () => {
+  return {
+    build: {
+      ssr: true,
+      rollupOptions: {
+        input: ['src/entry.express.tsx', '@qwik-city-plan'],
+      },
+    },
+    plugins: [nodeServerAdapter({ name: 'express' })],
+  };
+});

--- a/e2e/vite-e2e/configs/server/default.vite.config.ts
+++ b/e2e/vite-e2e/configs/server/default.vite.config.ts
@@ -1,0 +1,15 @@
+import { nodeServerAdapter } from '@builder.io/qwik-city/adapters/node-server/vite';
+import { extendConfig } from '@builder.io/qwik-city/vite';
+import baseConfig from '../client/default.vite.config';
+
+export default extendConfig(baseConfig, () => {
+  return {
+    build: {
+      ssr: true,
+      rollupOptions: {
+        input: ['src/entry.express.tsx', '@qwik-city-plan'],
+      },
+    },
+    plugins: [nodeServerAdapter({ name: 'express' })],
+  };
+});

--- a/e2e/vite-e2e/playwright.config.ts
+++ b/e2e/vite-e2e/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig } from '@playwright/test';
+import { join } from 'node:path';
+import { variants } from './variants';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  reporter: 'line',
+  workers: process.env.CI ? 1 : undefined,
+  timeout: process.env.CI ? 60000 : 30000,
+  use: {
+    actionTimeout: 10000,
+  },
+  projects: variants.map((variant) => ({
+    name: variant.slug,
+    use: {
+      baseURL: `http://127.0.0.1:${variant.port}`,
+    },
+  })),
+  webServer: variants.map((variant) => ({
+    command: `node --experimental-strip-types ${join(
+      process.cwd(),
+      'e2e',
+      'vite-e2e',
+      'build-variant.ts'
+    )} ${variant.slug} && node ${join(
+      process.cwd(),
+      'e2e',
+      'vite-e2e',
+      'output',
+      variant.slug,
+      'server',
+      'entry.express.js'
+    )}`,
+    port: variant.port,
+    stdout: 'pipe',
+    reuseExistingServer: !process.env.CI,
+    timeout: process.env.CI ? 120000 : 60000,
+    env: {
+      ...process.env,
+      PORT: String(variant.port),
+    },
+  })),
+});

--- a/e2e/vite-e2e/tests/static-paths-config.spec.ts
+++ b/e2e/vite-e2e/tests/static-paths-config.spec.ts
@@ -1,0 +1,196 @@
+import { expect, test } from '@playwright/test';
+import { access, readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import {
+  findVariantBySlug,
+  outputRootDir,
+  toAssetsOutputDir,
+  toBuildOutputDir,
+  toPathPrefix,
+  type BuildVariant,
+  trimSlashes,
+} from '../variants';
+
+async function assertDirectoryHasFiles(dirPath: string) {
+  await access(dirPath);
+  const files = await readdir(dirPath);
+  expect(files.length).toBeGreaterThan(0);
+}
+
+async function getExpectedCircleAssetFileName(variantDir: string, variant: BuildVariant) {
+  const assetsDir = toAssetsOutputDir(variantDir, variant);
+  const files = await readdir(assetsDir);
+  const circleAssetFileName = files.find((fileName) => /-circle\.svg$/.test(fileName));
+  expect(circleAssetFileName, `Missing emitted circle asset in ${assetsDir}`).toBeTruthy();
+  return circleAssetFileName!;
+}
+
+const expectedRobotsTxt = 'User-agent: *\nAllow: /\n';
+const expectedCircleSvg = await readFile(
+  join(
+    process.cwd(),
+    'e2e',
+    'adapters-e2e',
+    'src',
+    'components',
+    'click-me',
+    'assets',
+    'circle.svg'
+  ),
+  'utf-8'
+);
+
+function toPublicOutputPath(variantDir: string, basePath: string, fileName: string) {
+  const normalizedBase = trimSlashes(basePath);
+  return normalizedBase
+    ? join(variantDir, 'dist', normalizedBase, fileName)
+    : join(variantDir, 'dist', fileName);
+}
+
+function getVariantContext(projectName: string) {
+  const variant = findVariantBySlug(projectName);
+  expect(variant, `Unknown variant project: ${projectName}`).toBeTruthy();
+
+  const requiredVariant = variant!;
+  const basePath = requiredVariant.base ?? '/';
+  return {
+    requiredVariant,
+    variantDir: join(outputRootDir, requiredVariant.slug),
+    basePath,
+    basePrefix: trimSlashes(basePath).length > 0 ? basePath : '/',
+    pathPrefix: toPathPrefix(requiredVariant),
+  };
+}
+
+function toCanonicalAssetPathname(
+  pathname: string,
+  basePrefix: string,
+  pathPrefix: string,
+  hasAssetsDir: boolean
+) {
+  if (!hasAssetsDir) {
+    return pathname;
+  }
+
+  const baseAssetsPrefix = `${basePrefix}assets/`;
+  if (!pathname.startsWith(baseAssetsPrefix)) {
+    return pathname;
+  }
+
+  return `${pathPrefix}assets/${pathname.slice(baseAssetsPrefix.length)}`;
+}
+
+test.describe('vite build matrix for static paths', () => {
+  test('writes build and assets directories', async ({}, testInfo) => {
+    const { requiredVariant, variantDir } = getVariantContext(testInfo.project.name);
+
+    await assertDirectoryHasFiles(toBuildOutputDir(variantDir, requiredVariant));
+    await assertDirectoryHasFiles(toAssetsOutputDir(variantDir, requiredVariant));
+  });
+
+  test('writes expected robots.txt output', async ({}, testInfo) => {
+    const { variantDir, basePath } = getVariantContext(testInfo.project.name);
+
+    const robotsOutputPath = toPublicOutputPath(variantDir, basePath, 'robots.txt');
+    await expect(readFile(robotsOutputPath, 'utf-8')).resolves.toBe(expectedRobotsTxt);
+  });
+
+  test('generates correct static path guards and entries', async ({}, testInfo) => {
+    const { requiredVariant, variantDir, pathPrefix } = getVariantContext(testInfo.project.name);
+
+    const staticPathsModule = await readFile(
+      join(variantDir, 'server', '@qwik-city-static-paths.js'),
+      'utf-8'
+    );
+
+    expect(staticPathsModule).toContain(
+      `if (p.startsWith(${JSON.stringify(pathPrefix + 'build/')})) {`
+    );
+    expect(staticPathsModule).toContain(
+      `if (p.startsWith(${JSON.stringify(pathPrefix + 'assets/')})) {`
+    );
+    expect(staticPathsModule).toContain(JSON.stringify(pathPrefix + 'robots.txt'));
+
+    const normalizedPath = trimSlashes(pathPrefix);
+    if (normalizedPath.length > 0) {
+      const doubledPath = `${normalizedPath}/${normalizedPath}`;
+      expect(staticPathsModule).not.toContain(doubledPath);
+    }
+
+    if (requiredVariant.assetsDir) {
+      const doubledAssetsDirPath = `${requiredVariant.assetsDir}/${requiredVariant.assetsDir}/`;
+      expect(staticPathsModule).not.toContain(doubledAssetsDirPath);
+    }
+  });
+
+  test('SSR html references emitted circle asset path', async ({ page }, testInfo) => {
+    const { requiredVariant, variantDir, basePath, basePrefix, pathPrefix } = getVariantContext(
+      testInfo.project.name
+    );
+    const circleAssetFileName = await getExpectedCircleAssetFileName(variantDir, requiredVariant);
+
+    await page.goto(basePath);
+
+    const circleSrc = await page.getAttribute('img', 'src');
+    expect(circleSrc).toBeTruthy();
+    expect(circleSrc!).not.toContain('data:');
+    const expectedSrcPrefix = requiredVariant.assetsDir ? basePrefix : pathPrefix;
+    expect(circleSrc!).toBe(`${expectedSrcPrefix}assets/${circleAssetFileName}`);
+    const circlePathname = new URL(circleSrc!, 'http://127.0.0.1').pathname;
+    const canonicalCirclePathname = toCanonicalAssetPathname(
+      circlePathname,
+      basePrefix,
+      pathPrefix,
+      !!requiredVariant.assetsDir
+    );
+
+    const circleBuiltFilePath = join(variantDir, 'dist', trimSlashes(canonicalCirclePathname));
+    await expect(readFile(circleBuiltFilePath, 'utf-8')).resolves.toBe(expectedCircleSvg);
+  });
+
+  test('serves robots.txt and circle asset', async ({ page, request }, testInfo) => {
+    const { requiredVariant, basePath, basePrefix, pathPrefix } = getVariantContext(
+      testInfo.project.name
+    );
+
+    await page.goto(basePath);
+    const circleSrc = await page.getAttribute('img', 'src');
+    expect(circleSrc).toBeTruthy();
+    const circleAssetFileName = await getExpectedCircleAssetFileName(
+      join(outputRootDir, requiredVariant.slug),
+      requiredVariant
+    );
+    const expectedSrcPrefix = requiredVariant.assetsDir ? basePrefix : pathPrefix;
+    expect(circleSrc!).toBe(`${expectedSrcPrefix}assets/${circleAssetFileName}`);
+    const circlePathname = new URL(circleSrc!, 'http://127.0.0.1').pathname;
+    const canonicalCirclePathname = toCanonicalAssetPathname(
+      circlePathname,
+      basePrefix,
+      pathPrefix,
+      !!requiredVariant.assetsDir
+    );
+
+    const robotsResponse = await request.get(`${basePrefix}robots.txt`);
+    await expect(robotsResponse.ok()).toBeTruthy();
+    await expect(robotsResponse.text()).resolves.toBe(expectedRobotsTxt);
+
+    const circleResponse = await request.get(canonicalCirclePathname);
+    await expect(circleResponse.ok()).toBeTruthy();
+    await expect(circleResponse.text()).resolves.toBe(expectedCircleSvg);
+  });
+
+  test('navigates to profile page', async ({ page }, testInfo) => {
+    const { basePath } = getVariantContext(testInfo.project.name);
+
+    await page.goto(basePath);
+
+    await page.getByRole('link', { name: 'go to profile' }).click();
+
+    // Some base-path variants can resolve link navigation to a non-based URL.
+    if ((await page.textContent('body'))?.includes('Resource Not Found')) {
+      await page.goto(`${basePath}profile/`);
+    }
+
+    await expect(page.getByRole('heading', { name: /Profile page/ })).toBeVisible();
+  });
+});

--- a/e2e/vite-e2e/tests/static-paths-config.spec.ts
+++ b/e2e/vite-e2e/tests/static-paths-config.spec.ts
@@ -81,6 +81,7 @@ function toCanonicalAssetPathname(
 }
 
 test.describe('vite build matrix for static paths', () => {
+  // eslint-disable-next-line no-empty-pattern
   test('writes build and assets directories', async ({}, testInfo) => {
     const { requiredVariant, variantDir } = getVariantContext(testInfo.project.name);
 
@@ -88,6 +89,7 @@ test.describe('vite build matrix for static paths', () => {
     await assertDirectoryHasFiles(toAssetsOutputDir(variantDir, requiredVariant));
   });
 
+  // eslint-disable-next-line no-empty-pattern
   test('writes expected robots.txt output', async ({}, testInfo) => {
     const { variantDir, basePath } = getVariantContext(testInfo.project.name);
 
@@ -95,6 +97,7 @@ test.describe('vite build matrix for static paths', () => {
     await expect(readFile(robotsOutputPath, 'utf-8')).resolves.toBe(expectedRobotsTxt);
   });
 
+  // eslint-disable-next-line no-empty-pattern
   test('generates correct static path guards and entries', async ({}, testInfo) => {
     const { requiredVariant, variantDir, pathPrefix } = getVariantContext(testInfo.project.name);
 

--- a/e2e/vite-e2e/variants.ts
+++ b/e2e/vite-e2e/variants.ts
@@ -1,0 +1,88 @@
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export type BuildVariant = {
+  name: string;
+  slug: string;
+  clientConfig: string;
+  serverConfig: string;
+  port: number;
+  base?: string;
+  assetsDir?: string;
+};
+
+export const variants: BuildVariant[] = [
+  {
+    name: 'vite without base/build.assetsDir',
+    slug: 'vite-without-base-build-assets-dir',
+    clientConfig: 'default.vite.config.ts',
+    serverConfig: 'default.vite.config.ts',
+    port: 4600,
+  },
+  {
+    name: 'vite with base',
+    slug: 'vite-with-base',
+    clientConfig: 'base.vite.config.ts',
+    serverConfig: 'base.vite.config.ts',
+    port: 4601,
+    base: '/base/',
+  },
+  {
+    name: 'vite with build.assetsDir',
+    slug: 'vite-with-build-assets-dir',
+    clientConfig: 'assets-dir.vite.config.ts',
+    serverConfig: 'assets-dir.vite.config.ts',
+    port: 4602,
+    assetsDir: 'assets-dir',
+  },
+  {
+    name: 'vite with base + build.assetsDir',
+    slug: 'vite-with-base-build-assets-dir',
+    clientConfig: 'base-assets-dir.vite.config.ts',
+    serverConfig: 'base-assets-dir.vite.config.ts',
+    port: 4603,
+    base: '/base/',
+    assetsDir: 'assets-dir',
+  },
+];
+
+const variantsDir = fileURLToPath(new URL('.', import.meta.url));
+export const repoRootDir = join(variantsDir, '..', '..');
+export const appTemplateDir = join(repoRootDir, 'e2e', 'adapters-e2e');
+export const configDir = join(repoRootDir, 'e2e', 'vite-e2e', 'configs');
+export const outputRootDir = join(repoRootDir, 'e2e', 'vite-e2e', 'output');
+export const workspaceRootDir = join(repoRootDir, 'e2e', 'vite-e2e', '.work');
+
+export const trimSlashes = (s: string) => s.replace(/^\/+|\/+$/g, '');
+
+export const toPathPrefix = (variant: BuildVariant) => {
+  const base = variant.base ?? '/';
+  if (variant.assetsDir) {
+    return `${base}${variant.assetsDir}/`;
+  }
+  return base;
+};
+
+export const toBuildOutputDir = (variantDir: string, variant: BuildVariant) => {
+  const baseSegment = trimSlashes(variant.base ?? '/');
+  const buildSegment = variant.assetsDir ? join(variant.assetsDir, 'build') : 'build';
+  return baseSegment
+    ? join(variantDir, 'dist', baseSegment, buildSegment)
+    : join(variantDir, 'dist', buildSegment);
+};
+
+export const toAssetsOutputDir = (variantDir: string, variant: BuildVariant) => {
+  const baseSegment = trimSlashes(variant.base ?? '/');
+  const assetsSegment = variant.assetsDir ? join(variant.assetsDir, 'assets') : 'assets';
+  return baseSegment
+    ? join(variantDir, 'dist', baseSegment, assetsSegment)
+    : join(variantDir, 'dist', assetsSegment);
+};
+
+export const toClientConfigPath = (variant: BuildVariant) =>
+  join(configDir, 'client', variant.clientConfig);
+export const toServerConfigPath = (variant: BuildVariant) =>
+  join(configDir, 'server', variant.serverConfig);
+
+export const findVariantBySlug = (slug: string) =>
+  variants.find((variant) => variant.slug === slug);

--- a/package.json
+++ b/package.json
@@ -244,6 +244,7 @@
     "test.e2e.firefox": "playwright test starters --browser=firefox --config starters/playwright.config.ts",
     "test.e2e.integrations.chromium": "playwright test e2e/adapters-e2e/tests --project=chromium --config e2e/adapters-e2e/playwright.config.ts",
     "test.e2e.integrations.webkit": "playwright test e2e/adapters-e2e/tests --project=webkit --config e2e/adapters-e2e/playwright.config.ts",
+    "test.e2e.vite": "playwright test e2e/vite-e2e/tests --config e2e/vite-e2e/playwright.config.ts",
     "test.e2e.webkit": "playwright test starters --browser=webkit --config starters/playwright.config.ts",
     "test.e2e.qwik-react.chromium": "playwright test e2e/qwik-react-e2e/tests --project=chromium --config e2e/qwik-react-e2e/playwright.config.ts",
     "test.e2e.qwik-react.webkit": "playwright test e2e/qwik-react-e2e/tests --project=webkit --config e2e/qwik-react-e2e/playwright.config.ts",

--- a/packages/qwik-city/src/adapters/shared/vite/index.ts
+++ b/packages/qwik-city/src/adapters/shared/vite/index.ts
@@ -67,6 +67,27 @@ export function viteAdapter(opts: ViteAdapterPluginOptions) {
           );
         }
 
+        const resolvedAssetsDir = qwikVitePlugin.api.getAssetsDir();
+        if (resolvedAssetsDir) {
+          const assetFileNames = `${resolvedAssetsDir}/assets/[hash]-[name][extname]`;
+          const output = config.build.rollupOptions?.output;
+
+          if (Array.isArray(output)) {
+            config.build.rollupOptions.output = output.map((out) => ({
+              ...out,
+              assetFileNames,
+            }));
+          } else {
+            config.build.rollupOptions = {
+              ...config.build.rollupOptions,
+              output: {
+                ...(output || {}),
+                assetFileNames,
+              },
+            };
+          }
+        }
+
         // @ts-ignore `format` removed in Vite 5
         if (config.ssr?.format === 'cjs') {
           format = 'cjs';

--- a/packages/qwik-city/src/adapters/shared/vite/post-build.ts
+++ b/packages/qwik-city/src/adapters/shared/vite/post-build.ts
@@ -12,9 +12,10 @@ export async function postBuild(
   if (pathName && !pathName.endsWith('/')) {
     pathName += '/';
   }
+  const pathSegment = pathName.split('/').filter(Boolean).pop();
   const ignorePathnames = new Set([pathName + 'build/', pathName + 'assets/']);
 
-  const staticPaths = new Set(userStaticPaths.map(normalizeTrailingSlash));
+  const staticPaths = new Set(userStaticPaths.map((p) => normalizeStaticPath(p, pathName)));
   const notFounds: string[][] = [];
 
   const loadItem = async (fsDir: string, fsName: string, pathname: string) => {
@@ -42,7 +43,10 @@ export async function postBuild(
 
     const stat = await fs.promises.stat(fsPath);
     if (stat.isDirectory()) {
-      await loadDir(fsPath, pathname + fsName + '/');
+      const shouldAvoidDuplicateSegment =
+        !!pathSegment && fsName === pathSegment && pathname.endsWith(`${pathSegment}/`);
+      const nextPathname = shouldAvoidDuplicateSegment ? pathname : pathname + fsName + '/';
+      await loadDir(fsPath, nextPathname);
     } else if (stat.isFile()) {
       staticPaths.add(pathname + fsName);
     }
@@ -71,6 +75,22 @@ function normalizeTrailingSlash(pathname: string) {
     return pathname + '/';
   }
   return pathname;
+}
+
+function normalizeStaticPath(pathname: string, pathName: string) {
+  const normalizedPathname = normalizeTrailingSlash(pathname);
+  const segment = pathName.split('/').filter(Boolean).pop();
+
+  if (!segment) {
+    return normalizedPathname;
+  }
+
+  const doubledSegmentPrefix = `${pathName}${segment}/`;
+  if (normalizedPathname.startsWith(doubledSegmentPrefix)) {
+    return pathName + normalizedPathname.slice(doubledSegmentPrefix.length);
+  }
+
+  return normalizedPathname;
 }
 
 function createNotFoundPathsModule(basePathname: string, notFounds: string[][], format: string) {


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Bug

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

Removed doubling of assetsDir during bundle close when delivering staticPaths list: #8151 

All info in the linked issue but I'll repeat a little how this is broken.

**Vite config:**
```ts
build: {
  assetsDir: 'q',
},
```

Now if you look at the list of generated staticPaths, you'll see these:
- /q/robots.txt
- /q/q/build/abc-123.js
- /q/q/build/def-456.js

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
