### PR TITLE
[codex] Improve missing Suspense flag diagnostic

### DIFF
--- a/packages/qwik-vite/src/plugins/plugin.ts
+++ b/packages/qwik-vite/src/plugins/plugin.ts
@@ -80,6 +80,14 @@ export enum ExperimentalFeatures {
   insights = 'insights',
 }
 
+const MISSING_SUSPENSE_EXPERIMENTAL_FLAG =
+  `Suspense requires qwikVite({ experimental: ['suspense'] }). ` +
+  `Add the 'suspense' experimental flag in your Vite config before using ` +
+  `Suspense, Reveal, or async UI that depends on Suspense coordination. ` +
+  `Without this flag, SSR async boundaries can fail to resolve correctly.`;
+
+const CORE_SUSPENSE_IMPORT = /import\s*{[^}]*\bSuspense\b[^}]*}\s*from\s*['"]@qwik\.dev\/core['"]/;
+
 export interface QwikPackages {
   id: string;
   path: string;
@@ -794,6 +802,10 @@ export function createQwikPlugin(optimizerOptions: OptimizerOptions = {}) {
             ? 'hmr'
             : 'dev'
           : 'prod';
+
+    if (mode !== 'lib' && !opts.experimental?.suspense && CORE_SUSPENSE_IMPORT.test(code)) {
+      ctx.error(`${MISSING_SUSPENSE_EXPERIMENTAL_FLAG}\n\nFile: ${pathId}`);
+    }
 
     if (mode !== 'lib') {
       // this messes a bit with the source map, but it's ok for if statements

--- a/packages/qwik-vite/src/plugins/plugin.unit.ts
+++ b/packages/qwik-vite/src/plugins/plugin.unit.ts
@@ -227,6 +227,35 @@ test('experimental[]', async () => {
   assert.deepEqual(opts.experimental, { [flag]: true } as any);
 });
 
+test('transform explains missing Suspense experimental flag', async () => {
+  const plugin = await mockPlugin();
+  await plugin.normalizeOptions({ rootDir: '/root', srcDir: '/root/src' });
+
+  await expect(
+    plugin.transform(
+      {
+        addWatchFile: () => undefined,
+        emitFile: () => undefined,
+        error: (message: string) => {
+          throw new Error(message);
+        },
+      } as any,
+      `import { component$, Suspense, useAsync$ } from '@qwik.dev/core';
+
+export default component$(() => {
+  const product = useAsync$(async () => ({ title: 'Keyboard' }));
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <h1>{product.value.title}</h1>
+    </Suspense>
+  );
+});
+`,
+      '/root/src/routes/index.tsx'
+    )
+  ).rejects.toThrow(`Suspense requires qwikVite({ experimental: ['suspense'] })`);
+});
+
 describe('resolveId', () => {
   test('qrls', async () => {
     const plugin = await mockPlugin();


### PR DESCRIPTION
## Summary

Adds an early Qwik Vite transform diagnostic when a module imports `Suspense` from `@qwik.dev/core` but the app has not enabled `qwikVite({ experimental: ['suspense'] })`.

The new error tells the developer exactly which Vite config flag is missing and includes the file path that triggered the check.

## Problem

Without the `suspense` experimental flag, async UI that depends on Suspense coordination can fail in a confusing way during SSR. In practice this can look like a stalled SSR request or an unrelated optimizer/runtime symptom, which sends developers looking in the wrong place.

The existing runtime error is useful when the `Suspense` component function actually runs, but it is too late for some dev-server paths. Catching the import during transform gives a direct configuration error before the app gets into an opaque async render state.

## Changes

- Adds a focused missing-Suspense-flag diagnostic in the Qwik Vite plugin transform.
- Adds a unit test covering `Suspense` import without the experimental flag.

## Validation

- `pnpm build.core`
- `pnpm vitest --run packages/qwik-vite/src/plugins/plugin.unit.ts`
