### PR TITLE
fix(runtime): throw error when functions are passed as JSX children

### DIFF
--- a/.changeset/error-function-jsx-children.md
+++ b/.changeset/error-function-jsx-children.md
@@ -1,0 +1,5 @@
+---
+'@builder.io/qwik': patch
+---
+
+Throw an error when a function is passed as a JSX child instead of silently skipping it. This restores the v1 behavior where passing `{myFn}` instead of `{myFn()}` would produce a clear error message.

--- a/packages/qwik/src/core/render/dom/render-dom.ts
+++ b/packages/qwik/src/core/render/dom/render-dom.ts
@@ -176,6 +176,12 @@ export const processData = (
     return node.then((node) => processData(node, invocationContext));
   } else if (node === SkipRender) {
     return new ProcessedJSXNodeImpl(SKIP_RENDER_TYPE, EMPTY_OBJ, null, EMPTY_ARRAY, 0, null);
+  } else if (isFunction(node)) {
+    throw new Error(
+      `Functions are not valid JSX children. ` +
+        `You might have passed a function instead of calling it: use {fn()} instead of {fn}. ` +
+        `If this is a component, wrap it with component$().`
+    );
   } else {
     logWarn('A unsupported value was passed to the JSX, skipping render. Value:', node);
     return undefined;

--- a/packages/qwik/src/core/render/dom/render.unit.tsx
+++ b/packages/qwik/src/core/render/dom/render.unit.tsx
@@ -44,6 +44,16 @@ test('should only render string/number', async () => {
   await expectRendered(fixture, '<div>string123</div>');
 });
 
+test('should throw error when function is passed as JSX child', async () => {
+  const fixture = new ElementFixture();
+  try {
+    await render(fixture.host, <div>{() => <span>hello</span>}</div>);
+    assert.fail('Expected an error to be thrown');
+  } catch (e: any) {
+    assert.match(e.message, /is not an accepted value|Functions are not valid JSX children/);
+  }
+});
+
 test('should serialize events correctly', async () => {
   const fixture = new ElementFixture();
   await render(

--- a/packages/qwik/src/core/render/ssr/render-ssr.ts
+++ b/packages/qwik/src/core/render/ssr/render-ssr.ts
@@ -923,6 +923,12 @@ const processData = (
   } else if (isPromise(node)) {
     stream.write(FLUSH_COMMENT);
     return node.then((node) => processData(node, rCtx, ssrCtx, stream, flags, beforeClose));
+  } else if (isFunction(node)) {
+    throw new Error(
+      `Functions are not valid JSX children. ` +
+        `You might have passed a function instead of calling it: use {fn()} instead of {fn}. ` +
+        `If this is a component, wrap it with component$().`
+    );
   } else {
     logWarn('A unsupported value was passed to the JSX, skipping render. Value:', node);
     return;

--- a/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
+++ b/packages/qwik/src/core/render/ssr/render-ssr.unit.tsx
@@ -1968,6 +1968,11 @@ export const HtmlContext = component$(() => {
   return <Slot />;
 });
 
+test('should throw error when function is passed as JSX child', async () => {
+  const fn = () => jsx('div', { children: 'hello' });
+  await throws(() => testSSR(jsx('body', { children: [fn] }), ''));
+});
+
 async function testSSR(
   node: JSXOutput,
   expected: string | string[],


### PR DESCRIPTION
# What is it?

- Bug

# Description

Closes #8425

Right now if you do something like `{() => <div>hi</div>}` inside a component, it just... renders nothing. No error, no warning in the console (unless you're in dev mode). Pretty confusing when you're staring at your code wondering where your content went.

In v1 this actually threw an SSR error, which was way more helpful. The v2 `processData()` in both SSR and DOM paths has a catch-all `else` that logs a warning and moves on, so functions just get silently swallowed.

The fix adds a `typeof node === 'function'` check before that catch-all in both `render-ssr.ts` and `render-dom.ts`. Now you get a clear error telling you to either call the function (`{fn()}`) or wrap it with `component$()`.

Dev mode already catches this at JSX creation time via `validateJSXNode`, but that's behind a `qDev` guard and gets stripped in prod. This ensures the error shows up regardless.

## One thing worth discussing

This technically turns a silent no-op into a runtime error. If someone has `{myFn}` in production code today, it renders nothing but doesn't crash. After this change, it would crash.

In practice the impact should be minimal -- dev mode and ESLint both already flag this pattern, so it's unlikely to survive into prod unnoticed. But if you'd prefer a softer approach (like `logError` instead of `throw`), happy to adjust.

# Checklist

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [x] I added new tests to cover the fix / functionality