### PR TITLE
feat(core): add non-QRL API aliases

### DIFF
--- a/.changeset/non-qrl-api-compat.md
+++ b/.changeset/non-qrl-api-compat.md
@@ -1,0 +1,7 @@
+---
+'@qwik.dev/core': patch
+'@qwik.dev/router': patch
+'@qwik.dev/react': patch
+---
+
+feat: add non-QRL aliases for callback APIs

--- a/e2e/qwik-e2e/apps/e2e/src/components/events/events.tsx
+++ b/e2e/qwik-e2e/apps/e2e/src/components/events/events.tsx
@@ -28,6 +28,7 @@ const EventsParent = component$(() => {
     passivePreventDefaultState: 'unset',
     passiveDocumentCount: 0,
     passiveWindowCount: 0,
+    qrlNoDollarClickCount: 0,
     hoverOrderLog: '',
   });
   return (
@@ -190,6 +191,15 @@ const EventsParent = component$(() => {
       </p>
       <p id="count-passive-document">countPassiveDocument: {store.passiveDocumentCount}</p>
       <p id="count-passive-window">countPassiveWindow: {store.passiveWindowCount}</p>
+      <button
+        id="qrl-no-dollar-click"
+        onClick={$(() => {
+          store.qrlNoDollarClickCount++;
+        })}
+      >
+        QRL no-dollar click
+      </button>
+      <p id="count-qrl-no-dollar-click">countQrlNoDollarClick: {store.qrlNoDollarClickCount}</p>
       <UseOnWindowConditionalRenderIssue3948 />
       <UndefinedEventHandler />
       <ExecuteAllEventHandlers />

--- a/e2e/qwik-e2e/tests/events.e2e.ts
+++ b/e2e/qwik-e2e/tests/events.e2e.ts
@@ -81,6 +81,15 @@ test.describe('events', () => {
     await expect(page.locator('#hover-order-log')).toHaveText('red mouse out|blue mouse in');
   });
 
+  test('should execute qrl handler passed to no-dollar event', async ({ page }) => {
+    const button = page.locator('#qrl-no-dollar-click');
+    const count = page.locator('#count-qrl-no-dollar-click');
+
+    await expect(count).toHaveText('countQrlNoDollarClick: 0');
+    await button.click();
+    await expect(count).toHaveText('countQrlNoDollarClick: 1');
+  });
+
   test(`GIVEN "stoppropagation" is set as a attribute 
         THEN it should stop propagation`, async ({ page }) => {
     const stoppedPropagationButton = page.locator('#stop-propagation');

--- a/packages/docs/src/routes/api/qwik-router/api.json
+++ b/packages/docs/src/routes/api/qwik-router/api.json
@@ -395,6 +395,20 @@
       "mdFile": "router.getvalidatortype.md"
     },
     {
+      "name": "globalAction",
+      "id": "globalaction",
+      "hierarchy": [
+        {
+          "name": "globalAction",
+          "id": "globalaction"
+        }
+      ],
+      "kind": "Variable",
+      "content": "```typescript\nglobalAction: ActionConstructor & ActionConstructorQRL\n```",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/server-functions.ts",
+      "mdFile": "router.globalaction.md"
+    },
+    {
       "name": "globalAction$",
       "id": "globalaction_",
       "hierarchy": [
@@ -843,6 +857,20 @@
       "mdFile": "router.resolveddocumenthead.md"
     },
     {
+      "name": "routeAction",
+      "id": "routeaction",
+      "hierarchy": [
+        {
+          "name": "routeAction",
+          "id": "routeaction"
+        }
+      ],
+      "kind": "Variable",
+      "content": "```typescript\nrouteAction: ActionConstructor & ActionConstructorQRL\n```",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/server-functions.ts",
+      "mdFile": "router.routeaction.md"
+    },
+    {
       "name": "routeAction$",
       "id": "routeaction_",
       "hierarchy": [
@@ -899,6 +927,20 @@
       "mdFile": "router.routedata.md"
     },
     {
+      "name": "routeLoader",
+      "id": "routeloader",
+      "hierarchy": [
+        {
+          "name": "routeLoader",
+          "id": "routeloader"
+        }
+      ],
+      "kind": "Variable",
+      "content": "```typescript\nrouteLoader: LoaderConstructor & LoaderConstructorQRL\n```",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/server-functions.ts",
+      "mdFile": "router.routeloader.md"
+    },
+    {
       "name": "routeLoader$",
       "id": "routeloader_",
       "hierarchy": [
@@ -953,6 +995,20 @@
       "content": "```typescript\nRouterOutlet: import(\"@qwik.dev/core\").Component<unknown>\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/router-outlet-component.tsx",
       "mdFile": "router.routeroutlet.md"
+    },
+    {
+      "name": "server",
+      "id": "server",
+      "hierarchy": [
+        {
+          "name": "server",
+          "id": "server"
+        }
+      ],
+      "kind": "Function",
+      "content": "```typescript\nserver: <T extends ServerFunction>(fn: T | QRL<T>, options?: ServerConfig) => ServerQRL<T>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nfn\n\n\n</td><td>\n\nT \\| QRL&lt;T&gt;\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\noptions\n\n\n</td><td>\n\nServerConfig\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\n[ServerQRL](#serverqrl)<!-- -->&lt;T&gt;",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/server-functions.ts",
+      "mdFile": "router.server.md"
     },
     {
       "name": "server$",
@@ -1165,6 +1221,20 @@
       "mdFile": "router.usenavigate.md"
     },
     {
+      "name": "usePreventNavigate",
+      "id": "usepreventnavigate",
+      "hierarchy": [
+        {
+          "name": "usePreventNavigate",
+          "id": "usepreventnavigate"
+        }
+      ],
+      "kind": "Function",
+      "content": "```typescript\nusePreventNavigate: (fn: PreventNavigateCallback | QRL<PreventNavigateCallback>) => void\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nfn\n\n\n</td><td>\n\n[PreventNavigateCallback](#preventnavigatecallback) \\| QRL&lt;[PreventNavigateCallback](#preventnavigatecallback)<!-- -->&gt;\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\nvoid",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/use-functions.ts",
+      "mdFile": "router.usepreventnavigate.md"
+    },
+    {
       "name": "usePreventNavigate$",
       "id": "usepreventnavigate_",
       "hierarchy": [
@@ -1193,6 +1263,20 @@
       "mdFile": "router.useqwikrouter.md"
     },
     {
+      "name": "valibot",
+      "id": "valibot",
+      "hierarchy": [
+        {
+          "name": "valibot",
+          "id": "valibot"
+        }
+      ],
+      "kind": "Variable",
+      "content": "> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.\n> \n\n\n\n```typescript\nvalibot: ValibotConstructor & ValibotConstructorQRL\n```",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/server-functions.ts",
+      "mdFile": "router.valibot.md"
+    },
+    {
       "name": "valibot$",
       "id": "valibot_",
       "hierarchy": [
@@ -1205,6 +1289,20 @@
       "content": "> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.\n> \n\n\n\n```typescript\nvalibot$: ValibotConstructor\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/server-functions.ts",
       "mdFile": "router.valibot_.md"
+    },
+    {
+      "name": "validator",
+      "id": "validator",
+      "hierarchy": [
+        {
+          "name": "validator",
+          "id": "validator"
+        }
+      ],
+      "kind": "Variable",
+      "content": "```typescript\nvalidator: ValidatorConstructor & ValidatorConstructorQRL\n```",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/server-functions.ts",
+      "mdFile": "router.validator.md"
     },
     {
       "name": "validator$",
@@ -1261,6 +1359,20 @@
       "content": "```typescript\nexport type ValidatorReturn<T extends Record<string, any> = {}> = ValidatorReturnSuccess | ValidatorReturnFail<T>;\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts",
       "mdFile": "router.validatorreturn.md"
+    },
+    {
+      "name": "zod",
+      "id": "zod",
+      "hierarchy": [
+        {
+          "name": "zod",
+          "id": "zod"
+        }
+      ],
+      "kind": "Variable",
+      "content": "```typescript\nzod: ZodConstructor & ZodConstructorQRL\n```",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/server-functions.ts",
+      "mdFile": "router.zod.md"
     },
     {
       "name": "zod$",

--- a/packages/docs/src/routes/api/qwik-router/index.mdx
+++ b/packages/docs/src/routes/api/qwik-router/index.mdx
@@ -1053,6 +1053,14 @@ export type GetValidatorType<VALIDATOR extends TypedDataValidator> =
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts)
 
+<h2 id="globalaction">globalAction</h2>
+
+```typescript
+globalAction: ActionConstructor & ActionConstructorQRL;
+```
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/server-functions.ts)
+
 <h2 id="globalaction_">globalAction$</h2>
 
 ```typescript
@@ -2031,6 +2039,14 @@ export type ResolvedDocumentHead<
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts)
 
+<h2 id="routeaction">routeAction</h2>
+
+```typescript
+routeAction: ActionConstructor & ActionConstructorQRL;
+```
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/server-functions.ts)
+
 <h2 id="routeaction_">routeAction$</h2>
 
 ```typescript
@@ -2335,6 +2351,14 @@ _(Optional)_ The parameter name when this node is reached via `_W` or `_A` from 
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts)
 
+<h2 id="routeloader">routeLoader</h2>
+
+```typescript
+routeLoader: LoaderConstructor & LoaderConstructorQRL;
+```
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/server-functions.ts)
+
 <h2 id="routeloader_">routeLoader$</h2>
 
 ```typescript
@@ -2459,6 +2483,58 @@ RouterOutlet: import("@qwik.dev/core").Component<unknown>;
 ```
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/router-outlet-component.tsx)
+
+<h2 id="server">server</h2>
+
+```typescript
+server: <T extends ServerFunction>(fn: T | QRL<T>, options?: ServerConfig) =>
+  ServerQRL<T>;
+```
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+fn
+
+</td><td>
+
+T \| QRL&lt;T&gt;
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+options
+
+</td><td>
+
+ServerConfig
+
+</td><td>
+
+_(Optional)_
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+[ServerQRL](#serverqrl)&lt;T&gt;
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/server-functions.ts)
 
 <h2 id="server_">server$</h2>
 
@@ -2810,6 +2886,44 @@ useNavigate: () => RouteNavigate;
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/use-functions.ts)
 
+<h2 id="usepreventnavigate">usePreventNavigate</h2>
+
+```typescript
+usePreventNavigate: (fn: PreventNavigateCallback | QRL<PreventNavigateCallback>) => void
+```
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+fn
+
+</td><td>
+
+[PreventNavigateCallback](#preventnavigatecallback) \| QRL&lt;[PreventNavigateCallback](#preventnavigatecallback)&gt;
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+void
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/use-functions.ts)
+
 <h2 id="usepreventnavigate_">usePreventNavigate$</h2>
 
 Prevent navigation attempts. This hook registers a callback that will be called before SPA or browser navigation.
@@ -2912,12 +3026,30 @@ void
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/qwik-router-component.tsx)
 
+<h2 id="valibot">valibot</h2>
+
+> This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
+
+```typescript
+valibot: ValibotConstructor & ValibotConstructorQRL;
+```
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/server-functions.ts)
+
 <h2 id="valibot_">valibot$</h2>
 
 > This API is provided as a beta preview for developers and may change based on feedback that we receive. Do not use this API in a production environment.
 
 ```typescript
 valibot$: ValibotConstructor;
+```
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/server-functions.ts)
+
+<h2 id="validator">validator</h2>
+
+```typescript
+validator: ValidatorConstructor & ValidatorConstructorQRL;
 ```
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/server-functions.ts)
@@ -2985,6 +3117,14 @@ export type ValidatorReturn<T extends Record<string, any> = {}> =
 ```
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts)
+
+<h2 id="zod">zod</h2>
+
+```typescript
+zod: ZodConstructor & ZodConstructorQRL;
+```
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/server-functions.ts)
 
 <h2 id="zod_">zod$</h2>
 

--- a/packages/docs/src/routes/api/qwik-worker/api.json
+++ b/packages/docs/src/routes/api/qwik-worker/api.json
@@ -3,6 +3,20 @@
   "package": "@qwik.dev/qwik/worker",
   "members": [
     {
+      "name": "worker",
+      "id": "worker",
+      "hierarchy": [
+        {
+          "name": "worker",
+          "id": "worker"
+        }
+      ],
+      "kind": "Variable",
+      "content": "```typescript\nworker: WorkerConstructor\n```",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/web-worker/worker-qrl.ts",
+      "mdFile": "core.worker.md"
+    },
+    {
       "name": "worker$",
       "id": "worker_",
       "hierarchy": [
@@ -15,6 +29,20 @@
       "content": "```typescript\nworker$: <T extends WorkerFunction>(qrl: T) => QRL<T>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\nT\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\nQRL&lt;T&gt;",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/web-worker/worker-qrl.ts",
       "mdFile": "core.worker_.md"
+    },
+    {
+      "name": "WorkerConstructor",
+      "id": "workerconstructor",
+      "hierarchy": [
+        {
+          "name": "WorkerConstructor",
+          "id": "workerconstructor"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface WorkerConstructor \n```",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/web-worker/worker-qrl.ts",
+      "mdFile": "core.workerconstructor.md"
     },
     {
       "name": "WorkerConstructorQRL",

--- a/packages/docs/src/routes/api/qwik-worker/index.mdx
+++ b/packages/docs/src/routes/api/qwik-worker/index.mdx
@@ -4,6 +4,14 @@ title: \@qwik.dev/qwik/worker API Reference
 
 # [API](/api) &rsaquo; @qwik.dev/qwik/worker
 
+<h2 id="worker">worker</h2>
+
+```typescript
+worker: WorkerConstructor;
+```
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/web-worker/worker-qrl.ts)
+
 <h2 id="worker_">worker$</h2>
 
 ```typescript
@@ -39,6 +47,14 @@ T
 **Returns:**
 
 QRL&lt;T&gt;
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/web-worker/worker-qrl.ts)
+
+<h2 id="workerconstructor">WorkerConstructor</h2>
+
+```typescript
+export interface WorkerConstructor
+```
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/web-worker/worker-qrl.ts)
 

--- a/packages/docs/src/routes/api/qwik/api.json
+++ b/packages/docs/src/routes/api/qwik/api.json
@@ -328,6 +328,20 @@
       "mdFile": "core.renderresult.cleanup.md"
     },
     {
+      "name": "component",
+      "id": "component",
+      "hierarchy": [
+        {
+          "name": "component",
+          "id": "component"
+        }
+      ],
+      "kind": "Function",
+      "content": "Type representing the Qwik component.\n\n`Component` is the type returned by invoking `component$`<!-- -->.\n\n```tsx\ninterface MyComponentProps {\n  someProp: string;\n}\nconst MyComponent: Component<MyComponentProps> = component$((props: MyComponentProps) => {\n  return <span>{props.someProp}</span>;\n});\n```\n\n\n```typescript\nexport type Component<PROPS = unknown> = FunctionComponent<PublicProps<PROPS>>;\n```\n**References:** [FunctionComponent](#functioncomponent)<!-- -->, [PublicProps](#publicprops)",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/shared/component.public.ts",
+      "mdFile": "core.component.md"
+    },
+    {
       "name": "Component",
       "id": "component",
       "hierarchy": [
@@ -351,7 +365,7 @@
         }
       ],
       "kind": "Function",
-      "content": "Declare a Qwik component that can be used to create UI.\n\nUse `component$` to declare a Qwik component. A Qwik component is a special kind of component that allows the Qwik framework to lazy load and execute the component independently of other Qwik components as well as lazy load the component's life-cycle hooks and event handlers.\n\nSide note: You can also declare regular (standard JSX) components that will have standard synchronous behavior.\n\nQwik component is a facade that describes how the component should be used without forcing the implementation of the component to be eagerly loaded. A minimum Qwik definition consists of:\n\n\\#\\#\\# Example\n\nAn example showing how to create a counter component:\n\n```tsx\nexport interface CounterProps {\n  initialValue?: number;\n  step?: number;\n}\nexport const Counter = component$((props: CounterProps) => {\n  const state = useSignal(props.initialValue || 0);\n  return (\n    <div>\n      <span>{state.value}</span>\n      <button onClick$={() => (state.value += props.step || 1)}>+</button>\n    </div>\n  );\n});\n```\n- `component$` is how a component gets declared. - `{ value?: number; step?: number }` declares the public (props) interface of the component. - `{ count: number }` declares the private (state) interface of the component.\n\nThe above can then be used like so:\n\n```tsx\nexport const OtherComponent = component$(() => {\n  return <Counter initialValue={100} />;\n});\n```\nSee also: `component`<!-- -->, `useCleanup`<!-- -->, `onResume`<!-- -->, `onPause`<!-- -->, `useOn`<!-- -->, `useOnDocument`<!-- -->, `useOnWindow`<!-- -->, `useStyles`\n\n\n```typescript\ncomponent$: <PROPS = unknown>(onMount: OnRenderFn<PROPS>) => Component<PROPS>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nonMount\n\n\n</td><td>\n\n[OnRenderFn](#onrenderfn)<!-- -->&lt;PROPS&gt;\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\n[Component](#component)<!-- -->&lt;PROPS&gt;",
+      "content": "Declare a Qwik component that can be used to create UI.\n\nUse `component$` to declare a Qwik component. A Qwik component is a special kind of component that allows the Qwik framework to lazy load and execute the component independently of other Qwik components as well as lazy load the component's life-cycle hooks and event handlers.\n\nSide note: You can also declare regular (standard JSX) components that will have standard synchronous behavior.\n\nQwik component is a facade that describes how the component should be used without forcing the implementation of the component to be eagerly loaded. A minimum Qwik definition consists of:\n\n\\#\\#\\# Example\n\nAn example showing how to create a counter component:\n\n```tsx\nexport interface CounterProps {\n  initialValue?: number;\n  step?: number;\n}\nexport const Counter = component$((props: CounterProps) => {\n  const state = useSignal(props.initialValue || 0);\n  return (\n    <div>\n      <span>{state.value}</span>\n      <button onClick$={() => (state.value += props.step || 1)}>+</button>\n    </div>\n  );\n});\n```\n- `component$` is how a component gets declared. - `{ value?: number; step?: number }` declares the public (props) interface of the component. - `{ count: number }` declares the private (state) interface of the component.\n\nThe above can then be used like so:\n\n```tsx\nexport const OtherComponent = component$(() => {\n  return <Counter initialValue={100} />;\n});\n```\nSee also: `component`<!-- -->, `useCleanup`<!-- -->, `onResume`<!-- -->, `onPause`<!-- -->, `useOn`<!-- -->, `useOnDocument`<!-- -->, `useOnWindow`<!-- -->, `useStyles`\n\n\n```typescript\ncomponent$: <PROPS = unknown>(onMount: OnRenderFn<PROPS>) => Component<PROPS>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nonMount\n\n\n</td><td>\n\n[OnRenderFn](#onrenderfn)<!-- -->&lt;PROPS&gt;\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\n[Component](#component-type-alias)<!-- -->&lt;PROPS&gt;",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/shared/component.public.ts",
       "mdFile": "core.component_.md"
     },
@@ -468,6 +482,20 @@
       "mdFile": "core.correctedtoggleevent.md"
     },
     {
+      "name": "createAsync",
+      "id": "createasync",
+      "hierarchy": [
+        {
+          "name": "createAsync",
+          "id": "createasync"
+        }
+      ],
+      "kind": "Function",
+      "content": "```typescript\ncreateAsync: <T>(fn: ((arg: AsyncCtx) => Promise<T>) | QRL<(arg: AsyncCtx) => Promise<T>>, options?: AsyncSignalOptions<T>) => AsyncSignal<T>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nfn\n\n\n</td><td>\n\n((arg: AsyncCtx) =&gt; Promise&lt;T&gt;) \\| [QRL](#qrl-type-alias)<!-- -->&lt;(arg: AsyncCtx) =&gt; Promise&lt;T&gt;&gt;\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\noptions\n\n\n</td><td>\n\n[AsyncSignalOptions](#asyncsignaloptions)<!-- -->&lt;T&gt;\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\n[AsyncSignal](#asyncsignal)<!-- -->&lt;T&gt;",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/reactive-primitives/signal.public.ts",
+      "mdFile": "core.createasync.md"
+    },
+    {
       "name": "createAsync$",
       "id": "createasync_",
       "hierarchy": [
@@ -480,6 +508,20 @@
       "content": "Create a signal holding a `.value` which is calculated from the given async function (QRL). The standalone version of `useAsync$`<!-- -->.\n\n\n```typescript\ncreateAsync$: <T>(qrl: (arg: AsyncCtx<T>) => Promise<T>, options?: AsyncSignalOptions<T>) => AsyncSignal<T>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\n(arg: AsyncCtx&lt;T&gt;) =&gt; Promise&lt;T&gt;\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\noptions\n\n\n</td><td>\n\n[AsyncSignalOptions](#asyncsignaloptions)<!-- -->&lt;T&gt;\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\n[AsyncSignal](#asyncsignal)<!-- -->&lt;T&gt;",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/reactive-primitives/signal.public.ts",
       "mdFile": "core.createasync_.md"
+    },
+    {
+      "name": "createComputed",
+      "id": "createcomputed",
+      "hierarchy": [
+        {
+          "name": "createComputed",
+          "id": "createcomputed"
+        }
+      ],
+      "kind": "Function",
+      "content": "```typescript\ncreateComputed: <T>(fn: (() => T) | QRL<() => T>, options?: ComputedOptions) => ComputedReturnType<T>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nfn\n\n\n</td><td>\n\n(() =&gt; T) \\| [QRL](#qrl-type-alias)<!-- -->&lt;() =&gt; T&gt;\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\noptions\n\n\n</td><td>\n\n[ComputedOptions](#computedoptions)\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\n[ComputedReturnType](#computedreturntype)<!-- -->&lt;T&gt;",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/reactive-primitives/signal.public.ts",
+      "mdFile": "core.createcomputed.md"
     },
     {
       "name": "createComputed$",
@@ -510,6 +552,20 @@
       "mdFile": "core.createcontextid.md"
     },
     {
+      "name": "createSerializer",
+      "id": "createserializer",
+      "hierarchy": [
+        {
+          "name": "createSerializer",
+          "id": "createserializer"
+        }
+      ],
+      "kind": "Function",
+      "content": "```typescript\ncreateSerializer: <T, S>(arg: SerializerArg<T, S> | QRL<SerializerArg<T, S>>) => T extends Promise<any> ? never : SerializerSignal<T>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\narg\n\n\n</td><td>\n\nSerializerArg&lt;T, S&gt; \\| [QRL](#qrl-type-alias)<!-- -->&lt;SerializerArg&lt;T, S&gt;&gt;\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\nT extends Promise&lt;any&gt; ? never : [SerializerSignal](#serializersignal)<!-- -->&lt;T&gt;",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/reactive-primitives/signal.public.ts",
+      "mdFile": "core.createserializer.md"
+    },
+    {
       "name": "createSerializer$",
       "id": "createserializer_",
       "hierarchy": [
@@ -519,7 +575,7 @@
         }
       ],
       "kind": "Function",
-      "content": "Create a signal that holds a custom serializable value. See [useSerializer$](#useserializer_) for more details.\n\n\n```typescript\ncreateSerializer$: <T, S>(arg: SerializerArg<T, S>) => T extends Promise<any> ? never : SerializerSignal<T>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\narg\n\n\n</td><td>\n\nSerializerArg&lt;T, S&gt;\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\nT extends Promise&lt;any&gt; ? never : SerializerSignal&lt;T&gt;",
+      "content": "Create a signal that holds a custom serializable value. See [useSerializer$](#useserializer_) for more details.\n\n\n```typescript\ncreateSerializer$: <T, S>(arg: SerializerArg<T, S>) => T extends Promise<any> ? never : SerializerSignal<T>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\narg\n\n\n</td><td>\n\nSerializerArg&lt;T, S&gt;\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\nT extends Promise&lt;any&gt; ? never : [SerializerSignal](#serializersignal)<!-- -->&lt;T&gt;",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/reactive-primitives/signal.public.ts",
       "mdFile": "core.createserializer_.md"
     },
@@ -1341,7 +1397,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "Infers `Props` from the component or tag.\n\n\n```typescript\nexport type PropsOf<COMP> = COMP extends string ? COMP extends keyof QwikIntrinsicElements ? QwikIntrinsicElements[COMP] : QwikIntrinsicElements['span'] : NonNullable<COMP> extends never ? never : COMP extends FunctionComponent<infer PROPS> ? PROPS extends Record<any, infer V> ? IsAny<V> extends true ? never : ObjectProps<PROPS> : COMP extends Component<infer OrigProps> ? ObjectProps<OrigProps> : PROPS : never;\n```\n**References:** [QwikIntrinsicElements](#qwikintrinsicelements)<!-- -->, [FunctionComponent](#functioncomponent)<!-- -->, [Component](#component)\n\n\n\n```tsx\nconst Desc = component$(({desc, ...props}: { desc: string } & PropsOf<'div'>) => {\n return <div {...props}>{desc}</div>;\n});\n\nconst TitleBox = component$(({title, ...props}: { title: string } & PropsOf<Box>) => {\n  return <Box {...props}><h1>{title}</h1></Box>;\n});\n```",
+      "content": "Infers `Props` from the component or tag.\n\n\n```typescript\nexport type PropsOf<COMP> = COMP extends string ? COMP extends keyof QwikIntrinsicElements ? QwikIntrinsicElements[COMP] : QwikIntrinsicElements['span'] : NonNullable<COMP> extends never ? never : COMP extends FunctionComponent<infer PROPS> ? PROPS extends Record<any, infer V> ? IsAny<V> extends true ? never : ObjectProps<PROPS> : COMP extends Component<infer OrigProps> ? ObjectProps<OrigProps> : PROPS : never;\n```\n**References:** [QwikIntrinsicElements](#qwikintrinsicelements)<!-- -->, [FunctionComponent](#functioncomponent)<!-- -->, [Component](#component-type-alias)\n\n\n\n```tsx\nconst Desc = component$(({desc, ...props}: { desc: string } & PropsOf<'div'>) => {\n return <div {...props}>{desc}</div>;\n});\n\nconst TitleBox = component$(({title, ...props}: { title: string } & PropsOf<Box>) => {\n  return <Box {...props}><h1>{title}</h1></Box>;\n});\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/shared/component.public.ts",
       "mdFile": "core.propsof.md"
     },
@@ -2046,6 +2102,20 @@
       "mdFile": "core.serializationstrategy.md"
     },
     {
+      "name": "SerializerSignal",
+      "id": "serializersignal",
+      "hierarchy": [
+        {
+          "name": "SerializerSignal",
+          "id": "serializersignal"
+        }
+      ],
+      "kind": "Interface",
+      "content": "A serializer signal holds a custom serializable value. See `useSerializer$` for more details.\n\n\n```typescript\nexport interface SerializerSignal<T> extends ComputedSignal<T> \n```\n**Extends:** [ComputedSignal](#computedsignal)<!-- -->&lt;T&gt;\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\n\\_\\_no\\_serialize\\_\\_\n\n\n</td><td>\n\n\n</td><td>\n\ntrue\n\n\n</td><td>\n\nFake property to make the serialization linter happy\n\n\n</td></tr>\n</tbody></table>",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/reactive-primitives/signal.public.ts",
+      "mdFile": "core.serializersignal.md"
+    },
+    {
       "name": "SerializerSymbol",
       "id": "serializersymbol",
       "hierarchy": [
@@ -2483,6 +2553,20 @@
       "mdFile": "core.unwrapstore.md"
     },
     {
+      "name": "useAsync",
+      "id": "useasync",
+      "hierarchy": [
+        {
+          "name": "useAsync",
+          "id": "useasync"
+        }
+      ],
+      "kind": "Function",
+      "content": "```typescript\nuseAsync: <T>(fn: AsyncFn<T> | QRL<AsyncFn<T>>, options?: AsyncSignalOptions<T>) => AsyncSignal<T>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nfn\n\n\n</td><td>\n\n[AsyncFn](#asyncfn)<!-- -->&lt;T&gt; \\| [QRL](#qrl-type-alias)<!-- -->&lt;[AsyncFn](#asyncfn)<!-- -->&lt;T&gt;&gt;\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\noptions\n\n\n</td><td>\n\n[AsyncSignalOptions](#asyncsignaloptions)<!-- -->&lt;T&gt;\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\n[AsyncSignal](#asyncsignal)<!-- -->&lt;T&gt;",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-async.ts",
+      "mdFile": "core.useasync.md"
+    },
+    {
       "name": "useAsync$",
       "id": "useasync_",
       "hierarchy": [
@@ -2495,6 +2579,20 @@
       "content": "Creates an AsyncSignal which holds the result of the given async function. If the function uses `track()` to track reactive state, and that state changes, the AsyncSignal is recalculated, and if the result changed, all tasks which are tracking the AsyncSignal will be re-run and all subscribers (components, tasks etc) that read the AsyncSignal will be updated.\n\nIf the async function throws an error, the AsyncSignal will capture the error and set the `error` property. The error can be cleared by re-running the async function successfully.\n\nWhile the async function is running, the `loading` property will be set to `true`<!-- -->. Once the function completes, `loading` will be set to `false`<!-- -->.\n\nIf the value has not yet been resolved, reading the AsyncSignal will throw a Promise, which will retry the component or task once the value resolves.\n\nIf the value has been resolved, but the async function is re-running, reading the AsyncSignal will subscribe to it and return the last resolved value until the new value is ready. As soon as the new value is ready, the subscribers will be updated.\n\n\n```typescript\nuseAsync$: <T>(qrl: AsyncFn<T>, options?: AsyncSignalOptions<T> | undefined) => AsyncSignal<T>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\n[AsyncFn](#asyncfn)<!-- -->&lt;T&gt;\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\noptions\n\n\n</td><td>\n\n[AsyncSignalOptions](#asyncsignaloptions)<!-- -->&lt;T&gt; \\| undefined\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\n[AsyncSignal](#asyncsignal)<!-- -->&lt;T&gt;",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-async.ts",
       "mdFile": "core.useasync_.md"
+    },
+    {
+      "name": "useComputed",
+      "id": "usecomputed",
+      "hierarchy": [
+        {
+          "name": "useComputed",
+          "id": "usecomputed"
+        }
+      ],
+      "kind": "Function",
+      "content": "```typescript\nuseComputed: <T>(fn: ComputedFn<T> | QRL<ComputedFn<T>>, options?: ComputedOptions) => ComputedReturnType<T>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nfn\n\n\n</td><td>\n\n[ComputedFn](#computedfn)<!-- -->&lt;T&gt; \\| [QRL](#qrl-type-alias)<!-- -->&lt;[ComputedFn](#computedfn)<!-- -->&lt;T&gt;&gt;\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\noptions\n\n\n</td><td>\n\n[ComputedOptions](#computedoptions)\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\n[ComputedReturnType](#computedreturntype)<!-- -->&lt;T&gt;",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-computed.ts",
+      "mdFile": "core.usecomputed.md"
     },
     {
       "name": "useComputed$",
@@ -2590,7 +2688,7 @@
         }
       ],
       "kind": "Function",
-      "content": "Register a listener on the current component's host element.\n\nUsed to programmatically add event listeners. Useful from custom `use*` methods, which do not have access to the JSX. Otherwise, it's adding a JSX listener in the `<div>` is a better idea.\n\nEvents are case sensitive.\n\n\n```typescript\nuseOn: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T>, options?: UseOnOptions) => void\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nevent\n\n\n</td><td>\n\nT \\| T\\[\\]\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\neventQrl\n\n\n</td><td>\n\nEventQRL&lt;T&gt;\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\noptions\n\n\n</td><td>\n\n[UseOnOptions](#useonoptions)\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\nvoid",
+      "content": "Register a listener on the current component's host element.\n\nUsed to programmatically add event listeners. Useful from custom `use*` methods, which do not have access to the JSX. Otherwise, it's adding a JSX listener in the `<div>` is a better idea.\n\nEvents are case sensitive.\n\n\n```typescript\nuseOn: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T> | EventHandler<EventFromName<T>, Element>, options?: UseOnOptions) => void\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nevent\n\n\n</td><td>\n\nT \\| T\\[\\]\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\neventQrl\n\n\n</td><td>\n\nEventQRL&lt;T&gt; \\| [EventHandler](#eventhandler)<!-- -->&lt;EventFromName&lt;T&gt;, Element&gt;\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\noptions\n\n\n</td><td>\n\n[UseOnOptions](#useonoptions)\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\nvoid",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-on.ts",
       "mdFile": "core.useon.md"
     },
@@ -2604,7 +2702,7 @@
         }
       ],
       "kind": "Function",
-      "content": "Register a listener on `document`<!-- -->.\n\nUsed to programmatically add event listeners. Useful from custom `use*` methods, which do not have access to the JSX.\n\nEvents are case sensitive.\n\n\n```typescript\nuseOnDocument: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T>, options?: UseOnOptions) => void\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nevent\n\n\n</td><td>\n\nT \\| T\\[\\]\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\neventQrl\n\n\n</td><td>\n\nEventQRL&lt;T&gt;\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\noptions\n\n\n</td><td>\n\n[UseOnOptions](#useonoptions)\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\nvoid",
+      "content": "Register a listener on `document`<!-- -->.\n\nUsed to programmatically add event listeners. Useful from custom `use*` methods, which do not have access to the JSX.\n\nEvents are case sensitive.\n\n\n```typescript\nuseOnDocument: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T> | EventHandler<EventFromName<T>, Element>, options?: UseOnOptions) => void\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nevent\n\n\n</td><td>\n\nT \\| T\\[\\]\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\neventQrl\n\n\n</td><td>\n\nEventQRL&lt;T&gt; \\| [EventHandler](#eventhandler)<!-- -->&lt;EventFromName&lt;T&gt;, Element&gt;\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\noptions\n\n\n</td><td>\n\n[UseOnOptions](#useonoptions)\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\nvoid",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-on.ts",
       "mdFile": "core.useondocument.md"
     },
@@ -2632,9 +2730,23 @@
         }
       ],
       "kind": "Function",
-      "content": "Register a listener on `window`<!-- -->.\n\nUsed to programmatically add event listeners. Useful from custom `use*` methods, which do not have access to the JSX.\n\nEvents are case sensitive.\n\n\n```typescript\nuseOnWindow: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T>, options?: UseOnOptions) => void\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nevent\n\n\n</td><td>\n\nT \\| T\\[\\]\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\neventQrl\n\n\n</td><td>\n\nEventQRL&lt;T&gt;\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\noptions\n\n\n</td><td>\n\n[UseOnOptions](#useonoptions)\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\nvoid",
+      "content": "Register a listener on `window`<!-- -->.\n\nUsed to programmatically add event listeners. Useful from custom `use*` methods, which do not have access to the JSX.\n\nEvents are case sensitive.\n\n\n```typescript\nuseOnWindow: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T> | EventHandler<EventFromName<T>, Element>, options?: UseOnOptions) => void\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nevent\n\n\n</td><td>\n\nT \\| T\\[\\]\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\neventQrl\n\n\n</td><td>\n\nEventQRL&lt;T&gt; \\| [EventHandler](#eventhandler)<!-- -->&lt;EventFromName&lt;T&gt;, Element&gt;\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\noptions\n\n\n</td><td>\n\n[UseOnOptions](#useonoptions)\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\nvoid",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-on.ts",
       "mdFile": "core.useonwindow.md"
+    },
+    {
+      "name": "useResource",
+      "id": "useresource",
+      "hierarchy": [
+        {
+          "name": "useResource",
+          "id": "useresource"
+        }
+      ],
+      "kind": "Function",
+      "content": "```typescript\nuseResource: <T>(fn: ResourceFn<T> | QRL<ResourceFn<T>>, opts?: ResourceOptions) => ResourceReturn<T>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nfn\n\n\n</td><td>\n\n[ResourceFn](#resourcefn)<!-- -->&lt;T&gt; \\| [QRL](#qrl-type-alias)<!-- -->&lt;[ResourceFn](#resourcefn)<!-- -->&lt;T&gt;&gt;\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\nopts\n\n\n</td><td>\n\n[ResourceOptions](#resourceoptions)\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\n[ResourceReturn](#resourcereturn)<!-- -->&lt;T&gt;",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-resource.ts",
+      "mdFile": "core.useresource.md"
     },
     {
       "name": "useResource$",
@@ -2649,6 +2761,20 @@
       "content": "> Warning: This API is now obsolete.\n> \n> Use `useAsync$` instead, which is more powerful and flexible. `useResource$` is still available for backward compatibility but it is recommended to migrate to `useAsync$` for new code and when updating existing code.\n> \n\nThis method works like an async memoized function that runs whenever some tracked value changes and returns some data.\n\n`useResource` however returns immediate a `ResourceReturn` object that contains the data and a state that indicates if the data is available or not.\n\nThe status can be one of the following:\n\n- `pending` - the data is not yet available. - `resolved` - the data is available. - `rejected` - the data is not available due to an error or timeout.\n\nBe careful when using a `try/catch` statement in `useResource$`<!-- -->. If you catch the error and don't re-throw it (or a new Error), the resource status will never be `rejected`<!-- -->.\n\n\n```typescript\nuseResource$: <T>(qrl: import(\"./use-resource\").ResourceFn<T>, opts?: import(\"./use-resource\").ResourceOptions | undefined) => import(\"./use-resource\").ResourceReturn<T>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\nimport(\"./use-resource\").[ResourceFn](#resourcefn)<!-- -->&lt;T&gt;\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\nopts\n\n\n</td><td>\n\nimport(\"./use-resource\").[ResourceOptions](#resourceoptions) \\| undefined\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\nimport(\"./use-resource\").[ResourceReturn](#resourcereturn)<!-- -->&lt;T&gt;",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-resource-dollar.ts",
       "mdFile": "core.useresource_.md"
+    },
+    {
+      "name": "useSerializer",
+      "id": "useserializer",
+      "hierarchy": [
+        {
+          "name": "useSerializer",
+          "id": "useserializer"
+        }
+      ],
+      "kind": "Function",
+      "content": "```typescript\nuseSerializer: <T, S>(arg: SerializerArg<T, S> | QRL<SerializerArg<T, S>>) => T extends Promise<any> ? never : SerializerSignal<T>\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\narg\n\n\n</td><td>\n\nSerializerArg&lt;T, S&gt; \\| [QRL](#qrl-type-alias)<!-- -->&lt;SerializerArg&lt;T, S&gt;&gt;\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\nT extends Promise&lt;any&gt; ? never : [SerializerSignal](#serializersignal)<!-- -->&lt;T&gt;",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-serializer.ts",
+      "mdFile": "core.useserializer.md"
     },
     {
       "name": "useSerializer$",
@@ -2735,6 +2861,34 @@
       "mdFile": "core.usestoreoptions.md"
     },
     {
+      "name": "useStyles",
+      "id": "usestyles",
+      "hierarchy": [
+        {
+          "name": "useStyles",
+          "id": "usestyles"
+        }
+      ],
+      "kind": "Function",
+      "content": "```typescript\nexport interface UseStyles \n```\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nstyleId\n\n\n</td><td>\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-styles.ts",
+      "mdFile": "core.usestyles.md"
+    },
+    {
+      "name": "UseStyles",
+      "id": "usestyles",
+      "hierarchy": [
+        {
+          "name": "UseStyles",
+          "id": "usestyles"
+        }
+      ],
+      "kind": "Interface",
+      "content": "```typescript\nexport interface UseStyles \n```\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nstyleId\n\n\n</td><td>\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-styles.ts",
+      "mdFile": "core.usestyles.md"
+    },
+    {
       "name": "useStyles$",
       "id": "usestyles_",
       "hierarchy": [
@@ -2744,9 +2898,23 @@
         }
       ],
       "kind": "Function",
-      "content": "A lazy-loadable reference to a component's styles.\n\nComponent styles allow Qwik to lazy load the style information for the component only when needed. (And avoid double loading it in case of SSR hydration.)\n\n```tsx\nimport styles from './code-block.css?inline';\n\nexport const CmpStyles = component$(() => {\n  useStyles$(styles);\n\n  return <div>Some text</div>;\n});\n```\n\n\n```typescript\nuseStyles$: (qrl: string) => UseStyles\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\nUseStyles",
+      "content": "A lazy-loadable reference to a component's styles.\n\nComponent styles allow Qwik to lazy load the style information for the component only when needed. (And avoid double loading it in case of SSR hydration.)\n\n```tsx\nimport styles from './code-block.css?inline';\n\nexport const CmpStyles = component$(() => {\n  useStyles$(styles);\n\n  return <div>Some text</div>;\n});\n```\n\n\n```typescript\nuseStyles$: (qrl: string) => UseStyles\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\n[UseStyles](#usestyles-interface)",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-styles.ts",
       "mdFile": "core.usestyles_.md"
+    },
+    {
+      "name": "useStylesScoped",
+      "id": "usestylesscoped",
+      "hierarchy": [
+        {
+          "name": "useStylesScoped",
+          "id": "usestylesscoped"
+        }
+      ],
+      "kind": "Function",
+      "content": "```typescript\nexport interface UseStylesScoped \n```\n\n\n<table><thead><tr><th>\n\nProperty\n\n\n</th><th>\n\nModifiers\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nscopeId\n\n\n</td><td>\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-styles.ts",
+      "mdFile": "core.usestylesscoped.md"
     },
     {
       "name": "UseStylesScoped",
@@ -2772,9 +2940,23 @@
         }
       ],
       "kind": "Function",
-      "content": "A lazy-loadable reference to a component's styles, that is scoped to the component.\n\nComponent styles allow Qwik to lazy load the style information for the component only when needed. (And avoid double loading it in case of SSR hydration.)\n\n```tsx\nimport scoped from './code-block.css?inline';\n\nexport const CmpScopedStyles = component$(() => {\n  useStylesScoped$(scoped);\n\n  return <div>Some text</div>;\n});\n```\n\n\n```typescript\nuseStylesScoped$: (qrl: string) => UseStylesScoped\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\n[UseStylesScoped](#usestylesscoped)",
+      "content": "A lazy-loadable reference to a component's styles, that is scoped to the component.\n\nComponent styles allow Qwik to lazy load the style information for the component only when needed. (And avoid double loading it in case of SSR hydration.)\n\n```tsx\nimport scoped from './code-block.css?inline';\n\nexport const CmpScopedStyles = component$(() => {\n  useStylesScoped$(scoped);\n\n  return <div>Some text</div>;\n});\n```\n\n\n```typescript\nuseStylesScoped$: (qrl: string) => UseStylesScoped\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nqrl\n\n\n</td><td>\n\nstring\n\n\n</td><td>\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\n[UseStylesScoped](#usestylesscoped-interface)",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-styles.ts",
       "mdFile": "core.usestylesscoped_.md"
+    },
+    {
+      "name": "useTask",
+      "id": "usetask",
+      "hierarchy": [
+        {
+          "name": "useTask",
+          "id": "usetask"
+        }
+      ],
+      "kind": "Function",
+      "content": "```typescript\nuseTask: (fn: TaskFn | QRL<TaskFn>, opts?: TaskOptions) => void\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nfn\n\n\n</td><td>\n\n[TaskFn](#taskfn) \\| [QRL](#qrl-type-alias)<!-- -->&lt;[TaskFn](#taskfn)<!-- -->&gt;\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\nopts\n\n\n</td><td>\n\n[TaskOptions](#taskoptions)\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\nvoid",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-task.ts",
+      "mdFile": "core.usetask.md"
     },
     {
       "name": "useTask$",
@@ -2789,6 +2971,20 @@
       "content": "Reruns the `taskFn` when the observed inputs change.\n\nUse `useTask` to observe changes on a set of inputs, and then re-execute the `taskFn` when those inputs change.\n\nThe `taskFn` only executes if the observed inputs change. To observe the inputs, use the `obs` function to wrap property reads. This creates subscriptions that will trigger the `taskFn` to rerun.\n\n\n```typescript\nuseTask$: (fn: TaskFn, opts?: TaskOptions) => void\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nfn\n\n\n</td><td>\n\n[TaskFn](#taskfn)\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\nopts\n\n\n</td><td>\n\n[TaskOptions](#taskoptions)\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\nvoid",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-task-dollar.ts",
       "mdFile": "core.usetask_.md"
+    },
+    {
+      "name": "useVisibleTask",
+      "id": "usevisibletask",
+      "hierarchy": [
+        {
+          "name": "useVisibleTask",
+          "id": "usevisibletask"
+        }
+      ],
+      "kind": "Function",
+      "content": "```typescript\nuseVisibleTask: (fn: TaskFn | QRL<TaskFn>, opts?: OnVisibleTaskOptions) => void\n```\n\n\n<table><thead><tr><th>\n\nParameter\n\n\n</th><th>\n\nType\n\n\n</th><th>\n\nDescription\n\n\n</th></tr></thead>\n<tbody><tr><td>\n\nfn\n\n\n</td><td>\n\n[TaskFn](#taskfn) \\| [QRL](#qrl-type-alias)<!-- -->&lt;[TaskFn](#taskfn)<!-- -->&gt;\n\n\n</td><td>\n\n\n</td></tr>\n<tr><td>\n\nopts\n\n\n</td><td>\n\n[OnVisibleTaskOptions](#onvisibletaskoptions)\n\n\n</td><td>\n\n_(Optional)_\n\n\n</td></tr>\n</tbody></table>\n\n**Returns:**\n\nvoid",
+      "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-visible-task.ts",
+      "mdFile": "core.usevisibletask.md"
     },
     {
       "name": "useVisibleTask$",

--- a/packages/docs/src/routes/api/qwik/index.mdx
+++ b/packages/docs/src/routes/api/qwik/index.mdx
@@ -632,7 +632,32 @@ cleanup(): void;
 
 void
 
-<h2 id="component">Component</h2>
+<h2 id="component-function">component</h2>
+
+Type representing the Qwik component.
+
+`Component` is the type returned by invoking `component$`.
+
+```tsx
+interface MyComponentProps {
+  someProp: string;
+}
+const MyComponent: Component<MyComponentProps> = component$(
+  (props: MyComponentProps) => {
+    return <span>{props.someProp}</span>;
+  },
+);
+```
+
+```typescript
+export type Component<PROPS = unknown> = FunctionComponent<PublicProps<PROPS>>;
+```
+
+**References:** [FunctionComponent](#functioncomponent), [PublicProps](#publicprops)
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/shared/component.public.ts)
+
+<h2 id="component-type-alias">Component</h2>
 
 Type representing the Qwik component.
 
@@ -731,7 +756,7 @@ onMount
 
 **Returns:**
 
-[Component](#component)&lt;PROPS&gt;
+[Component](#component-type-alias)&lt;PROPS&gt;
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/shared/component.public.ts)
 
@@ -1172,6 +1197,60 @@ prevState
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/shared/jsx/types/jsx-qwik-attributes.ts)
 
+<h2 id="createasync">createAsync</h2>
+
+```typescript
+createAsync: <T>(
+  fn: ((arg: AsyncCtx) => Promise<T>) | QRL<(arg: AsyncCtx) => Promise<T>>,
+  options?: AsyncSignalOptions<T>,
+) => AsyncSignal<T>;
+```
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+fn
+
+</td><td>
+
+((arg: AsyncCtx) =&gt; Promise&lt;T&gt;) \| [QRL](#qrl-type-alias)&lt;(arg: AsyncCtx) =&gt; Promise&lt;T&gt;&gt;
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+options
+
+</td><td>
+
+[AsyncSignalOptions](#asyncsignaloptions)&lt;T&gt;
+
+</td><td>
+
+_(Optional)_
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+[AsyncSignal](#asyncsignal)&lt;T&gt;
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/reactive-primitives/signal.public.ts)
+
 <h2 id="createasync_">createAsync$</h2>
 
 Create a signal holding a `.value` which is calculated from the given async function (QRL). The standalone version of `useAsync$`.
@@ -1225,6 +1304,58 @@ _(Optional)_
 **Returns:**
 
 [AsyncSignal](#asyncsignal)&lt;T&gt;
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/reactive-primitives/signal.public.ts)
+
+<h2 id="createcomputed">createComputed</h2>
+
+```typescript
+createComputed: <T>(fn: (() => T) | QRL<() => T>, options?: ComputedOptions) =>
+  ComputedReturnType<T>;
+```
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+fn
+
+</td><td>
+
+(() =&gt; T) \| [QRL](#qrl-type-alias)&lt;() =&gt; T&gt;
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+options
+
+</td><td>
+
+[ComputedOptions](#computedoptions)
+
+</td><td>
+
+_(Optional)_
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+[ComputedReturnType](#computedreturntype)&lt;T&gt;
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/reactive-primitives/signal.public.ts)
 
@@ -1368,6 +1499,44 @@ The name of the context.
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-context.ts)
 
+<h2 id="createserializer">createSerializer</h2>
+
+```typescript
+createSerializer: <T, S>(arg: SerializerArg<T, S> | QRL<SerializerArg<T, S>>) => T extends Promise<any> ? never : SerializerSignal<T>
+```
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+arg
+
+</td><td>
+
+SerializerArg&lt;T, S&gt; \| [QRL](#qrl-type-alias)&lt;SerializerArg&lt;T, S&gt;&gt;
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+T extends Promise&lt;any&gt; ? never : [SerializerSignal](#serializersignal)&lt;T&gt;
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/reactive-primitives/signal.public.ts)
+
 <h2 id="createserializer_">createSerializer$</h2>
 
 Create a signal that holds a custom serializable value. See [useSerializer$](#useserializer_) for more details.
@@ -1404,7 +1573,7 @@ SerializerArg&lt;T, S&gt;
 
 **Returns:**
 
-T extends Promise&lt;any&gt; ? never : SerializerSignal&lt;T&gt;
+T extends Promise&lt;any&gt; ? never : [SerializerSignal](#serializersignal)&lt;T&gt;
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/reactive-primitives/signal.public.ts)
 
@@ -3069,7 +3238,7 @@ export type PropsOf<COMP> = COMP extends string
       : never;
 ```
 
-**References:** [QwikIntrinsicElements](#qwikintrinsicelements), [FunctionComponent](#functioncomponent), [Component](#component)
+**References:** [QwikIntrinsicElements](#qwikintrinsicelements), [FunctionComponent](#functioncomponent), [Component](#component-type-alias)
 
 ```tsx
 const Desc = component$(
@@ -4442,6 +4611,52 @@ export type SerializationStrategy = "never" | "always";
 ```
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/shared/types.ts)
+
+<h2 id="serializersignal">SerializerSignal</h2>
+
+A serializer signal holds a custom serializable value. See `useSerializer$` for more details.
+
+```typescript
+export interface SerializerSignal<T> extends ComputedSignal<T>
+```
+
+**Extends:** [ComputedSignal](#computedsignal)&lt;T&gt;
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+\_\_no_serialize\_\_
+
+</td><td>
+
+</td><td>
+
+true
+
+</td><td>
+
+Fake property to make the serialization linter happy
+
+</td></tr>
+</tbody></table>
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/reactive-primitives/signal.public.ts)
 
 <h2 id="serializersymbol">SerializerSymbol</h2>
 
@@ -9322,6 +9537,60 @@ T
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/reactive-primitives/impl/store.ts)
 
+<h2 id="useasync">useAsync</h2>
+
+```typescript
+useAsync: <T>(
+  fn: AsyncFn<T> | QRL<AsyncFn<T>>,
+  options?: AsyncSignalOptions<T>,
+) => AsyncSignal<T>;
+```
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+fn
+
+</td><td>
+
+[AsyncFn](#asyncfn)&lt;T&gt; \| [QRL](#qrl-type-alias)&lt;[AsyncFn](#asyncfn)&lt;T&gt;&gt;
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+options
+
+</td><td>
+
+[AsyncSignalOptions](#asyncsignaloptions)&lt;T&gt;
+
+</td><td>
+
+_(Optional)_
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+[AsyncSignal](#asyncsignal)&lt;T&gt;
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-async.ts)
+
 <h2 id="useasync_">useAsync$</h2>
 
 Creates an AsyncSignal which holds the result of the given async function. If the function uses `track()` to track reactive state, and that state changes, the AsyncSignal is recalculated, and if the result changed, all tasks which are tracking the AsyncSignal will be re-run and all subscribers (components, tasks etc) that read the AsyncSignal will be updated.
@@ -9383,6 +9652,60 @@ _(Optional)_
 [AsyncSignal](#asyncsignal)&lt;T&gt;
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-async.ts)
+
+<h2 id="usecomputed">useComputed</h2>
+
+```typescript
+useComputed: <T>(
+  fn: ComputedFn<T> | QRL<ComputedFn<T>>,
+  options?: ComputedOptions,
+) => ComputedReturnType<T>;
+```
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+fn
+
+</td><td>
+
+[ComputedFn](#computedfn)&lt;T&gt; \| [QRL](#qrl-type-alias)&lt;[ComputedFn](#computedfn)&lt;T&gt;&gt;
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+options
+
+</td><td>
+
+[ComputedOptions](#computedoptions)
+
+</td><td>
+
+_(Optional)_
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+[ComputedReturnType](#computedreturntype)&lt;T&gt;
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-computed.ts)
 
 <h2 id="usecomputed_">useComputed$</h2>
 
@@ -9676,7 +9999,7 @@ Used to programmatically add event listeners. Useful from custom `use*` methods,
 Events are case sensitive.
 
 ```typescript
-useOn: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T>, options?: UseOnOptions) => void
+useOn: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T> | EventHandler<EventFromName<T>, Element>, options?: UseOnOptions) => void
 ```
 
 <table><thead><tr><th>
@@ -9709,7 +10032,7 @@ eventQrl
 
 </td><td>
 
-EventQRL&lt;T&gt;
+EventQRL&lt;T&gt; \| [EventHandler](#eventhandler)&lt;EventFromName&lt;T&gt;, Element&gt;
 
 </td><td>
 
@@ -9744,7 +10067,7 @@ Used to programmatically add event listeners. Useful from custom `use*` methods,
 Events are case sensitive.
 
 ```typescript
-useOnDocument: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T>, options?: UseOnOptions) => void
+useOnDocument: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T> | EventHandler<EventFromName<T>, Element>, options?: UseOnOptions) => void
 ```
 
 <table><thead><tr><th>
@@ -9777,7 +10100,7 @@ eventQrl
 
 </td><td>
 
-EventQRL&lt;T&gt;
+EventQRL&lt;T&gt; \| [EventHandler](#eventhandler)&lt;EventFromName&lt;T&gt;, Element&gt;
 
 </td><td>
 
@@ -9830,7 +10153,7 @@ Used to programmatically add event listeners. Useful from custom `use*` methods,
 Events are case sensitive.
 
 ```typescript
-useOnWindow: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T>, options?: UseOnOptions) => void
+useOnWindow: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T> | EventHandler<EventFromName<T>, Element>, options?: UseOnOptions) => void
 ```
 
 <table><thead><tr><th>
@@ -9863,7 +10186,7 @@ eventQrl
 
 </td><td>
 
-EventQRL&lt;T&gt;
+EventQRL&lt;T&gt; \| [EventHandler](#eventhandler)&lt;EventFromName&lt;T&gt;, Element&gt;
 
 </td><td>
 
@@ -9888,6 +10211,60 @@ _(Optional)_
 void
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-on.ts)
+
+<h2 id="useresource">useResource</h2>
+
+```typescript
+useResource: <T>(
+  fn: ResourceFn<T> | QRL<ResourceFn<T>>,
+  opts?: ResourceOptions,
+) => ResourceReturn<T>;
+```
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+fn
+
+</td><td>
+
+[ResourceFn](#resourcefn)&lt;T&gt; \| [QRL](#qrl-type-alias)&lt;[ResourceFn](#resourcefn)&lt;T&gt;&gt;
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+opts
+
+</td><td>
+
+[ResourceOptions](#resourceoptions)
+
+</td><td>
+
+_(Optional)_
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+[ResourceReturn](#resourcereturn)&lt;T&gt;
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-resource.ts)
 
 <h2 id="useresource_">useResource$</h2>
 
@@ -9956,6 +10333,44 @@ _(Optional)_
 import("./use-resource").[ResourceReturn](#resourcereturn)&lt;T&gt;
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-resource-dollar.ts)
+
+<h2 id="useserializer">useSerializer</h2>
+
+```typescript
+useSerializer: <T, S>(arg: SerializerArg<T, S> | QRL<SerializerArg<T, S>>) => T extends Promise<any> ? never : SerializerSignal<T>
+```
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+arg
+
+</td><td>
+
+SerializerArg&lt;T, S&gt; \| [QRL](#qrl-type-alias)&lt;SerializerArg&lt;T, S&gt;&gt;
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+T extends Promise&lt;any&gt; ? never : [SerializerSignal](#serializersignal)&lt;T&gt;
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-serializer.ts)
 
 <h2 id="useserializer_">useSerializer$</h2>
 
@@ -10306,6 +10721,86 @@ _(Optional)_ If `false` then the object will not be tracked for changes. Default
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-store.public.ts)
 
+<h2 id="usestyles-function">useStyles</h2>
+
+```typescript
+export interface UseStyles
+```
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+styleId
+
+</td><td>
+
+</td><td>
+
+string
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-styles.ts)
+
+<h2 id="usestyles-interface">UseStyles</h2>
+
+```typescript
+export interface UseStyles
+```
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+styleId
+
+</td><td>
+
+</td><td>
+
+string
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-styles.ts)
+
 <h2 id="usestyles_">useStyles$</h2>
 
 A lazy-loadable reference to a component's styles.
@@ -10354,11 +10849,51 @@ string
 
 **Returns:**
 
-UseStyles
+[UseStyles](#usestyles-interface)
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-styles.ts)
 
-<h2 id="usestylesscoped">UseStylesScoped</h2>
+<h2 id="usestylesscoped-function">useStylesScoped</h2>
+
+```typescript
+export interface UseStylesScoped
+```
+
+<table><thead><tr><th>
+
+Property
+
+</th><th>
+
+Modifiers
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+scopeId
+
+</td><td>
+
+</td><td>
+
+string
+
+</td><td>
+
+</td></tr>
+</tbody></table>
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-styles.ts)
+
+<h2 id="usestylesscoped-interface">UseStylesScoped</h2>
 
 ```typescript
 export interface UseStylesScoped
@@ -10446,9 +10981,60 @@ string
 
 **Returns:**
 
-[UseStylesScoped](#usestylesscoped)
+[UseStylesScoped](#usestylesscoped-interface)
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-styles.ts)
+
+<h2 id="usetask">useTask</h2>
+
+```typescript
+useTask: (fn: TaskFn | QRL<TaskFn>, opts?: TaskOptions) => void
+```
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+fn
+
+</td><td>
+
+[TaskFn](#taskfn) \| [QRL](#qrl-type-alias)&lt;[TaskFn](#taskfn)&gt;
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+opts
+
+</td><td>
+
+[TaskOptions](#taskoptions)
+
+</td><td>
+
+_(Optional)_
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+void
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-task.ts)
 
 <h2 id="usetask_">useTask$</h2>
 
@@ -10506,6 +11092,57 @@ _(Optional)_
 void
 
 [Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-task-dollar.ts)
+
+<h2 id="usevisibletask">useVisibleTask</h2>
+
+```typescript
+useVisibleTask: (fn: TaskFn | QRL<TaskFn>, opts?: OnVisibleTaskOptions) => void
+```
+
+<table><thead><tr><th>
+
+Parameter
+
+</th><th>
+
+Type
+
+</th><th>
+
+Description
+
+</th></tr></thead>
+<tbody><tr><td>
+
+fn
+
+</td><td>
+
+[TaskFn](#taskfn) \| [QRL](#qrl-type-alias)&lt;[TaskFn](#taskfn)&gt;
+
+</td><td>
+
+</td></tr>
+<tr><td>
+
+opts
+
+</td><td>
+
+[OnVisibleTaskOptions](#onvisibletaskoptions)
+
+</td><td>
+
+_(Optional)_
+
+</td></tr>
+</tbody></table>
+
+**Returns:**
+
+void
+
+[Edit this section](https://github.com/QwikDev/qwik/tree/main/packages/qwik/src/core/use/use-visible-task.ts)
 
 <h2 id="usevisibletask_">useVisibleTask$</h2>
 

--- a/packages/optimizer/core/src/snapshots/qwik_core__test__example_1.snap
+++ b/packages/optimizer/core/src/snapshots/qwik_core__test__example_1.snap
@@ -1,6 +1,5 @@
 ---
 source: packages/optimizer/core/src/test.rs
-assertion_line: 92
 expression: output
 ---
 ==INPUT==
@@ -18,20 +17,20 @@ const renderHeader2 = component($(() => {
 	return render;
 }));
 
-============================= test.tsx_renderHeader1_div_onClick_USi8k1jUb40.tsx (ENTRY POINT)==
+============================= test.tsx_renderHeader1_div_q_e_click_fjy1WIjm9hw.tsx (ENTRY POINT)==
 
-export const renderHeader1_div_onClick_USi8k1jUb40 = (ctx)=>console.log(ctx);
+export const renderHeader1_div_q_e_click_fjy1WIjm9hw = (ctx)=>console.log(ctx);
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"qDAKkB,CAAC,MAAQ,QAAQ,GAAG,CAAC\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"uDAKkB,CAAC,MAAQ,QAAQ,GAAG,CAAC\"}")
 /*
 {
   "origin": "test.tsx",
-  "name": "renderHeader1_div_onClick_USi8k1jUb40",
+  "name": "renderHeader1_div_q_e_click_fjy1WIjm9hw",
   "entry": null,
-  "displayName": "test.tsx_renderHeader1_div_onClick",
-  "hash": "USi8k1jUb40",
-  "canonicalFilename": "test.tsx_renderHeader1_div_onClick_USi8k1jUb40",
+  "displayName": "test.tsx_renderHeader1_div_q_e_click",
+  "hash": "fjy1WIjm9hw",
+  "canonicalFilename": "test.tsx_renderHeader1_div_q_e_click_fjy1WIjm9hw",
   "path": "",
   "extension": "tsx",
   "parent": "renderHeader1_jMxQsjbyDss",
@@ -64,10 +63,10 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
 
 import { qrl } from "@qwik.dev/core";
 //
-const q_renderHeader1_div_onClick_USi8k1jUb40 = /*#__PURE__*/ qrl(()=>import("./test.tsx_renderHeader1_div_onClick_USi8k1jUb40"), "renderHeader1_div_onClick_USi8k1jUb40");
+const q_renderHeader1_div_q_e_click_fjy1WIjm9hw = /*#__PURE__*/ qrl(()=>import("./test.tsx_renderHeader1_div_q_e_click_fjy1WIjm9hw"), "renderHeader1_div_q_e_click_fjy1WIjm9hw");
 //
 export const renderHeader1_jMxQsjbyDss = ()=>{
-    return <div onClick={q_renderHeader1_div_onClick_USi8k1jUb40}/>;
+    return <div q-e:click={q_renderHeader1_div_q_e_click_fjy1WIjm9hw}/>;
 };
 
 

--- a/packages/optimizer/core/src/snapshots/qwik_core__test__example_10.snap
+++ b/packages/optimizer/core/src/snapshots/qwik_core__test__example_10.snap
@@ -1,6 +1,5 @@
 ---
 source: packages/optimizer/core/src/test.rs
-assertion_line: 269
 expression: output
 ---
 ==INPUT==
@@ -46,11 +45,11 @@ export const Header_WlR3xnI6u38 = (decl1, { decl2 }, [decl3])=>{
             return ident10;
         }
     }
-    return <div onClick={(ident11)=>ident11 + ident12} required={false}/>;
+    return <div q-e:click={(ident11)=>ident11 + ident12} required={false}/>;
 };
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\":[],\"mappings\":\"kCAEiB,CAAC,OAAO,EAAC,KAAK,EAAC,EAAE,CAAC,MAAM;IAE3B,OAAO,EAAE;IACtB;IACU,QAAS;IACT,QAAS;IACnB,OAAO,QAAQ;QAAC;KAAO,EAAE;QAAC;IAAM,GAAG;QAAC,KAAK;IAAM;IAC/C,MAAM;QACL,OAAO,OAAO;QACd,SAAS;YACR,OAAO;QACR;IACD;IAEA,QACE,IAAI,SAAS,CAAC,UAAY,UAAU,SAAS,UAAU;AAE1D\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/project/test.tsx\"],\"names\":[],\"mappings\":\"kCAEiB,CAAC,OAAO,EAAC,KAAK,EAAC,EAAE,CAAC,MAAM;IAE3B,OAAO,EAAE;IACtB;IACU,QAAS;IACT,QAAS;IACnB,OAAO,QAAQ;QAAC;KAAO,EAAE;QAAC;IAAM,GAAG;QAAC,KAAK;IAAM;IAC/C,MAAM;QACL,OAAO,OAAO;QACd,SAAS;YACR,OAAO;QACR;IACD;IAEA,QACE,IAAI,WAAS,CAAC,UAAY,UAAU,SAAS,UAAU;AAE1D\"}")
 /*
 {
   "origin": "project/test.tsx",

--- a/packages/optimizer/core/src/snapshots/qwik_core__test__example_2.snap
+++ b/packages/optimizer/core/src/snapshots/qwik_core__test__example_2.snap
@@ -1,6 +1,5 @@
 ---
 source: packages/optimizer/core/src/test.rs
-assertion_line: 113
 expression: output
 ---
 ==INPUT==
@@ -14,15 +13,44 @@ export const Header = component$(() => {
 	);
 });
 
+============================= test.tsx_Header_component_div_q_e_click_aMxtmYKxCwA.tsx (ENTRY POINT)==
+
+export const Header_component_div_q_e_click_aMxtmYKxCwA = (ctx)=>console.log(ctx);
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"0DAKkB,CAAC,MAAQ,QAAQ,GAAG,CAAC\"}")
+/*
+{
+  "origin": "test.tsx",
+  "name": "Header_component_div_q_e_click_aMxtmYKxCwA",
+  "entry": null,
+  "displayName": "test.tsx_Header_component_div_q_e_click",
+  "hash": "aMxtmYKxCwA",
+  "canonicalFilename": "test.tsx_Header_component_div_q_e_click_aMxtmYKxCwA",
+  "path": "",
+  "extension": "tsx",
+  "parent": "Header_component_J4uyIhaBNR4",
+  "ctxKind": "function",
+  "ctxName": "$",
+  "captures": false,
+  "loc": [
+    142,
+    167
+  ],
+  "paramNames": [
+    "ctx"
+  ]
+}
+*/
 ============================= test.tsx_Header_component_J4uyIhaBNR4.tsx (ENTRY POINT)==
 
 import { qrl } from "@qwik.dev/core";
 //
-const q_Header_component_div_onClick_i7ekvWH3674 = /*#__PURE__*/ qrl(()=>import("./test.tsx_Header_component_div_onClick_i7ekvWH3674"), "Header_component_div_onClick_i7ekvWH3674");
+const q_Header_component_div_q_e_click_aMxtmYKxCwA = /*#__PURE__*/ qrl(()=>import("./test.tsx_Header_component_div_q_e_click_aMxtmYKxCwA"), "Header_component_div_q_e_click_aMxtmYKxCwA");
 //
 export const Header_component_J4uyIhaBNR4 = ()=>{
     console.log("mount");
-    return <div onClick={q_Header_component_div_onClick_i7ekvWH3674}/>;
+    return <div q-e:click={q_Header_component_div_q_e_click_aMxtmYKxCwA}/>;
 };
 
 
@@ -58,35 +86,6 @@ export const Header = /*#__PURE__*/ componentQrl(q_Header_component_J4uyIhaBNR4)
 
 
 Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;AAEA,OAAO,MAAM,uBAAS,6CAKnB\"}")
-============================= test.tsx_Header_component_div_onClick_i7ekvWH3674.tsx (ENTRY POINT)==
-
-export const Header_component_div_onClick_i7ekvWH3674 = (ctx)=>console.log(ctx);
-
-
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"wDAKkB,CAAC,MAAQ,QAAQ,GAAG,CAAC\"}")
-/*
-{
-  "origin": "test.tsx",
-  "name": "Header_component_div_onClick_i7ekvWH3674",
-  "entry": null,
-  "displayName": "test.tsx_Header_component_div_onClick",
-  "hash": "i7ekvWH3674",
-  "canonicalFilename": "test.tsx_Header_component_div_onClick_i7ekvWH3674",
-  "path": "",
-  "extension": "tsx",
-  "parent": "Header_component_J4uyIhaBNR4",
-  "ctxKind": "function",
-  "ctxName": "$",
-  "captures": false,
-  "loc": [
-    142,
-    167
-  ],
-  "paramNames": [
-    "ctx"
-  ]
-}
-*/
 == DIAGNOSTICS ==
 
 []

--- a/packages/optimizer/core/src/snapshots/qwik_core__test__example_3.snap
+++ b/packages/optimizer/core/src/snapshots/qwik_core__test__example_3.snap
@@ -1,6 +1,5 @@
 ---
 source: packages/optimizer/core/src/test.rs
-assertion_line: 130
 expression: output
 ---
 ==INPUT==
@@ -21,11 +20,11 @@ export const App = () => {
 
 import { qrl } from "@qwik.dev/core";
 //
-const q_App_Header_component_div_onClick_aO7uI7Iw6oQ = /*#__PURE__*/ qrl(()=>import("./test.tsx_App_Header_component_div_onClick_aO7uI7Iw6oQ"), "App_Header_component_div_onClick_aO7uI7Iw6oQ");
+const q_App_Header_component_div_q_e_click_tbeQzUb0b9Q = /*#__PURE__*/ qrl(()=>import("./test.tsx_App_Header_component_div_q_e_click_tbeQzUb0b9Q"), "App_Header_component_div_q_e_click_tbeQzUb0b9Q");
 //
 export const App_Header_component_B9F3YeqcO1w = ()=>{
     console.log("mount");
-    return <div onClick={q_App_Header_component_div_onClick_aO7uI7Iw6oQ}/>;
+    return <div q-e:click={q_App_Header_component_div_q_e_click_tbeQzUb0b9Q}/>;
 };
 
 
@@ -50,20 +49,34 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= test.tsx_App_Header_component_div_onClick_aO7uI7Iw6oQ.tsx (ENTRY POINT)==
+============================= test.tsx ==
 
-export const App_Header_component_div_onClick_aO7uI7Iw6oQ = (ctx)=>console.log(ctx);
+import { componentQrl } from "@qwik.dev/core";
+import { qrl } from "@qwik.dev/core";
+//
+const q_App_Header_component_B9F3YeqcO1w = /*#__PURE__*/ qrl(()=>import("./test.tsx_App_Header_component_B9F3YeqcO1w"), "App_Header_component_B9F3YeqcO1w");
+//
+export const App = ()=>{
+    const Header = /*#__PURE__*/ componentQrl(q_App_Header_component_B9F3YeqcO1w);
+    return Header;
+};
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"4DAMmB,CAAC,MAAQ,QAAQ,GAAG,CAAC\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;AAEA,OAAO,MAAM,MAAM;IAClB,MAAM,uBAAS;IAMf,OAAO;AACR,EAAG\"}")
+============================= test.tsx_App_Header_component_div_q_e_click_tbeQzUb0b9Q.tsx (ENTRY POINT)==
+
+export const App_Header_component_div_q_e_click_tbeQzUb0b9Q = (ctx)=>console.log(ctx);
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"8DAMmB,CAAC,MAAQ,QAAQ,GAAG,CAAC\"}")
 /*
 {
   "origin": "test.tsx",
-  "name": "App_Header_component_div_onClick_aO7uI7Iw6oQ",
+  "name": "App_Header_component_div_q_e_click_tbeQzUb0b9Q",
   "entry": null,
-  "displayName": "test.tsx_App_Header_component_div_onClick",
-  "hash": "aO7uI7Iw6oQ",
-  "canonicalFilename": "test.tsx_App_Header_component_div_onClick_aO7uI7Iw6oQ",
+  "displayName": "test.tsx_App_Header_component_div_q_e_click",
+  "hash": "tbeQzUb0b9Q",
+  "canonicalFilename": "test.tsx_App_Header_component_div_q_e_click_tbeQzUb0b9Q",
   "path": "",
   "extension": "tsx",
   "parent": "App_Header_component_B9F3YeqcO1w",
@@ -79,20 +92,6 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= test.tsx ==
-
-import { componentQrl } from "@qwik.dev/core";
-import { qrl } from "@qwik.dev/core";
-//
-const q_App_Header_component_B9F3YeqcO1w = /*#__PURE__*/ qrl(()=>import("./test.tsx_App_Header_component_B9F3YeqcO1w"), "App_Header_component_B9F3YeqcO1w");
-//
-export const App = ()=>{
-    const Header = /*#__PURE__*/ componentQrl(q_App_Header_component_B9F3YeqcO1w);
-    return Header;
-};
-
-
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;AAEA,OAAO,MAAM,MAAM;IAClB,MAAM,uBAAS;IAMf,OAAO;AACR,EAAG\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/optimizer/core/src/snapshots/qwik_core__test__example_4.snap
+++ b/packages/optimizer/core/src/snapshots/qwik_core__test__example_4.snap
@@ -1,6 +1,5 @@
 ---
 source: packages/optimizer/core/src/test.rs
-assertion_line: 150
 expression: output
 ---
 ==INPUT==
@@ -21,11 +20,11 @@ export function App() {
 
 import { qrl } from "@qwik.dev/core";
 //
-const q_App_Header_component_div_onClick_aO7uI7Iw6oQ = /*#__PURE__*/ qrl(()=>import("./test.tsx_App_Header_component_div_onClick_aO7uI7Iw6oQ"), "App_Header_component_div_onClick_aO7uI7Iw6oQ");
+const q_App_Header_component_div_q_e_click_tbeQzUb0b9Q = /*#__PURE__*/ qrl(()=>import("./test.tsx_App_Header_component_div_q_e_click_tbeQzUb0b9Q"), "App_Header_component_div_q_e_click_tbeQzUb0b9Q");
 //
 export const App_Header_component_B9F3YeqcO1w = ()=>{
     console.log("mount");
-    return <div onClick={q_App_Header_component_div_onClick_aO7uI7Iw6oQ}/>;
+    return <div q-e:click={q_App_Header_component_div_q_e_click_tbeQzUb0b9Q}/>;
 };
 
 
@@ -50,20 +49,34 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= test.tsx_App_Header_component_div_onClick_aO7uI7Iw6oQ.tsx (ENTRY POINT)==
+============================= test.tsx ==
 
-export const App_Header_component_div_onClick_aO7uI7Iw6oQ = (ctx)=>console.log(ctx);
+import { componentQrl } from "@qwik.dev/core";
+import { qrl } from "@qwik.dev/core";
+//
+const q_App_Header_component_B9F3YeqcO1w = /*#__PURE__*/ qrl(()=>import("./test.tsx_App_Header_component_B9F3YeqcO1w"), "App_Header_component_B9F3YeqcO1w");
+//
+export function App() {
+    const Header = /*#__PURE__*/ componentQrl(q_App_Header_component_B9F3YeqcO1w);
+    return Header;
+}
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"4DAMmB,CAAC,MAAQ,QAAQ,GAAG,CAAC\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;AAEA,OAAO,SAAS;IACf,MAAM,uBAAS;IAMf,OAAO;AACR\"}")
+============================= test.tsx_App_Header_component_div_q_e_click_tbeQzUb0b9Q.tsx (ENTRY POINT)==
+
+export const App_Header_component_div_q_e_click_tbeQzUb0b9Q = (ctx)=>console.log(ctx);
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"8DAMmB,CAAC,MAAQ,QAAQ,GAAG,CAAC\"}")
 /*
 {
   "origin": "test.tsx",
-  "name": "App_Header_component_div_onClick_aO7uI7Iw6oQ",
+  "name": "App_Header_component_div_q_e_click_tbeQzUb0b9Q",
   "entry": null,
-  "displayName": "test.tsx_App_Header_component_div_onClick",
-  "hash": "aO7uI7Iw6oQ",
-  "canonicalFilename": "test.tsx_App_Header_component_div_onClick_aO7uI7Iw6oQ",
+  "displayName": "test.tsx_App_Header_component_div_q_e_click",
+  "hash": "tbeQzUb0b9Q",
+  "canonicalFilename": "test.tsx_App_Header_component_div_q_e_click_tbeQzUb0b9Q",
   "path": "",
   "extension": "tsx",
   "parent": "App_Header_component_B9F3YeqcO1w",
@@ -79,20 +92,6 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   ]
 }
 */
-============================= test.tsx ==
-
-import { componentQrl } from "@qwik.dev/core";
-import { qrl } from "@qwik.dev/core";
-//
-const q_App_Header_component_B9F3YeqcO1w = /*#__PURE__*/ qrl(()=>import("./test.tsx_App_Header_component_B9F3YeqcO1w"), "App_Header_component_B9F3YeqcO1w");
-//
-export function App() {
-    const Header = /*#__PURE__*/ componentQrl(q_App_Header_component_B9F3YeqcO1w);
-    return Header;
-}
-
-
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;AAEA,OAAO,SAAS;IACf,MAAM,uBAAS;IAMf,OAAO;AACR\"}")
 == DIAGNOSTICS ==
 
 []

--- a/packages/optimizer/core/src/snapshots/qwik_core__test__example_5.snap
+++ b/packages/optimizer/core/src/snapshots/qwik_core__test__example_5.snap
@@ -1,6 +1,5 @@
 ---
 source: packages/optimizer/core/src/test.rs
-assertion_line: 170
 expression: output
 ---
 ==INPUT==
@@ -16,21 +15,50 @@ export const Header = component$(() => {
 	);
 });
 
+============================= test.tsx_Header_component_div_q_e_click_aMxtmYKxCwA.tsx (ENTRY POINT)==
+
+export const Header_component_div_q_e_click_aMxtmYKxCwA = (ctx)=>console.log("2");
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"0DAMmB,CAAC,MAAQ,QAAQ,GAAG,CAAC\"}")
+/*
+{
+  "origin": "test.tsx",
+  "name": "Header_component_div_q_e_click_aMxtmYKxCwA",
+  "entry": null,
+  "displayName": "test.tsx_Header_component_div_q_e_click",
+  "hash": "aMxtmYKxCwA",
+  "canonicalFilename": "test.tsx_Header_component_div_q_e_click_aMxtmYKxCwA",
+  "path": "",
+  "extension": "tsx",
+  "parent": "Header_component_J4uyIhaBNR4",
+  "ctxKind": "function",
+  "ctxName": "$",
+  "captures": false,
+  "loc": [
+    171,
+    196
+  ],
+  "paramNames": [
+    "ctx"
+  ]
+}
+*/
 ============================= test.tsx_Header_component_J4uyIhaBNR4.tsx (ENTRY POINT)==
 
 import { qrl } from "@qwik.dev/core";
 //
-const q_Header_component_div_onClick_i7ekvWH3674 = /*#__PURE__*/ qrl(()=>import("./test.tsx_Header_component_div_onClick_i7ekvWH3674"), "Header_component_div_onClick_i7ekvWH3674");
+const q_Header_component_div_q_e_click_aMxtmYKxCwA = /*#__PURE__*/ qrl(()=>import("./test.tsx_Header_component_div_q_e_click_aMxtmYKxCwA"), "Header_component_div_q_e_click_aMxtmYKxCwA");
 //
 export const Header_component_J4uyIhaBNR4 = ()=>{
     return <>
-			<div onClick={(ctx)=>console.log("1")}/>
-			<div onClick={q_Header_component_div_onClick_i7ekvWH3674}/>
+			<div q-e:click={(ctx)=>console.log("1")}/>
+			<div q-e:click={q_Header_component_div_q_e_click_aMxtmYKxCwA}/>
 		</>;
 };
 
 
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;4CAEiC;IAChC,SACG;GACD,CAAC,IAAI,SAAS,CAAC,MAAQ,QAAQ,GAAG,CAAC,OAAO;GAC1C,CAAC,IAAI,sDAAwC;EAC9C;AAEF\"}")
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;4CAEiC;IAChC,SACG;GACD,CAAC,IAAI,WAAS,CAAC,MAAQ,QAAQ,GAAG,CAAC,OAAO;GAC1C,CAAC,IAAI,0DAAwC;EAC9C;AAEF\"}")
 /*
 {
   "origin": "test.tsx",
@@ -62,35 +90,6 @@ export const Header = /*#__PURE__*/ componentQrl(q_Header_component_J4uyIhaBNR4)
 
 
 Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\";;;;;AAEA,OAAO,MAAM,uBAAS,6CAOnB\"}")
-============================= test.tsx_Header_component_div_onClick_i7ekvWH3674.tsx (ENTRY POINT)==
-
-export const Header_component_div_onClick_i7ekvWH3674 = (ctx)=>console.log("2");
-
-
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"wDAMmB,CAAC,MAAQ,QAAQ,GAAG,CAAC\"}")
-/*
-{
-  "origin": "test.tsx",
-  "name": "Header_component_div_onClick_i7ekvWH3674",
-  "entry": null,
-  "displayName": "test.tsx_Header_component_div_onClick",
-  "hash": "i7ekvWH3674",
-  "canonicalFilename": "test.tsx_Header_component_div_onClick_i7ekvWH3674",
-  "path": "",
-  "extension": "tsx",
-  "parent": "Header_component_J4uyIhaBNR4",
-  "ctxKind": "function",
-  "ctxName": "$",
-  "captures": false,
-  "loc": [
-    171,
-    196
-  ],
-  "paramNames": [
-    "ctx"
-  ]
-}
-*/
 == DIAGNOSTICS ==
 
 []

--- a/packages/optimizer/core/src/snapshots/qwik_core__test__example_7.snap
+++ b/packages/optimizer/core/src/snapshots/qwik_core__test__example_7.snap
@@ -1,6 +1,5 @@
 ---
 source: packages/optimizer/core/src/test.rs
-assertion_line: 201
 expression: output
 ---
 ==INPUT==
@@ -21,15 +20,44 @@ const App = component$(() => {
 	);
 });
 
+============================= test.tsx_Header_component_div_q_e_click_aMxtmYKxCwA.tsx (ENTRY POINT)==
+
+export const Header_component_div_q_e_click_aMxtmYKxCwA = (ctx)=>console.log(ctx);
+
+
+Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"0DAMkB,CAAC,MAAQ,QAAQ,GAAG,CAAC\"}")
+/*
+{
+  "origin": "test.tsx",
+  "name": "Header_component_div_q_e_click_aMxtmYKxCwA",
+  "entry": null,
+  "displayName": "test.tsx_Header_component_div_q_e_click",
+  "hash": "aMxtmYKxCwA",
+  "canonicalFilename": "test.tsx_Header_component_div_q_e_click_aMxtmYKxCwA",
+  "path": "",
+  "extension": "tsx",
+  "parent": "Header_component_J4uyIhaBNR4",
+  "ctxKind": "function",
+  "ctxName": "$",
+  "captures": false,
+  "loc": [
+    143,
+    168
+  ],
+  "paramNames": [
+    "ctx"
+  ]
+}
+*/
 ============================= test.tsx_Header_component_J4uyIhaBNR4.tsx (ENTRY POINT)==
 
 import { qrl } from "@qwik.dev/core";
 //
-const q_Header_component_div_onClick_i7ekvWH3674 = /*#__PURE__*/ qrl(()=>import("./test.tsx_Header_component_div_onClick_i7ekvWH3674"), "Header_component_div_onClick_i7ekvWH3674");
+const q_Header_component_div_q_e_click_aMxtmYKxCwA = /*#__PURE__*/ qrl(()=>import("./test.tsx_Header_component_div_q_e_click_aMxtmYKxCwA"), "Header_component_div_q_e_click_aMxtmYKxCwA");
 //
 export const Header_component_J4uyIhaBNR4 = ()=>{
     console.log("mount");
-    return <div onClick={q_Header_component_div_onClick_i7ekvWH3674}/>;
+    return <div q-e:click={q_Header_component_div_q_e_click_aMxtmYKxCwA}/>;
 };
 
 
@@ -94,35 +122,6 @@ Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"ma
   "loc": [
     206,
     241
-  ]
-}
-*/
-============================= test.tsx_Header_component_div_onClick_i7ekvWH3674.tsx (ENTRY POINT)==
-
-export const Header_component_div_onClick_i7ekvWH3674 = (ctx)=>console.log(ctx);
-
-
-Some("{\"version\":3,\"sources\":[\"/user/qwik/src/test.tsx\"],\"names\":[],\"mappings\":\"wDAMkB,CAAC,MAAQ,QAAQ,GAAG,CAAC\"}")
-/*
-{
-  "origin": "test.tsx",
-  "name": "Header_component_div_onClick_i7ekvWH3674",
-  "entry": null,
-  "displayName": "test.tsx_Header_component_div_onClick",
-  "hash": "i7ekvWH3674",
-  "canonicalFilename": "test.tsx_Header_component_div_onClick_i7ekvWH3674",
-  "path": "",
-  "extension": "tsx",
-  "parent": "Header_component_J4uyIhaBNR4",
-  "ctxKind": "function",
-  "ctxName": "$",
-  "captures": false,
-  "loc": [
-    143,
-    168
-  ],
-  "paramNames": [
-    "ctx"
   ]
 }
 */

--- a/packages/optimizer/core/src/transform.rs
+++ b/packages/optimizer/core/src/transform.rs
@@ -1795,7 +1795,7 @@ impl<'a> QwikTransform<'a> {
 					}
 				}
 
-				// Transform event props (e.g., onClick$ -> q-e:click)
+				// Transform event props (e.g., onClick$/onClick -> q-e:click)
 				let is_passive = jsx_event_to_event_name(kw.as_ref())
 					.is_some_and(|event_name| context.passive_events.contains(&event_name));
 				if let Some(html_attr) = jsx_event_to_html_attribute(kw.as_ref(), is_passive) {
@@ -3979,7 +3979,7 @@ impl<'a> Fold for QwikTransform<'a> {
 			ast::JSXAttrName::Ident(ref ident) => {
 				let new_word = convert_qrl_word(&ident.sym);
 
-				// Transform event names (onClick$ -> q-e:click) only on native HTML elements
+				// Transform event names (onClick$/onClick -> q-e:click) only on native HTML elements
 				let is_native_element = self.jsx_element_is_native.last().copied().unwrap_or(false);
 				let transformed_name = if is_native_element {
 					let passive_events = self.jsx_element_passive_events.last();
@@ -4806,19 +4806,15 @@ fn normalize_jsx_event_name(name: &str) -> String {
 }
 
 fn jsx_event_to_event_name(jsx_event: &str) -> Option<String> {
-	if !jsx_event.ends_with('$') {
-		return None;
-	}
-
 	let (_, idx) = get_event_scope_data_from_jsx_event(jsx_event, false);
 
 	if idx == usize::MAX {
 		return None;
 	}
 
-	Some(normalize_jsx_event_name(
-		&jsx_event[idx..jsx_event.len() - 1],
-	))
+	let end = jsx_event_name_end(jsx_event, idx)?;
+
+	Some(normalize_jsx_event_name(&jsx_event[idx..end]))
 }
 
 fn passive_attr_to_event_name(passive_attr: &str) -> Option<String> {
@@ -4869,24 +4865,39 @@ fn collect_passive_event_names_from_jsx_attrs(attrs: &[ast::JSXAttrOrSpread]) ->
 		.collect()
 }
 
-/// Converts JSX event names (e.g., onClick$) to HTML attribute names (e.g., q-e:click)
+/// Converts JSX event names (e.g., onClick$/onClick) to HTML attribute names (e.g., q-e:click)
 /// Follows the same logic as jsxEventToHtmlAttribute in event-names.ts
 fn jsx_event_to_html_attribute(jsx_event: &str, is_passive: bool) -> Option<Atom> {
-	if !jsx_event.ends_with('$') {
-		return None;
-	}
-
 	let (prefix, idx) = get_event_scope_data_from_jsx_event(jsx_event, is_passive);
 
 	if idx == usize::MAX {
 		return None;
 	}
 
+	let end = jsx_event_name_end(jsx_event, idx)?;
+
 	Some(Atom::from(format!(
 		"{}{}",
 		prefix,
-		normalize_jsx_event_name(&jsx_event[idx..jsx_event.len() - 1])
+		normalize_jsx_event_name(&jsx_event[idx..end])
 	)))
+}
+
+fn jsx_event_name_end(jsx_event: &str, idx: usize) -> Option<usize> {
+	if jsx_event.ends_with('$') {
+		let end = jsx_event.len() - 1;
+		if end > idx {
+			return Some(end);
+		}
+		return None;
+	}
+
+	let first_event_char = jsx_event[idx..].chars().next()?;
+	if first_event_char.is_ascii_uppercase() || first_event_char == '-' {
+		Some(jsx_event.len())
+	} else {
+		None
+	}
 }
 
 /// Get the event scope prefix and starting index from a JSX event name

--- a/packages/qwik-react/src/index.qwik.ts
+++ b/packages/qwik-react/src/index.qwik.ts
@@ -1,4 +1,4 @@
-export { qwikify$, qwikifyQrl } from './react/qwikify';
-export { reactify$, reactifyQrl } from './react/reactify';
+export { qwikify, qwikify$, qwikifyQrl } from './react/qwikify';
+export { reactify, reactify$, reactifyQrl } from './react/reactify';
 
 export type { QwikifyProps } from './react/types';

--- a/packages/qwik-react/src/react/qwik-react-aliases.unit.tsx
+++ b/packages/qwik-react/src/react/qwik-react-aliases.unit.tsx
@@ -1,0 +1,24 @@
+import { component$, type QRL } from '@qwik.dev/core';
+import { describe, expectTypeOf, test } from 'vitest';
+import type { FunctionComponent as ReactFC } from 'react';
+import { qwikify, qwikify$, qwikifyQrl } from './qwikify';
+import { reactify, reactify$, reactifyQrl } from './reactify';
+
+describe('qwik react aliases', () => {
+  test('qwikify and reactify accept plain values and QRLs', () => () => {
+    const ReactCmp: ReactFC<{ count: number; children?: unknown }> = () => null;
+    const ReactCmpQrl = true as any as QRL<typeof ReactCmp>;
+    const QwikCmp = component$<{ count: number }>(() => null);
+    const QwikCmpQrl = true as any as QRL<typeof QwikCmp>;
+
+    expectTypeOf(qwikify(ReactCmp)).not.toBeAny();
+    expectTypeOf(qwikify(ReactCmpQrl)).not.toBeAny();
+    expectTypeOf(qwikify$(() => null)).not.toBeAny();
+    expectTypeOf(qwikifyQrl(ReactCmpQrl)).not.toBeAny();
+
+    expectTypeOf(reactify(QwikCmp)).toBeAny();
+    expectTypeOf(reactify(QwikCmpQrl)).toBeAny();
+    expectTypeOf(reactify$(() => null)).toBeAny();
+    expectTypeOf(reactifyQrl(QwikCmpQrl)).toBeAny();
+  });
+});

--- a/packages/qwik-react/src/react/qwikify.tsx
+++ b/packages/qwik-react/src/react/qwikify.tsx
@@ -24,6 +24,10 @@ import { getHostProps, main, mainExactProps, useWakeupSignal } from './slot';
 import type { QwikProjectionState } from './slot';
 import type { Internal, QwikifyOptions, QwikifyProps } from './types';
 
+const toQrl = <T,>(value: T | QRL<T>): QRL<T> => {
+  return value as QRL<T>;
+};
+
 export function qwikifyQrl<PROPS extends Record<any, any>>(
   reactCmp$: QRL<ReactFC<PROPS & { children?: any }>>,
   opts?: QwikifyOptions
@@ -162,3 +166,10 @@ export function qwikifyQrl<PROPS extends Record<any, any>>(
 }
 
 export const qwikify$ = /*#__PURE__*/ implicit$FirstArg(qwikifyQrl);
+
+export const qwikify = <PROPS extends Record<any, any>>(
+  reactCmp: ReactFC<PROPS & { children?: any }> | QRL<ReactFC<PROPS & { children?: any }>>,
+  opts?: QwikifyOptions
+) => {
+  return qwikifyQrl(toQrl(reactCmp), opts);
+};

--- a/packages/qwik-react/src/react/reactify.ts
+++ b/packages/qwik-react/src/react/reactify.ts
@@ -13,6 +13,10 @@ import {
   type QwikProjectionState,
 } from './slot';
 
+const toQrl = <T>(value: T | QRL<T>): QRL<T> => {
+  return value as QRL<T>;
+};
+
 let slotCounter = 0;
 
 /**
@@ -180,3 +184,8 @@ export function reactifyQrl(qwikCompQrl: QRL<any>): any {
  * @returns A React component that renders the Qwik component
  */
 export const reactify$ = /*#__PURE__*/ implicit$FirstArg(reactifyQrl);
+
+/** @public */
+export const reactify = (qwikComp: any | QRL<any>): any => {
+  return reactifyQrl(toQrl(qwikComp));
+};

--- a/packages/qwik-router/src/runtime/src/index.ts
+++ b/packages/qwik-router/src/runtime/src/index.ts
@@ -72,18 +72,25 @@ export {
 } from './qwik-router-component';
 export { RouterOutlet } from './router-outlet-component';
 export {
+  globalAction,
   globalAction$,
   globalActionQrl,
+  routeAction,
   routeAction$,
   routeActionQrl,
+  routeLoader,
   routeLoader$,
   routeLoaderQrl,
+  server,
   server$,
   serverQrl,
+  valibot,
   valibot$,
   valibotQrl,
+  validator,
   validator$,
   validatorQrl,
+  zod,
   zod$,
   zodQrl,
 } from './server-functions';
@@ -94,6 +101,7 @@ export {
   useHttpStatus,
   useLocation,
   useNavigate,
+  usePreventNavigate,
   usePreventNavigate$,
   usePreventNavigateQrl,
 } from './use-functions';

--- a/packages/qwik-router/src/runtime/src/qwik-router.runtime.api.md
+++ b/packages/qwik-router/src/runtime/src/qwik-router.runtime.api.md
@@ -236,6 +236,10 @@ export type GetValidatorType<VALIDATOR extends TypedDataValidator> = GetValidato
 export const globalAction$: ActionConstructor;
 
 // Warning: (ae-forgotten-export) The symbol "ActionConstructorQRL" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export const globalAction: ActionConstructor & ActionConstructorQRL;
+
 // Warning: (ae-internal-missing-underscore) The name "globalActionQrl" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
@@ -449,6 +453,9 @@ export type ResolvedDocumentHead<FrontMatter extends Record<string, any> = Recor
 // @public (undocumented)
 export const routeAction$: ActionConstructor;
 
+// @public (undocumented)
+export const routeAction: ActionConstructor & ActionConstructorQRL;
+
 // Warning: (ae-internal-missing-underscore) The name "routeActionQrl" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
@@ -492,6 +499,10 @@ export interface RouteData {
 export const routeLoader$: LoaderConstructor;
 
 // Warning: (ae-forgotten-export) The symbol "LoaderConstructorQRL" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export const routeLoader: LoaderConstructor & LoaderConstructorQRL;
+
 // Warning: (ae-internal-missing-underscore) The name "routeLoaderQrl" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
@@ -524,6 +535,9 @@ export const RouterOutlet: Component<unknown>;
 //
 // @public (undocumented)
 export const server$: <T extends ServerFunction>(qrl: T, options?: ServerConfig | undefined) => ServerQRL<T>;
+
+// @public (undocumented)
+export const server: <T extends ServerFunction>(fn: T | QRL<T>, options?: ServerConfig) => ServerQRL<T>;
 
 // @public
 export type ServerData = {
@@ -600,6 +614,9 @@ export const useNavigate: () => RouteNavigate;
 // @public
 export const usePreventNavigate$: (qrl: PreventNavigateCallback) => void;
 
+// @public (undocumented)
+export const usePreventNavigate: (fn: PreventNavigateCallback | QRL<PreventNavigateCallback>) => void;
+
 // Warning: (ae-internal-missing-underscore) The name "usePreventNavigateQrl" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal
@@ -614,6 +631,10 @@ export const useQwikRouter: (props?: QwikRouterProps) => void;
 export const valibot$: ValibotConstructor;
 
 // Warning: (ae-forgotten-export) The symbol "ValibotConstructorQRL" needs to be exported by the entry point index.d.ts
+//
+// @beta (undocumented)
+export const valibot: ValibotConstructor & ValibotConstructorQRL;
+
 // Warning: (ae-internal-missing-underscore) The name "valibotQrl" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
@@ -623,6 +644,11 @@ export const valibotQrl: ValibotConstructorQRL;
 //
 // @public (undocumented)
 export const validator$: ValidatorConstructor;
+
+// Warning: (ae-forgotten-export) The symbol "ValidatorConstructorQRL" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export const validator: ValidatorConstructor & ValidatorConstructorQRL;
 
 // Warning: (ae-forgotten-export) The symbol "IsAny" needs to be exported by the entry point index.d.ts
 //
@@ -639,7 +665,6 @@ export type ValidatorErrorType<T, U = string> = {
     }>;
 };
 
-// Warning: (ae-forgotten-export) The symbol "ValidatorConstructorQRL" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-missing-underscore) The name "validatorQrl" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
@@ -656,6 +681,11 @@ export { z }
 // @public (undocumented)
 export const zod$: ZodConstructor;
 
+// Warning: (ae-forgotten-export) The symbol "ZodConstructorQRL" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export const zod: ZodConstructor & ZodConstructorQRL;
+
 // @public (undocumented)
 export type ZodConstructor = {
     <T extends z_2.ZodRawShape>(schema: T): ZodDataValidator<z_2.ZodObject<T>>;
@@ -664,7 +694,6 @@ export type ZodConstructor = {
     <T extends z_2.Schema>(schema: (zod: typeof z_2.z, ev: RequestEvent) => T): ZodDataValidator<T>;
 };
 
-// Warning: (ae-forgotten-export) The symbol "ZodConstructorQRL" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-missing-underscore) The name "zodQrl" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)

--- a/packages/qwik-router/src/runtime/src/server-functions.ts
+++ b/packages/qwik-router/src/runtime/src/server-functions.ts
@@ -63,6 +63,36 @@ import type {
 } from './types';
 import { useAction, useLocation, useQwikRouterEnv } from './use-functions';
 
+const toQrl = <T>(value: T | QRL<T>): QRL<T> => {
+  return value as QRL<T>;
+};
+
+type ActionCompatInput =
+  | QRL<(form: JSONObject, event: RequestEventAction) => ValueOrPromise<unknown>>
+  | ((form: JSONObject, event: RequestEventAction) => ValueOrPromise<unknown>);
+
+type LoaderCompatInput =
+  | QRL<(event: RequestEventLoader) => ValueOrPromise<unknown>>
+  | ((event: RequestEventLoader) => ValueOrPromise<unknown>);
+
+type ValidatorCompatInput =
+  | QRL<(ev: RequestEvent, data: unknown) => ValueOrPromise<ValidatorReturn>>
+  | ((ev: RequestEvent, data: unknown) => ValueOrPromise<ValidatorReturn>);
+
+type ValibotCompatInput =
+  | QRL<v.GenericSchema | v.GenericSchemaAsync>
+  | QRL<(ev: RequestEvent) => v.GenericSchema | v.GenericSchemaAsync>
+  | v.GenericSchema
+  | v.GenericSchemaAsync
+  | ((ev: RequestEvent) => v.GenericSchema | v.GenericSchemaAsync);
+
+type ZodCompatInput =
+  | QRL<z.ZodRawShape | z.Schema>
+  | QRL<(zod: typeof z.z, ev: RequestEvent) => z.ZodRawShape | z.Schema>
+  | z.ZodRawShape
+  | z.Schema
+  | ((zod: typeof z.z, ev: RequestEvent) => z.ZodRawShape | z.Schema);
+
 /** @internal */
 export const routeActionQrl = ((
   actionQrl: QRL<(form: JSONObject, event: RequestEventAction) => unknown>,
@@ -188,9 +218,25 @@ export const routeAction$: ActionConstructor = /*#__PURE__*/ implicit$FirstArg(
 ) as any;
 
 /** @public */
+export const routeAction: ActionConstructor & ActionConstructorQRL = ((
+  action: ActionCompatInput,
+  ...rest: (ActionOptions | DataValidator)[]
+) => {
+  return routeActionQrl(toQrl(action), ...(rest as any));
+}) as any;
+
+/** @public */
 export const globalAction$: ActionConstructor = /*#__PURE__*/ implicit$FirstArg(
   globalActionQrl
 ) as any;
+
+/** @public */
+export const globalAction: ActionConstructor & ActionConstructorQRL = ((
+  action: ActionCompatInput,
+  ...rest: (ActionOptions | DataValidator)[]
+) => {
+  return globalActionQrl(toQrl(action), ...(rest as any));
+}) as any;
 
 const getValue = <T extends { value: any }>(obj: T) => obj.value;
 /** @internal */
@@ -235,6 +281,14 @@ export const routeLoaderQrl = ((
 /** @public */
 export const routeLoader$: LoaderConstructor = /*#__PURE__*/ implicit$FirstArg(routeLoaderQrl);
 
+/** @public */
+export const routeLoader: LoaderConstructor & LoaderConstructorQRL = ((
+  loader: LoaderCompatInput,
+  ...rest: (LoaderOptions | DataValidator)[]
+) => {
+  return routeLoaderQrl(toQrl(loader), ...(rest as any));
+}) as any;
+
 /** @internal */
 export const validatorQrl = ((
   validator: QRL<(ev: RequestEvent, data: unknown) => ValueOrPromise<ValidatorReturn>>
@@ -249,6 +303,13 @@ export const validatorQrl = ((
 
 /** @public */
 export const validator$: ValidatorConstructor = /*#__PURE__*/ implicit$FirstArg(validatorQrl);
+
+/** @public */
+export const validator: ValidatorConstructor & ValidatorConstructorQRL = ((
+  fn: ValidatorCompatInput
+) => {
+  return validatorQrl(toQrl(fn));
+}) as any;
 
 const flattenValibotIssues = (issues: v.GenericIssue[]) => {
   return issues.reduce<Record<string, string | string[]>>((acc, issue) => {
@@ -323,6 +384,13 @@ export const valibotQrl: ValibotConstructorQRL = (
 /** @beta */
 export const valibot$: ValibotConstructor = /*#__PURE__*/ implicit$FirstArg(valibotQrl);
 
+/** @beta */
+export const valibot: ValibotConstructor & ValibotConstructorQRL = ((
+  schema: ValibotCompatInput
+) => {
+  return valibotQrl(toQrl(schema) as Parameters<typeof valibotQrl>[0]);
+}) as any;
+
 const flattenZodIssues = (issues: z.ZodIssue | z.ZodIssue[]) => {
   issues = Array.isArray(issues) ? issues : [issues];
   return issues.reduce<Record<string, string | string[]>>((acc, issue) => {
@@ -392,6 +460,11 @@ export const zodQrl: ZodConstructorQRL = (
 
 /** @public */
 export const zod$: ZodConstructor = /*#__PURE__*/ implicit$FirstArg(zodQrl);
+
+/** @public */
+export const zod: ZodConstructor & ZodConstructorQRL = ((schema: ZodCompatInput) => {
+  return zodQrl(toQrl(schema) as Parameters<typeof zodQrl>[0]);
+}) as any;
 
 /** @internal */
 export const serverQrl = <T extends ServerFunction>(
@@ -517,6 +590,14 @@ export const serverQrl = <T extends ServerFunction>(
 
 /** @public */
 export const server$ = /*#__PURE__*/ implicit$FirstArg(serverQrl);
+
+/** @public */
+export const server = <T extends ServerFunction>(
+  fn: T | QRL<T>,
+  options?: ServerConfig
+): ServerQRL<T> => {
+  return serverQrl(toQrl(fn), options);
+};
 
 const getValidators = (rest: (LoaderOptions | DataValidator)[], qrl: QRL) => {
   let id: string | undefined;

--- a/packages/qwik-router/src/runtime/src/server-functions.unit.ts
+++ b/packages/qwik-router/src/runtime/src/server-functions.unit.ts
@@ -1,25 +1,50 @@
 import { describe, expectTypeOf, test } from 'vitest';
+import { $, type QRL } from '@qwik.dev/core';
+import * as v from 'valibot';
 import * as z from 'zod';
-import { server$ } from './server-functions';
-import type { RequestEventBase, ValidatorErrorType } from './types';
+import {
+  globalAction,
+  globalAction$,
+  routeAction,
+  routeAction$,
+  routeLoader,
+  routeLoader$,
+  server,
+  server$,
+  valibot,
+  valibot$,
+  validator,
+  validator$,
+  zod,
+  zod$,
+} from './server-functions';
+import type { JSONObject, RequestEventBase, ValidatorErrorType } from './types';
 
 describe('types', () => {
   test('matching', () => () => {
     const foo = () => server$(() => 'hello');
+    const plain = () => server(() => 'hello');
+    const qrl = () => server($(() => 'hello'));
 
     expectTypeOf(foo).not.toBeAny();
     expectTypeOf(foo).returns.toMatchTypeOf<() => Promise<string>>();
     expectTypeOf(foo).returns.toMatchTypeOf<(sig: AbortSignal) => Promise<string>>();
     expectTypeOf(foo).returns.not.toMatchTypeOf<(meep: boolean) => Promise<string>>();
+    expectTypeOf(plain).returns.toMatchTypeOf<() => Promise<string>>();
+    expectTypeOf(qrl).returns.toMatchTypeOf<() => Promise<string>>();
   });
 
   test('matching with args', () => () => {
     const foo = () => server$((name: string) => 'hello ' + name);
+    const plain = () => server((name: string) => 'hello ' + name);
+    const qrl = () => server($((name: string) => 'hello ' + name));
 
     expectTypeOf(foo).not.toBeAny();
     expectTypeOf(foo).returns.toMatchTypeOf<(name: string) => Promise<string>>();
     expectTypeOf(foo).returns.toMatchTypeOf<(sig: AbortSignal, name: string) => Promise<string>>();
     expectTypeOf(foo).returns.not.toMatchTypeOf<(meep: boolean) => Promise<string>>();
+    expectTypeOf(plain).returns.toMatchTypeOf<(name: string) => Promise<string>>();
+    expectTypeOf(qrl).returns.toMatchTypeOf<(name: string) => Promise<string>>();
   });
 
   test('inferring', () => () => {
@@ -160,5 +185,53 @@ describe('types', () => {
     expectTypeOf<ErrorType>().not.toEqualTypeOf<{
       someAnyType?: string;
     }>();
+  });
+
+  test('non-dollar constructors accept plain and QRL inputs', () => () => {
+    const action = routeAction((form) => ({ ok: form != null }));
+    const actionQrl = routeAction($((form: JSONObject) => ({ ok: form != null })));
+    const actionLegacy = routeAction$((form) => ({ ok: form != null }));
+    const global = globalAction((form) => ({ ok: form != null }));
+    const globalQrl = globalAction($((form: JSONObject) => ({ ok: form != null })));
+    const globalLegacy = globalAction$((form) => ({ ok: form != null }));
+
+    expectTypeOf(action).toEqualTypeOf(actionLegacy);
+    expectTypeOf(actionQrl).toEqualTypeOf(actionLegacy);
+    expectTypeOf(global).toEqualTypeOf(globalLegacy);
+    expectTypeOf(globalQrl).toEqualTypeOf(globalLegacy);
+
+    const loader = routeLoader(() => ({ value: 1 }));
+    const loaderQrl = routeLoader($(() => ({ value: 1 })));
+    const loaderLegacy = routeLoader$(() => ({ value: 1 }));
+
+    expectTypeOf(loader).toEqualTypeOf(loaderLegacy);
+    expectTypeOf(loaderQrl).toEqualTypeOf(loaderLegacy);
+
+    const validate = validator(() => ({ success: true as const, data: { ok: true } }));
+    const validateQrl = validator($(() => ({ success: true as const, data: { ok: true } })));
+    const validateLegacy = validator$(() => ({ success: true as const, data: { ok: true } }));
+
+    expectTypeOf(validate).toEqualTypeOf(validateLegacy);
+    expectTypeOf(validateQrl).toEqualTypeOf(validateLegacy);
+
+    const valibotSchema = v.object({ username: v.string() });
+    const valibotSchemaQrl = true as any as QRL<typeof valibotSchema>;
+    expectTypeOf(valibot(valibotSchema)).not.toBeAny();
+    expectTypeOf(valibot(valibotSchemaQrl)).not.toBeAny();
+    expectTypeOf(valibot(() => valibotSchema)).not.toBeAny();
+    expectTypeOf(valibot($(() => v.object({ username: v.string() })))).toEqualTypeOf(
+      valibot$(() => v.object({ username: v.string() }))
+    );
+
+    const zodSchema = z.object({ username: z.string() });
+    const zodSchemaQrl = true as any as QRL<typeof zodSchema>;
+    expectTypeOf(zod(zodSchema)).not.toBeAny();
+    expectTypeOf(zod(zodSchemaQrl)).not.toBeAny();
+    expectTypeOf(zod((zod) => ({ username: zod.string() }))).toEqualTypeOf(
+      zod$((zod) => ({ username: zod.string() }))
+    );
+    expectTypeOf(
+      zod($((zodInstance: typeof z.z) => ({ username: zodInstance.string() })))
+    ).toEqualTypeOf(zod$((zod) => ({ username: zod.string() })));
   });
 });

--- a/packages/qwik-router/src/runtime/src/use-functions.ts
+++ b/packages/qwik-router/src/runtime/src/use-functions.ts
@@ -24,6 +24,10 @@ import type {
   RouteNavigate,
 } from './types';
 
+const toQrl = <T>(value: T | QRL<T>): QRL<T> => {
+  return value as QRL<T>;
+};
+
 /** @public */
 export const useHttpStatus = () => useContext(HttpStatusContext).value;
 
@@ -90,6 +94,11 @@ export const usePreventNavigateQrl = (fn: QRL<PreventNavigateCallback>): void =>
  * @public
  */
 export const usePreventNavigate$ = implicit$FirstArg(usePreventNavigateQrl);
+
+/** @public */
+export const usePreventNavigate = (fn: PreventNavigateCallback | QRL<PreventNavigateCallback>) => {
+  return usePreventNavigateQrl(toQrl(fn));
+};
 
 export const useAction = (): RouteAction => useContext(RouteActionContext);
 

--- a/packages/qwik-router/src/runtime/src/use-functions.unit.ts
+++ b/packages/qwik-router/src/runtime/src/use-functions.unit.ts
@@ -1,0 +1,12 @@
+import { $ } from '@qwik.dev/core';
+import { describe, expectTypeOf, test } from 'vitest';
+import { usePreventNavigate, usePreventNavigate$, usePreventNavigateQrl } from './use-functions';
+
+describe('use-functions types', () => {
+  test('usePreventNavigate accepts plain callbacks and QRLs', () => () => {
+    expectTypeOf(usePreventNavigate((url) => !!url)).toEqualTypeOf<void>();
+    expectTypeOf(usePreventNavigate($((url) => !!url))).toEqualTypeOf<void>();
+    expectTypeOf(usePreventNavigate$((url) => !!url)).toEqualTypeOf<void>();
+    expectTypeOf(usePreventNavigateQrl($((url) => !!url))).toEqualTypeOf<void>();
+  });
+});

--- a/packages/qwik/src/core/index.ts
+++ b/packages/qwik/src/core/index.ts
@@ -18,7 +18,7 @@ if (import.meta.hot) {
 //////////////////////////////////////////////////////////////////////////////////////////
 // Developer Core API
 //////////////////////////////////////////////////////////////////////////////////////////
-export { componentQrl, component$ } from './shared/component.public';
+export { componentQrl, component$, component } from './shared/component.public';
 
 export type { PropsOf, OnRenderFn, Component, PublicProps } from './shared/component.public';
 
@@ -125,20 +125,27 @@ export { untrack } from './use/use-core';
 export { useId } from './use/use-id';
 export { useContext, useContextProvider, createContextId } from './use/use-context';
 export { useServerData } from './use/use-env-data';
-export { useStylesQrl, useStyles$, useStylesScopedQrl, useStylesScoped$ } from './use/use-styles';
+export {
+  useStylesQrl,
+  useStyles$,
+  useStyles,
+  useStylesScopedQrl,
+  useStylesScoped$,
+  useStylesScoped,
+} from './use/use-styles';
 export { useOn, useOnDocument, useOnWindow, type UseOnOptions } from './use/use-on';
 export { useSignal, useConstant } from './use/use-signal';
 export { withLocale, getLocale } from './use/use-locale';
 
-export type { UseStylesScoped } from './use/use-styles';
+export type { UseStyles, UseStylesScoped } from './use/use-styles';
 export type { UseSignal } from './use/use-signal';
 export type { ContextId } from './use/use-context';
 export type { UseStoreOptions } from './use/use-store.public';
 export type { ComputedFn, ComputedReturnType } from './use/use-computed';
 export { useComputedQrl } from './use/use-computed';
-export { useSerializerQrl, useSerializer$ } from './use/use-serializer';
+export { useSerializerQrl, useSerializer$, useSerializer } from './use/use-serializer';
 export type { OnVisibleTaskOptions, VisibleTaskStrategy } from './use/use-visible-task';
-export { useVisibleTaskQrl } from './use/use-visible-task';
+export { useVisibleTaskQrl, useVisibleTask } from './use/use-visible-task';
 export type { TaskCtx, TaskFn, Tracker, TaskOptions } from './use/use-task';
 export type {
   ResourceProps,
@@ -150,14 +157,14 @@ export type {
   ResourceResolved,
   ResourceReturn,
 } from './use/use-resource';
-export { useResourceQrl, Resource } from './use/use-resource';
+export { useResourceQrl, useResource, Resource } from './use/use-resource';
 export { useResource$ } from './use/use-resource-dollar';
-export { useTaskQrl } from './use/use-task';
+export { useTaskQrl, useTask } from './use/use-task';
 export { useTask$ } from './use/use-task-dollar';
 export { useVisibleTask$ } from './use/use-visible-task-dollar';
-export { useComputed$ } from './use/use-computed';
+export { useComputed$, useComputed } from './use/use-computed';
 export type { AsyncFn } from './use/use-async';
-export { useAsyncQrl, useAsync$ } from './use/use-async';
+export { useAsyncQrl, useAsync$, useAsync } from './use/use-async';
 export { useErrorBoundary } from './use/use-error-boundary';
 export type { ErrorBoundaryStore } from './shared/error/error-handling';
 export {
@@ -165,16 +172,20 @@ export {
   type AsyncSignal,
   type Signal,
   type ComputedSignal,
+  type SerializerSignal,
 } from './reactive-primitives/signal.public';
 export {
   isSignal,
   createSignal,
   createComputedQrl,
   createComputed$,
+  createComputed,
   createSerializerQrl,
   createSerializer$,
+  createSerializer,
   createAsyncQrl,
   createAsync$,
+  createAsync,
 } from './reactive-primitives/signal.public';
 export type { ComputedOptions } from './reactive-primitives/types';
 

--- a/packages/qwik/src/core/qwik.core.api.md
+++ b/packages/qwik/src/core/qwik.core.api.md
@@ -96,6 +96,9 @@ export const component$: <PROPS = unknown>(onMount: OnRenderFn<PROPS>) => Compon
 export type Component<PROPS = unknown> = FunctionComponent<PublicProps<PROPS>>;
 
 // @public (undocumented)
+export const component: <PROPS = unknown>(onMount: OnRenderFn<PROPS> | QRL<OnRenderFn<PROPS>>) => Component<PROPS>;
+
+// @public (undocumented)
 export interface ComponentBaseProps {
     // (undocumented)
     'q:slot'?: string;
@@ -232,6 +235,9 @@ export interface CorrectedToggleEvent extends Event {
 // @public
 export const createAsync$: <T>(qrl: (arg: AsyncCtx<T>) => Promise<T>, options?: AsyncSignalOptions<T>) => AsyncSignal<T>;
 
+// @public (undocumented)
+export const createAsync: <T>(fn: ((arg: AsyncCtx) => Promise<T>) | QRL<(arg: AsyncCtx) => Promise<T>>, options?: AsyncSignalOptions<T>) => AsyncSignal<T>;
+
 // Warning: (ae-forgotten-export) The symbol "AsyncSignalImpl" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-missing-underscore) The name "createAsyncQrl" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -240,6 +246,9 @@ export const createAsyncQrl: <T>(qrl: QRL<AsyncFn<T>>, options?: AsyncSignalOpti
 
 // @public
 export const createComputed$: <T>(qrl: () => T, options?: ComputedOptions) => ComputedReturnType<T>;
+
+// @public (undocumented)
+export const createComputed: <T>(fn: (() => T) | QRL<() => T>, options?: ComputedOptions) => ComputedReturnType<T>;
 
 // Warning: (ae-forgotten-export) The symbol "ComputedSignalImpl" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-missing-underscore) The name "createComputedQrl" should be prefixed with an underscore because the declaration is marked as @internal
@@ -259,10 +268,12 @@ export function _createDeserializeContainer(stateData: unknown[]): DeserializeCo
 export const _createQRL: <TYPE>(chunk: string | null, symbol: string, symbolRef?: null | ValueOrPromise<TYPE>, symbolFn?: null | (() => Promise<Record<string, TYPE>>), captures?: Readonly<unknown[]> | string | null, container?: _Container) => _QRLInternal<TYPE>;
 
 // Warning: (ae-forgotten-export) The symbol "SerializerArg" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "SerializerSignal" needs to be exported by the entry point index.d.ts
 //
 // @public
 export const createSerializer$: <T, S>(arg: SerializerArg<T, S>) => T extends Promise<any> ? never : SerializerSignal<T>;
+
+// @public (undocumented)
+export const createSerializer: <T, S>(arg: SerializerArg<T, S> | QRL<SerializerArg<T, S>>) => T extends Promise<any> ? never : SerializerSignal<T>;
 
 // Warning: (ae-forgotten-export) The symbol "SerializerSignalImpl" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-missing-underscore) The name "createSerializerQrl" should be prefixed with an underscore because the declaration is marked as @internal
@@ -1075,6 +1086,11 @@ export type SerializationStrategy = 'never' | 'always';
 
 // @internal
 export function _serialize<T>(data: T): Promise<string>;
+
+// @public
+export interface SerializerSignal<T> extends ComputedSignal<T> {
+    __no_serialize__: true;
+}
 
 // @public
 export const SerializerSymbol: unique symbol;
@@ -1902,6 +1918,9 @@ export function _updateProjectionProps(container: _Container, vnode: _VirtualVNo
 // @public
 export const useAsync$: <T>(qrl: AsyncFn<T>, options?: AsyncSignalOptions<T> | undefined) => AsyncSignal<T>;
 
+// @public (undocumented)
+export const useAsync: <T>(fn: AsyncFn<T> | QRL<AsyncFn<T>>, options?: AsyncSignalOptions<T>) => AsyncSignal<T>;
+
 // Warning: (ae-internal-missing-underscore) The name "useAsyncQrl" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
@@ -1909,6 +1928,9 @@ export const useAsyncQrl: <T>(qrl: QRL<AsyncFn<T>>, options?: AsyncSignalOptions
 
 // @public
 export const useComputed$: <T>(qrl: ComputedFn<T>, options?: ComputedOptions | undefined) => ComputedReturnType<T>;
+
+// @public (undocumented)
+export const useComputed: <T>(fn: ComputedFn<T> | QRL<ComputedFn<T>>, options?: ComputedOptions) => ComputedReturnType<T>;
 
 // Warning: (ae-internal-missing-underscore) The name "useComputedQrl" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -1941,12 +1963,13 @@ export const useId: () => string;
 export const useLexicalScope: <VARS extends any[]>() => VARS;
 
 // Warning: (ae-forgotten-export) The symbol "EventQRL" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "EventFromName" needs to be exported by the entry point index.d.ts
 //
 // @public
-export const useOn: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T>, options?: UseOnOptions) => void;
+export const useOn: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T> | EventHandler<EventFromName<T>, Element>, options?: UseOnOptions) => void;
 
 // @public
-export const useOnDocument: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T>, options?: UseOnOptions) => void;
+export const useOnDocument: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T> | EventHandler<EventFromName<T>, Element>, options?: UseOnOptions) => void;
 
 // Warning: (ae-forgotten-export) The symbol "UseOnOptionsBase" needs to be exported by the entry point index.d.ts
 //
@@ -1960,10 +1983,13 @@ export type UseOnOptions = UseOnOptionsBase & ({
 });
 
 // @public
-export const useOnWindow: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T>, options?: UseOnOptions) => void;
+export const useOnWindow: <T extends KnownEventNames>(event: T | T[], eventQrl: EventQRL<T> | EventHandler<EventFromName<T>, Element>, options?: UseOnOptions) => void;
 
 // @public @deprecated
 export const useResource$: <T>(qrl: ResourceFn<T>, opts?: ResourceOptions | undefined) => ResourceReturn<T>;
+
+// @public (undocumented)
+export const useResource: <T>(fn: ResourceFn<T> | QRL<ResourceFn<T>>, opts?: ResourceOptions) => ResourceReturn<T>;
 
 // Warning: (ae-internal-missing-underscore) The name "useResourceQrl" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -1972,6 +1998,9 @@ export const useResourceQrl: <T>(qrl: QRL<ResourceFn<T>>, opts?: ResourceOptions
 
 // @public
 export const useSerializer$: typeof createSerializer$;
+
+// @public (undocumented)
+export const useSerializer: <T, S>(arg: SerializerArg<T, S> | QRL<SerializerArg<T, S>>) => T extends Promise<any> ? never : SerializerSignal<T>;
 
 // Warning: (ae-internal-missing-underscore) The name "useSerializerQrl" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -2004,10 +2033,17 @@ export interface UseStoreOptions {
     reactive?: boolean;
 }
 
-// Warning: (ae-forgotten-export) The symbol "UseStyles" needs to be exported by the entry point index.d.ts
-//
 // @public
 export const useStyles$: (qrl: string) => UseStyles;
+
+// @public (undocumented)
+export interface UseStyles {
+    // (undocumented)
+    styleId: string;
+}
+
+// @public (undocumented)
+export const useStyles: (styles: string | QRL<string>) => UseStyles;
 
 // Warning: (ae-internal-missing-underscore) The name "useStylesQrl" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -2023,6 +2059,9 @@ export interface UseStylesScoped {
     scopeId: string;
 }
 
+// @public (undocumented)
+export const useStylesScoped: (styles: string | QRL<string>) => UseStylesScoped;
+
 // Warning: (ae-internal-missing-underscore) The name "useStylesScopedQrl" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
@@ -2031,6 +2070,9 @@ export const useStylesScopedQrl: (styles: QRL<string>) => UseStylesScoped;
 // @public
 export const useTask$: (fn: TaskFn, opts?: TaskOptions) => void;
 
+// @public (undocumented)
+export const useTask: (fn: TaskFn | QRL<TaskFn>, opts?: TaskOptions) => void;
+
 // Warning: (ae-internal-missing-underscore) The name "useTaskQrl" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
@@ -2038,6 +2080,9 @@ export const useTaskQrl: (qrl: QRL<TaskFn>, opts?: TaskOptions) => void;
 
 // @public
 export const useVisibleTask$: (fn: TaskFn, opts?: OnVisibleTaskOptions) => void;
+
+// @public (undocumented)
+export const useVisibleTask: (fn: TaskFn | QRL<TaskFn>, opts?: OnVisibleTaskOptions) => void;
 
 // Warning: (ae-internal-missing-underscore) The name "useVisibleTaskQrl" should be prefixed with an underscore because the declaration is marked as @internal
 //

--- a/packages/qwik/src/core/reactive-primitives/impl/signal.unit.tsx
+++ b/packages/qwik/src/core/reactive-primitives/impl/signal.unit.tsx
@@ -13,9 +13,12 @@ import { retryOnPromise } from '../../shared/utils/promises';
 import { invoke, newInvokeContext } from '../../use/use-core';
 import { Task } from '../../use/use-task';
 import {
+  createAsync,
   createAsync$,
+  createComputed,
   createComputed$,
   createComputedQrl,
+  createSerializer,
   createSerializer$,
   createSignal,
   type AsyncSignal,
@@ -44,6 +47,10 @@ describe('signal types', () => {
     expectTypeOf(signal).toEqualTypeOf<ComputedSignal<number>>();
     const signal2 = createComputed$<number>(() => 1);
     expectTypeOf(signal2).toEqualTypeOf<ComputedSignal<number>>();
+    const signal3 = createComputed(() => 1);
+    expectTypeOf(signal3).toEqualTypeOf<ComputedSignal<number>>();
+    const signal4 = createComputed($(() => 1));
+    expectTypeOf(signal4).toEqualTypeOf<ComputedSignal<number>>();
   });
   it('SerializerSignal<T, S>', () => () => {
     {
@@ -102,6 +109,30 @@ describe('signal types', () => {
       expectTypeOf(signal).toEqualTypeOf<SerializerSignal<Foo>>();
       expectTypeOf(signal.value).toEqualTypeOf<Foo>();
     }
+    {
+      const signal = createSerializer({
+        deserialize: () => new Foo(),
+        serialize: (obj) => {
+          expect(obj).toBeInstanceOf(Foo);
+          return 1;
+        },
+      });
+      expectTypeOf(signal).toEqualTypeOf<SerializerSignal<Foo>>();
+      expectTypeOf(signal.value).toEqualTypeOf<Foo>();
+    }
+    {
+      const signal = createSerializer(
+        $(() => ({
+          deserialize: () => new Foo(),
+          serialize: (obj: Foo) => {
+            expect(obj).toBeInstanceOf(Foo);
+            return 1;
+          },
+        }))
+      );
+      expectTypeOf(signal).toEqualTypeOf<SerializerSignal<Foo>>();
+      expectTypeOf(signal.value).toEqualTypeOf<Foo>();
+    }
   });
   it('AsyncSignal<T>', () => async () => {
     const signal = createAsync$(() => Promise.resolve(42));
@@ -117,6 +148,10 @@ describe('signal types', () => {
     expectTypeOf(signal.abort()).toEqualTypeOf<void>();
     expectTypeOf(signal.invalidate()).toEqualTypeOf<void>();
     expectTypeOf(signal.invalidate('info')).toEqualTypeOf<void>();
+    const signal2 = createAsync(() => Promise.resolve(42));
+    expectTypeOf(signal2).toEqualTypeOf<AsyncSignal<number>>();
+    const signal3 = createAsync($(() => Promise.resolve(42)));
+    expectTypeOf(signal3).toEqualTypeOf<AsyncSignal<number>>();
   });
 });
 

--- a/packages/qwik/src/core/reactive-primitives/signal.public.ts
+++ b/packages/qwik/src/core/reactive-primitives/signal.public.ts
@@ -1,4 +1,6 @@
 import { implicit$FirstArg } from '../shared/qrl/implicit_dollar';
+import { dollar, type QRL } from '../shared/qrl/qrl.public';
+import { isQrl } from '../shared/qrl/qrl-utils';
 import type { AsyncCtx, AsyncSignalOptions, ComputedOptions, SerializerArg } from './types';
 import {
   createSignal as _createSignal,
@@ -173,6 +175,17 @@ export const createComputed$: <T>(
   qrl: () => T,
   options?: ComputedOptions
 ) => ComputedReturnType<T> = /*#__PURE__*/ implicit$FirstArg(createComputedQrl as any);
+
+/** @public */
+export const createComputed = <T>(
+  fn: (() => T) | QRL<() => T>,
+  options?: ComputedOptions
+): ComputedReturnType<T> => {
+  return createComputedQrl(
+    isQrl(fn) ? (fn as QRL<() => T>) : dollar(fn as () => T),
+    options
+  ) as any;
+};
 export { createComputedQrl };
 
 /**
@@ -185,6 +198,17 @@ export const createAsync$: <T>(
   qrl: (arg: AsyncCtx<T>) => Promise<T>,
   options?: AsyncSignalOptions<T>
 ) => AsyncSignal<T> = /*#__PURE__*/ implicit$FirstArg(createAsyncQrl as any);
+
+/** @public */
+export const createAsync = <T>(
+  fn: ((arg: AsyncCtx) => Promise<T>) | QRL<(arg: AsyncCtx) => Promise<T>>,
+  options?: AsyncSignalOptions<T>
+): AsyncSignal<T> => {
+  return createAsyncQrl(
+    (isQrl(fn) ? fn : dollar(fn as (arg: AsyncCtx) => Promise<T>)) as any,
+    options
+  );
+};
 export { createAsyncQrl };
 
 /**
@@ -198,4 +222,11 @@ export const createSerializer$: <T, S>(
 ) => T extends Promise<any> ? never : SerializerSignal<T> = implicit$FirstArg(
   createSerializerQrl as any
 );
+
+/** @public */
+export const createSerializer = <T, S>(
+  arg: SerializerArg<T, S> | QRL<SerializerArg<T, S>>
+): T extends Promise<any> ? never : SerializerSignal<T> => {
+  return createSerializerQrl((isQrl(arg) ? arg : dollar(arg as SerializerArg<T, S>)) as any) as any;
+};
 export { createSerializerQrl };

--- a/packages/qwik/src/core/shared/component.public.ts
+++ b/packages/qwik/src/core/shared/component.public.ts
@@ -11,7 +11,7 @@ import { _jsxSplit } from '../internal';
 import type { QwikIntrinsicElements } from './jsx/types/jsx-qwik-elements';
 import { assertNumber } from './error/assert';
 import { qTest } from './utils/qdev';
-import { assertQrl } from './qrl/qrl-utils';
+import { assertQrl, isQrl } from './qrl/qrl-utils';
 import { isDev } from '@qwik.dev/core/build';
 import type { QRLInternal } from './qrl/qrl-class';
 
@@ -211,6 +211,15 @@ export const isQwikComponent = <T extends Component<any>>(component: unknown): c
 // </docs>
 export const component$ = <PROPS = unknown>(onMount: OnRenderFn<PROPS>): Component<PROPS> => {
   return componentQrl(dollar(onMount));
+};
+
+/** @public */
+export const component = <PROPS = unknown>(
+  onMount: OnRenderFn<PROPS> | QRL<OnRenderFn<PROPS>>
+): Component<PROPS> => {
+  return componentQrl(
+    isQrl(onMount) ? (onMount as QRL<OnRenderFn<PROPS>>) : dollar(onMount as OnRenderFn<PROPS>)
+  );
 };
 
 /** @public */

--- a/packages/qwik/src/core/shared/jsx/jsx-internal.ts
+++ b/packages/qwik/src/core/shared/jsx/jsx-internal.ts
@@ -55,14 +55,9 @@ const removePassiveMarkers = (
 };
 
 const getPassiveEventKey = (key: string): string | null => {
-  if (key.startsWith('on') && key.endsWith('$')) {
-    return normalizeJsxEventName(key.slice(2, -1));
-  }
-  if (key.startsWith('window:on') && key.endsWith('$')) {
-    return normalizeJsxEventName(key.slice(9, -1));
-  }
-  if (key.startsWith('document:on') && key.endsWith('$')) {
-    return normalizeJsxEventName(key.slice(11, -1));
+  const attr = jsxEventToHtmlAttribute(key);
+  if (attr) {
+    return attr.slice(attr.indexOf(':') + 1);
   }
   return null;
 };

--- a/packages/qwik/src/core/shared/jsx/types/jsx-qwik-attributes.ts
+++ b/packages/qwik/src/core/shared/jsx/types/jsx-qwik-attributes.ts
@@ -94,6 +94,25 @@ type LcEventNameMap = {
 type PascalCaseName<T extends string> = T extends keyof LcEventNameMap
   ? LcEventNameMap[T]
   : Capitalize<T>;
+type LiteralEventName<K> = K extends string ? (string extends K ? never : K) : never;
+type ElementEventPropName<K> =
+  LiteralEventName<K> extends infer E
+    ? E extends string
+      ? `on${PascalCaseName<E>}$` | `on${PascalCaseName<E>}`
+      : never
+    : never;
+type DocumentEventPropName<K> =
+  LiteralEventName<K> extends infer E
+    ? E extends string
+      ? `document:on${PascalCaseName<E>}$` | `document:on${PascalCaseName<E>}`
+      : never
+    : never;
+type WindowEventPropName<K> =
+  LiteralEventName<K> extends infer E
+    ? E extends string
+      ? `window:on${PascalCaseName<E>}$` | `window:on${PascalCaseName<E>}`
+      : never
+    : never;
 
 type PreventDefault = {
   [K in keyof HTMLElementEventMap as `preventdefault:${K}`]?: boolean;
@@ -193,13 +212,13 @@ export type QRLEventHandlerMulti<EV extends Event, EL> =
   | QRLEventHandlerMulti<EV, EL>[];
 
 type JSXElementEvents = {
-  [K in keyof QwikHTMLElementEventMap as `on${PascalCaseName<K>}$`]: QwikHTMLElementEventMap[K];
+  [K in keyof QwikHTMLElementEventMap as ElementEventPropName<K>]: QwikHTMLElementEventMap[K];
 };
 type JSXDocumentEvents = {
-  [K in keyof QwikDocumentEventMap as `document:on${PascalCaseName<K>}$`]: QwikDocumentEventMap[K];
+  [K in keyof QwikDocumentEventMap as DocumentEventPropName<K>]: QwikDocumentEventMap[K];
 };
 type JSXWindowEvents = {
-  [K in keyof QwikWindowEventMap as `window:on${PascalCaseName<K>}$`]: QwikWindowEventMap[K];
+  [K in keyof QwikWindowEventMap as WindowEventPropName<K>]: QwikWindowEventMap[K];
 };
 type QwikJSXEvents = JSXElementEvents & JSXDocumentEvents & JSXWindowEvents;
 type QwikKnownEvents<EL> = {

--- a/packages/qwik/src/core/shared/jsx/types/jsx-types.unit.tsx
+++ b/packages/qwik/src/core/shared/jsx/types/jsx-types.unit.tsx
@@ -15,7 +15,7 @@ import type {
   QwikViewTransitionEvent,
   QwikVisibleEvent,
 } from '@qwik.dev/core';
-import { $, component$, sync$ } from '@qwik.dev/core';
+import { $, component, component$, sync$ } from '@qwik.dev/core';
 import { assertType, describe, expectTypeOf, test } from 'vitest';
 
 const Fn = () => <div />;
@@ -41,8 +41,12 @@ describe('types', () => {
       return <div />;
     });
     const NoP = component$(() => <div />);
+    const NoPDollarless = component(() => <div />);
+    const NoPQrl = component($(() => <div />));
     expectTypeOf<PropsOf<typeof WithP>>().toEqualTypeOf<never>();
     expectTypeOf<PropsOf<typeof NoP>>().toEqualTypeOf<never>();
+    expectTypeOf<PropsOf<typeof NoPDollarless>>().toEqualTypeOf<never>();
+    expectTypeOf<PropsOf<typeof NoPQrl>>().toEqualTypeOf<never>();
     component$(() => {
       return (
         <>
@@ -52,6 +56,12 @@ describe('types', () => {
           <NoP key={123}>
             <div />
           </NoP>
+          <NoPDollarless key={123}>
+            <div />
+          </NoPDollarless>
+          <NoPQrl key={123}>
+            <div />
+          </NoPQrl>
         </>
       );
     });
@@ -94,8 +104,9 @@ describe('types', () => {
 
   test('component', () => () => {
     const Cmp = component$((props: PropsOf<'svg'>) => {
-      const { width = '240', height = '56', onClick$, ...rest } = props;
+      const { width = '240', height = '56', onClick$, onClick, ...rest } = props;
       expectTypeOf(onClick$).toEqualTypeOf<QRLEventHandlerMulti<PointerEvent, SVGSVGElement>>();
+      expectTypeOf(onClick).toEqualTypeOf<QRLEventHandlerMulti<PointerEvent, SVGSVGElement>>();
       return (
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -109,12 +120,44 @@ describe('types', () => {
     expectTypeOf<Parameters<typeof Cmp>[0]['onClick$']>().toMatchTypeOf<
       EventHandler<PointerEvent, SVGSVGElement> | QRLEventHandlerMulti<PointerEvent, SVGSVGElement>
     >();
+    expectTypeOf<Parameters<typeof Cmp>[0]['onClick']>().toMatchTypeOf<
+      QRLEventHandlerMulti<PointerEvent, SVGSVGElement>
+    >();
 
     return (
       <p>
         <Cmp />
       </p>
     );
+  });
+
+  test('no-dollar event handlers', () => () => {
+    expectTypeOf<QwikIntrinsicElements['button']['onClick']>().toEqualTypeOf<
+      QRLEventHandlerMulti<PointerEvent, HTMLButtonElement>
+    >();
+
+    const t = (
+      <>
+        <button
+          onClick={(ev, el) => {
+            expectTypeOf(ev).not.toBeAny();
+            expectTypeOf(ev).toEqualTypeOf<PointerEvent>();
+            expectTypeOf(el).toEqualTypeOf<HTMLButtonElement>();
+          }}
+        />
+        <button onClick={$(() => {})} />
+        <button onClick={$((ev) => expectTypeOf(ev).toEqualTypeOf<PointerEvent>())} />
+        <button
+          document:onClick={(ev, el) => {
+            expectTypeOf(ev).not.toBeAny();
+            expectTypeOf(ev).toEqualTypeOf<PointerEvent>();
+            expectTypeOf(el).toEqualTypeOf<HTMLButtonElement>();
+          }}
+        />
+        <button window:onClick={$((ev) => expectTypeOf(ev).toEqualTypeOf<PointerEvent>())} />
+      </>
+    );
+    expectTypeOf(t).toEqualTypeOf<JSX.Element>();
   });
 
   test('PropFunction', () => () => {

--- a/packages/qwik/src/core/shared/utils/event-names.ts
+++ b/packages/qwik/src/core/shared/utils/event-names.ts
@@ -27,13 +27,13 @@ export const enum EventNameHtmlScope {
 export const EVENT_SUFFIX = '$';
 export const DOM_CONTENT_LOADED_EVENT = 'DOMContentLoaded';
 
+const getJsxEventName = (name: string, idx: number): string => {
+  return name.slice(idx, name.endsWith(EVENT_SUFFIX) ? -1 : undefined);
+};
+
 export const isJsxPropertyAnEventName = (name: string): boolean => {
-  return (
-    name.endsWith(EVENT_SUFFIX) &&
-    (name.startsWith(EventNameJSXScope.on) ||
-      name.startsWith(EventNameJSXScope.window) ||
-      name.startsWith(EventNameJSXScope.document))
-  );
+  const [, idx] = getEventScopeDataFromJsxEvent(name);
+  return idx !== -1 && getJsxEventName(name, idx).length > 0;
 };
 
 export const isHtmlAttributeAnEventName = (name: string): boolean => {
@@ -46,11 +46,12 @@ export const isHtmlAttributeAnEventName = (name: string): boolean => {
 };
 
 export function jsxEventToHtmlAttribute(jsxEvent: string, isPassive = false): string | null {
-  if (jsxEvent.endsWith(EVENT_SUFFIX)) {
-    const [prefix, idx] = getEventScopeDataFromJsxEvent(jsxEvent, isPassive);
+  const [prefix, idx] = getEventScopeDataFromJsxEvent(jsxEvent, isPassive);
+  if (idx !== -1) {
+    const eventName = getJsxEventName(jsxEvent, idx);
 
-    if (idx !== -1) {
-      return prefix + normalizeJsxEventName(jsxEvent.slice(idx, -1));
+    if (eventName) {
+      return prefix + normalizeJsxEventName(eventName);
     }
   }
   return null; // Return null if not matching expected format

--- a/packages/qwik/src/core/shared/utils/event-names.unit.ts
+++ b/packages/qwik/src/core/shared/utils/event-names.unit.ts
@@ -11,8 +11,11 @@ import { getEventDataFromHtmlAttribute, jsxEventToHtmlAttribute } from './event-
 const testCases = [
   // default scope
   { jsx: 'onClick$', html: 'q-e:click', eventName: 'click' },
+  { jsx: 'onClick', html: 'q-e:click', eventName: 'click' },
   { jsx: 'onDblClick$', html: 'q-e:dblclick' },
+  { jsx: 'onDblClick', html: 'q-e:dblclick' },
   { jsx: 'on--CustomEvent$', html: 'q-e:---custom-event' },
+  { jsx: 'on--CustomEvent', html: 'q-e:---custom-event' },
   { jsx: 'on-Custom-Event$', html: 'q-e:-custom---event' },
   { jsx: 'on-custom-event$', html: 'q-e:custom--event' },
   { jsx: 'on-CustomEvent$', html: 'q-e:-custom-event' },
@@ -21,18 +24,24 @@ const testCases = [
   { jsx: 'onCustom-Event$', html: 'q-e:custom--event' },
   // exception for DOMContentLoaded
   { jsx: 'onDOMContentLoaded$', html: 'q-e:-d-o-m-content-loaded' },
+  { jsx: 'onDOMContentLoaded', html: 'q-e:-d-o-m-content-loaded' },
   // window scope
   { jsx: 'window:onLoad$', html: 'q-w:load' },
+  { jsx: 'window:onLoad', html: 'q-w:load' },
   { jsx: 'window:onUnload$', html: 'q-w:unload' },
   // document scope
   { jsx: 'document:onLoad$', html: 'q-d:load' },
+  { jsx: 'document:onLoad', html: 'q-d:load' },
   { jsx: 'document:onUnload$', html: 'q-d:unload' },
 ];
 
 const passiveTestCases = [
   { jsx: 'onClick$', html: 'q-ep:click' },
+  { jsx: 'onClick', html: 'q-ep:click' },
   { jsx: 'window:onScroll$', html: 'q-wp:scroll' },
+  { jsx: 'window:onScroll', html: 'q-wp:scroll' },
   { jsx: 'document:onTouchStart$', html: 'q-dp:touchstart' },
+  { jsx: 'document:onTouchStart', html: 'q-dp:touchstart' },
 ];
 
 describe('Event conversion utilities', () => {

--- a/packages/qwik/src/core/use/use-async.ts
+++ b/packages/qwik/src/core/use/use-async.ts
@@ -2,7 +2,8 @@ import { createAsyncSignal } from '../reactive-primitives/signal-api';
 import { type AsyncSignal } from '../reactive-primitives/signal.public';
 import type { AsyncCtx, AsyncSignalOptions } from '../reactive-primitives/types';
 import { implicit$FirstArg } from '../shared/qrl/implicit_dollar';
-import type { QRL } from '../shared/qrl/qrl.public';
+import { dollar, type QRL } from '../shared/qrl/qrl.public';
+import { isQrl } from '../shared/qrl/qrl-utils';
 import type { ValueOrPromise } from '../shared/utils/types';
 import { useConstant } from './use-signal';
 
@@ -26,6 +27,14 @@ export const useAsyncQrl = <T>(
   options?: AsyncSignalOptions<T>
 ): AsyncSignal<T> => {
   return useConstant(creator<T>, qrl, options);
+};
+
+/** @public */
+export const useAsync = <T>(
+  fn: AsyncFn<T> | QRL<AsyncFn<T>>,
+  options?: AsyncSignalOptions<T>
+): AsyncSignal<T> => {
+  return useAsyncQrl(isQrl(fn) ? (fn as QRL<AsyncFn<T>>) : dollar(fn as AsyncFn<T>), options);
 };
 
 /**

--- a/packages/qwik/src/core/use/use-computed.ts
+++ b/packages/qwik/src/core/use/use-computed.ts
@@ -1,5 +1,6 @@
 import { implicit$FirstArg } from '../shared/qrl/implicit_dollar';
-import type { QRL } from '../shared/qrl/qrl.public';
+import { dollar, type QRL } from '../shared/qrl/qrl.public';
+import { isQrl } from '../shared/qrl/qrl-utils';
 import type { ComputedSignal } from '../reactive-primitives/signal.public';
 import { createComputedSignal } from '../reactive-primitives/signal-api';
 import type { ComputedOptions } from '../reactive-primitives/types';
@@ -20,6 +21,17 @@ export const useComputedQrl = <T>(
   options?: ComputedOptions
 ): ComputedReturnType<T> => {
   return useConstant(creator<T>, qrl, options) as any;
+};
+
+/** @public */
+export const useComputed = <T>(
+  fn: ComputedFn<T> | QRL<ComputedFn<T>>,
+  options?: ComputedOptions
+): ComputedReturnType<T> => {
+  return useComputedQrl(
+    isQrl(fn) ? (fn as QRL<ComputedFn<T>>) : dollar(fn as ComputedFn<T>),
+    options
+  );
 };
 
 /**

--- a/packages/qwik/src/core/use/use-computed.unit.ts
+++ b/packages/qwik/src/core/use/use-computed.unit.ts
@@ -1,0 +1,78 @@
+import { describe, expectTypeOf, test } from 'vitest';
+import { component$ } from '../shared/component.public';
+import { $ } from '../shared/qrl/qrl.public';
+import { useSignal } from './use-signal';
+import { useAsync, useAsync$ } from './use-async';
+import { useComputed, useComputed$, useComputedQrl } from './use-computed';
+import { useSerializer, useSerializer$ } from './use-serializer';
+import { useStyles, useStyles$, useStylesScoped, useStylesScoped$ } from './use-styles';
+
+describe('types', () => {
+  test('useComputed accepts plain callbacks and QRLs', () => () => {
+    component$(() => {
+      const count = useSignal(1);
+
+      const plain = useComputed(() => count.value * 2);
+      expectTypeOf(plain.value).toEqualTypeOf<number>();
+
+      const qrl = useComputed($(() => count.value * 2));
+      expectTypeOf(qrl.value).toEqualTypeOf<number>();
+
+      const qrlOnly = useComputedQrl($(() => count.value * 2));
+      expectTypeOf(qrlOnly.value).toEqualTypeOf<number>();
+
+      const legacy = useComputed$(() => count.value * 2);
+      expectTypeOf(legacy.value).toEqualTypeOf<number>();
+
+      expectTypeOf(useComputed(() => Promise.resolve(count.value))).toEqualTypeOf<never>();
+      return null;
+    });
+  });
+
+  test('related no-dollar hooks accept plain values and QRLs', () => () => {
+    component$(() => {
+      const count = useSignal(1);
+
+      const asyncPlain = useAsync(async () => count.value);
+      expectTypeOf(asyncPlain.value).toEqualTypeOf<number>();
+
+      const asyncQrl = useAsync($(async () => count.value));
+      expectTypeOf(asyncQrl.value).toEqualTypeOf<number>();
+
+      const asyncLegacy = useAsync$(async () => count.value);
+      expectTypeOf(asyncLegacy.value).toEqualTypeOf<number>();
+
+      const serializerPlain = useSerializer({
+        deserialize: (data: number | undefined) => ({ count: data ?? 0 }),
+        serialize: (value) => value.count,
+        initial: 1,
+      });
+      expectTypeOf(serializerPlain.value).toEqualTypeOf<{ count: number }>();
+
+      const serializerQrl = useSerializer(
+        $(() => ({
+          deserialize: (data: number | undefined) => ({ count: data ?? 0 }),
+          serialize: (value: { count: number }) => value.count,
+          initial: 1,
+        }))
+      );
+      expectTypeOf(serializerQrl.value).toEqualTypeOf<{ count: number }>();
+
+      const serializerLegacy = useSerializer$({
+        deserialize: (data: number | undefined) => ({ count: data ?? 0 }),
+        serialize: (value) => value.count,
+        initial: 1,
+      });
+      expectTypeOf(serializerLegacy.value).toEqualTypeOf<{ count: number }>();
+
+      expectTypeOf(useStyles('div{}').styleId).toEqualTypeOf<string>();
+      expectTypeOf(useStyles($('div{}')).styleId).toEqualTypeOf<string>();
+      expectTypeOf(useStyles$('div{}').styleId).toEqualTypeOf<string>();
+      expectTypeOf(useStylesScoped('div{}').scopeId).toEqualTypeOf<string>();
+      expectTypeOf(useStylesScoped($('div{}')).scopeId).toEqualTypeOf<string>();
+      expectTypeOf(useStylesScoped$('div{}').scopeId).toEqualTypeOf<string>();
+
+      return null;
+    });
+  });
+});

--- a/packages/qwik/src/core/use/use-on.ts
+++ b/packages/qwik/src/core/use/use-on.ts
@@ -1,4 +1,5 @@
-import type { QRL } from '../shared/qrl/qrl.public';
+import { dollar, type QRL } from '../shared/qrl/qrl.public';
+import { isQrl } from '../shared/qrl/qrl-utils';
 import { useInvokeContext } from './use-core';
 import { type KnownEventNames } from '../shared/jsx/types/jsx-qwik-events';
 import type {
@@ -49,7 +50,7 @@ export type UseOnOptions = UseOnOptionsBase &
 // </docs>
 export const useOn = <T extends KnownEventNames>(
   event: T | T[],
-  eventQrl: EventQRL<T>,
+  eventQrl: EventQRL<T> | EventHandler<EventFromName<T>, Element>,
   options?: UseOnOptions
 ) => {
   _useOn(
@@ -93,7 +94,7 @@ export const useOn = <T extends KnownEventNames>(
 // </docs>
 export const useOnDocument = <T extends KnownEventNames>(
   event: T | T[],
-  eventQrl: EventQRL<T>,
+  eventQrl: EventQRL<T> | EventHandler<EventFromName<T>, Element>,
   options?: UseOnOptions
 ) => {
   _useOn(
@@ -138,7 +139,7 @@ export const useOnDocument = <T extends KnownEventNames>(
 // </docs>
 export const useOnWindow = <T extends KnownEventNames>(
   event: T | T[],
-  eventQrl: EventQRL<T>,
+  eventQrl: EventQRL<T> | EventHandler<EventFromName<T>, Element>,
   options?: UseOnOptions
 ) => {
   _useOn(
@@ -152,7 +153,7 @@ export const useOnWindow = <T extends KnownEventNames>(
 const _useOn = (
   prefix: EventNameHtmlScope,
   eventName: string | string[],
-  eventQrl: EventQRL,
+  eventQrl: EventQRL | EventHandler,
   options?: UseOnOptions
 ) => {
   const { isAdded, addEvent } = useOnEventsSequentialScope();
@@ -160,13 +161,14 @@ const _useOn = (
     return;
   }
   if (eventQrl) {
+    const qrl = (isQrl(eventQrl) ? eventQrl : dollar(eventQrl)) as EventQRL<KnownEventNames>;
     if (Array.isArray(eventName)) {
       for (let i = 0; i < eventName.length; i++) {
         const event = eventName[i];
-        addEvent(prefix + fromCamelToKebabCase(event), eventQrl, options);
+        addEvent(prefix + fromCamelToKebabCase(event), qrl, options);
       }
     } else {
-      addEvent(prefix + fromCamelToKebabCase(eventName), eventQrl, options);
+      addEvent(prefix + fromCamelToKebabCase(eventName), qrl, options);
     }
   }
 };

--- a/packages/qwik/src/core/use/use-on.unit.ts
+++ b/packages/qwik/src/core/use/use-on.unit.ts
@@ -20,9 +20,14 @@ describe('types', () => {
     expectTypeOf<QRL<typeof cb2>>().toExtend<EventQRL>();
 
     expectTypeOf<QRL<typeof cbAny>>().toExtend<EventQRL>();
+    expectTypeOf<typeof cb0>().toExtend<Parameters<typeof useOn>[1]>();
+    expectTypeOf<typeof cb1>().toExtend<Parameters<typeof useOn>[1]>();
+    expectTypeOf<typeof cb2>().toExtend<Parameters<typeof useOn>[1]>();
 
     expectTypeOf<QRL<typeof wrong1>>().not.toExtend<EventQRL>();
     expectTypeOf<QRL<typeof wrong2>>().not.toExtend<EventQRL>();
+    expectTypeOf<typeof wrong1>().not.toExtend<Parameters<typeof useOn>[1]>();
+    expectTypeOf<typeof wrong2>().not.toExtend<Parameters<typeof useOn>[1]>();
   });
 
   test('inferring', () => () => {
@@ -47,6 +52,10 @@ describe('types', () => {
         assertType<MouseEvent>(ev);
       })
     );
+    useOn('click', (ev) => {
+      expectTypeOf(ev).not.toBeAny();
+      assertType<MouseEvent>(ev);
+    });
     useOn(
       'copy',
       $((ev) => {

--- a/packages/qwik/src/core/use/use-resource.ts
+++ b/packages/qwik/src/core/use/use-resource.ts
@@ -11,8 +11,8 @@ import type { AsyncCtx } from '../reactive-primitives/types';
 import { StoreFlags } from '../reactive-primitives/types';
 import type { JSXOutput } from '../shared/jsx/types/jsx-node';
 import { createQRL } from '../shared/qrl/qrl-class';
-import { assertQrl } from '../shared/qrl/qrl-utils';
-import { type QRL } from '../shared/qrl/qrl.public';
+import { assertQrl, isQrl } from '../shared/qrl/qrl-utils';
+import { dollar, type QRL } from '../shared/qrl/qrl.public';
 import { isPromise } from '../shared/utils/promises';
 import { useSequentialScope } from './use-sequential-scope';
 
@@ -128,6 +128,14 @@ export const useResourceQrl = <T>(
 
   set(resource);
   return resource;
+};
+
+/** @public */
+export const useResource = <T>(
+  fn: ResourceFn<T> | QRL<ResourceFn<T>>,
+  opts?: ResourceOptions
+): ResourceReturn<T> => {
+  return useResourceQrl(isQrl(fn) ? (fn as QRL<ResourceFn<T>>) : dollar(fn as ResourceFn<T>), opts);
 };
 
 /** @public */

--- a/packages/qwik/src/core/use/use-serializer.ts
+++ b/packages/qwik/src/core/use/use-serializer.ts
@@ -1,7 +1,8 @@
 import { implicit$FirstArg } from '../shared/qrl/implicit_dollar';
-import type { QRL } from '../shared/qrl/qrl.public';
+import { dollar, type QRL } from '../shared/qrl/qrl.public';
+import { isQrl } from '../shared/qrl/qrl-utils';
 import type { SerializerArg } from '../reactive-primitives/types';
-import type { createSerializer$ } from '../reactive-primitives/signal.public';
+import type { createSerializer$, SerializerSignal } from '../reactive-primitives/signal.public';
 import { createSerializerSignal } from '../reactive-primitives/signal-api';
 import { useConstant } from './use-signal';
 
@@ -76,3 +77,11 @@ export const useSerializerQrl = <T, S>(qrl: QRL<SerializerArg<T, S>>) =>
  * @public
  */
 export const useSerializer$: typeof createSerializer$ = implicit$FirstArg(useSerializerQrl as any);
+
+/** @public */
+export const useSerializer = <T, S>(
+  arg: SerializerArg<T, S> | QRL<SerializerArg<T, S>>
+): T extends Promise<any> ? never : SerializerSignal<T> => {
+  const qrl = (isQrl(arg) ? arg : dollar(arg as SerializerArg<T, S>)) as QRL<SerializerArg<T, S>>;
+  return useSerializerQrl(qrl) as any;
+};

--- a/packages/qwik/src/core/use/use-styles.ts
+++ b/packages/qwik/src/core/use/use-styles.ts
@@ -1,9 +1,9 @@
-import { type QRL } from '../shared/qrl/qrl.public';
+import { dollar, type QRL } from '../shared/qrl/qrl.public';
 import { qTest } from '../shared/utils/qdev';
 import { implicit$FirstArg } from '../shared/qrl/implicit_dollar';
 import { getScopedStyles } from '../shared/utils/scoped-stylesheet';
 import { useSequentialScope } from './use-sequential-scope';
-import { assertQrl } from '../shared/qrl/qrl-utils';
+import { assertQrl, isQrl } from '../shared/qrl/qrl-utils';
 import { ComponentStylesPrefixContent } from '../shared/utils/markers';
 import { styleKey } from '../shared/utils/styles';
 import { isDev } from '@qwik.dev/core/build';
@@ -51,6 +51,11 @@ export const useStylesQrl = (styles: QRL<string>): UseStyles => {
 // </docs>
 export const useStyles$ = /*#__PURE__*/ implicit$FirstArg(useStylesQrl);
 
+/** @public */
+export const useStyles = (styles: string | QRL<string>): UseStyles => {
+  return useStylesQrl((isQrl(styles) ? styles : dollar(styles)) as QRL<string>);
+};
+
 /** @internal */
 export const useStylesScopedQrl = (styles: QRL<string>): UseStylesScoped => {
   return {
@@ -82,6 +87,11 @@ export const useStylesScopedQrl = (styles: QRL<string>): UseStylesScoped => {
  */
 // </docs>
 export const useStylesScoped$ = /*#__PURE__*/ implicit$FirstArg(useStylesScopedQrl);
+
+/** @public */
+export const useStylesScoped = (styles: string | QRL<string>): UseStylesScoped => {
+  return useStylesScopedQrl((isQrl(styles) ? styles : dollar(styles)) as QRL<string>);
+};
 
 const liveUpdate = isDev && ((import.meta.hot && typeof document !== 'undefined') || qTest);
 

--- a/packages/qwik/src/core/use/use-task.ts
+++ b/packages/qwik/src/core/use/use-task.ts
@@ -8,8 +8,8 @@ import {
   setCaptures,
   type QRLInternal,
 } from '../shared/qrl/qrl-class';
-import { assertQrl } from '../shared/qrl/qrl-utils';
-import type { QRL } from '../shared/qrl/qrl.public';
+import { assertQrl, isQrl } from '../shared/qrl/qrl-utils';
+import { dollar, type QRL } from '../shared/qrl/qrl.public';
 import { type Container, type HostElement } from '../shared/types';
 import { TaskEvent } from '../shared/utils/markers';
 import { isPromise, maybeThen, safeCall } from '../shared/utils/promises';
@@ -178,6 +178,11 @@ export const useTaskQrl = (qrl: QRL<TaskFn>, opts?: TaskOptions): void => {
   if (isPromise(result)) {
     iCtx.$waitOn$ = result;
   }
+};
+
+/** @public */
+export const useTask = (fn: TaskFn | QRL<TaskFn>, opts?: TaskOptions): void => {
+  useTaskQrl(isQrl(fn) ? (fn as QRL<TaskFn>) : dollar(fn as TaskFn), opts);
 };
 
 export const runTask = (

--- a/packages/qwik/src/core/use/use-task.unit.ts
+++ b/packages/qwik/src/core/use/use-task.unit.ts
@@ -1,12 +1,15 @@
 import { describe, expect, expectTypeOf, it, test, vi } from 'vitest';
 import { component$ } from '../shared/component.public';
+import { $ } from '../shared/qrl/qrl.public';
 import type { QRLInternal } from '../shared/qrl/qrl-class';
 import type { Container, HostElement } from '../shared/types';
+import { useResource } from './use-resource';
 import { useResource$ } from './use-resource-dollar';
 import { useSignal } from './use-signal';
 import { useStore } from './use-store.public';
-import { Task, TaskFlags, runTask } from './use-task';
+import { Task, TaskFlags, runTask, useTask } from './use-task';
 import { useTask$ } from './use-task-dollar';
+import { useVisibleTask } from './use-visible-task';
 import { useVisibleTask$ } from './use-visible-task-dollar';
 
 describe('types', () => {
@@ -20,12 +23,40 @@ describe('types', () => {
         expectTypeOf(track(() => sig.value)).toEqualTypeOf<number>();
         expectTypeOf(track(() => store.count)).toEqualTypeOf<number>();
       });
+      useResource(({ track }) => {
+        expectTypeOf(track(store)).toEqualTypeOf(store);
+        expectTypeOf(track(sig)).toEqualTypeOf<number>();
+        expectTypeOf(track(() => sig.value)).toEqualTypeOf<number>();
+        expectTypeOf(track(() => store.count)).toEqualTypeOf<number>();
+      });
+      useResource(
+        $(({ track }) => {
+          expectTypeOf(track(store)).toEqualTypeOf(store);
+          expectTypeOf(track(sig)).toEqualTypeOf<number>();
+          expectTypeOf(track(() => sig.value)).toEqualTypeOf<number>();
+          expectTypeOf(track(() => store.count)).toEqualTypeOf<number>();
+        })
+      );
       useTask$(({ track }) => {
         expectTypeOf(track(store)).toEqualTypeOf(store);
         expectTypeOf(track(sig)).toEqualTypeOf<number>();
         expectTypeOf(track(() => sig.value)).toEqualTypeOf<number>();
         expectTypeOf(track(() => store.count)).toEqualTypeOf<number>();
       });
+      useTask(({ track }) => {
+        expectTypeOf(track(store)).toEqualTypeOf(store);
+        expectTypeOf(track(sig)).toEqualTypeOf<number>();
+        expectTypeOf(track(() => sig.value)).toEqualTypeOf<number>();
+        expectTypeOf(track(() => store.count)).toEqualTypeOf<number>();
+      });
+      useTask(
+        $(({ track }) => {
+          expectTypeOf(track(store)).toEqualTypeOf(store);
+          expectTypeOf(track(sig)).toEqualTypeOf<number>();
+          expectTypeOf(track(() => sig.value)).toEqualTypeOf<number>();
+          expectTypeOf(track(() => store.count)).toEqualTypeOf<number>();
+        })
+      );
       return null;
     });
   });
@@ -40,6 +71,16 @@ describe('types', () => {
         cleanup(async () => {});
         return async () => {};
       });
+      useVisibleTask(async ({ cleanup }) => {
+        cleanup(async () => {});
+        return async () => {};
+      });
+      useVisibleTask(
+        $(async ({ cleanup }) => {
+          cleanup(async () => {});
+          return async () => {};
+        })
+      );
       return null;
     });
   });

--- a/packages/qwik/src/core/use/use-visible-task.ts
+++ b/packages/qwik/src/core/use/use-visible-task.ts
@@ -1,8 +1,8 @@
 import type { EventHandler } from '../shared/jsx/types/jsx-qwik-attributes';
 import { isServerPlatform } from '../shared/platform/platform';
 import { createQRL, type QRLInternal } from '../shared/qrl/qrl-class';
-import { assertQrl } from '../shared/qrl/qrl-utils';
-import type { QRL } from '../shared/qrl/qrl.public';
+import { assertQrl, isQrl } from '../shared/qrl/qrl-utils';
+import { dollar, type QRL } from '../shared/qrl/qrl.public';
 import { ChoreBits } from '../shared/vnode/enums/chore-bits.enum';
 import { markVNodeDirty } from '../shared/vnode/vnode-dirty';
 import { useOn, useOnDocument } from './use-on';
@@ -54,6 +54,11 @@ export const useVisibleTaskQrl = (qrl: QRL<TaskFn>, opts?: OnVisibleTaskOptions)
   const task = new Task(flags, i, iCtx.$hostElement$, qrl, undefined, null);
   set(task);
   useRegisterTaskEvents(task, eagerness);
+};
+
+/** @public */
+export const useVisibleTask = (fn: TaskFn | QRL<TaskFn>, opts?: OnVisibleTaskOptions): void => {
+  useVisibleTaskQrl(isQrl(fn) ? (fn as QRL<TaskFn>) : dollar(fn as TaskFn), opts);
 };
 
 export const useRegisterTaskEvents = (task: Task, eagerness: VisibleTaskStrategy | undefined) => {

--- a/packages/qwik/src/web-worker/index.ts
+++ b/packages/qwik/src/web-worker/index.ts
@@ -1,3 +1,10 @@
 /** @packageDocumentation */
 
-export { worker$, workerQrl, type WorkerConstructorQRL, type WorkerFunction } from './worker-qrl';
+export {
+  worker,
+  worker$,
+  workerQrl,
+  type WorkerConstructor,
+  type WorkerConstructorQRL,
+  type WorkerFunction,
+} from './worker-qrl';

--- a/packages/qwik/src/web-worker/qwik.worker.api.md
+++ b/packages/qwik/src/web-worker/qwik.worker.api.md
@@ -10,6 +10,15 @@ import { QRL } from '@qwik.dev/core';
 export const worker$: <T extends WorkerFunction>(qrl: T) => QRL<T>;
 
 // @public (undocumented)
+export const worker: WorkerConstructor;
+
+// @public (undocumented)
+export interface WorkerConstructor {
+    // (undocumented)
+    <T extends WorkerFunction>(fn: T | QRL<T>): QRL<T>;
+}
+
+// @public (undocumented)
 export interface WorkerConstructorQRL {
     // (undocumented)
     <T extends WorkerFunction>(fnQrl: QRL<T>): QRL<T>;

--- a/packages/qwik/src/web-worker/worker-qrl.ts
+++ b/packages/qwik/src/web-worker/worker-qrl.ts
@@ -13,6 +13,11 @@ export interface WorkerConstructorQRL {
 }
 
 /** @public */
+export interface WorkerConstructor {
+  <T extends WorkerFunction>(fn: T | QRL<T>): QRL<T>;
+}
+
+/** @public */
 export const workerQrl: WorkerConstructorQRL = (qrl) => {
   return $(async (...args: any[]) => {
     const filtered = sanitizeWorkerArgs(args);
@@ -27,3 +32,8 @@ export const workerQrl: WorkerConstructorQRL = (qrl) => {
 
 /** @public */
 export const worker$ = implicit$FirstArg(workerQrl);
+
+/** @public */
+export const worker: WorkerConstructor = <T extends WorkerFunction>(fn: T | QRL<T>) => {
+  return workerQrl(fn as QRL<T>);
+};

--- a/packages/qwik/src/web-worker/worker-qrl.unit.ts
+++ b/packages/qwik/src/web-worker/worker-qrl.unit.ts
@@ -1,6 +1,6 @@
 import { sync$ } from '@qwik.dev/core';
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { workerQrl } from './worker-qrl';
+import { afterEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
+import { worker, worker$, workerQrl } from './worker-qrl';
 import { __clearWorkerRuntimeCache } from './worker-runtime-shared';
 
 const nodeWorkerThreads = vi.hoisted(() => ({
@@ -28,6 +28,18 @@ describe('workerQrl', () => {
     nodeWorkerThreads.Worker.mockReset();
     nodeWorkerThreads.fs.existsSync.mockReset();
     vi.unstubAllGlobals();
+  });
+
+  it('worker accepts plain functions and QRLs', () => () => {
+    const plain = worker((count: number) => count + 1);
+    const qrl = worker(sync$((count: number) => count + 1));
+    const legacy = worker$((count: number) => count + 1);
+    const qrlOnly = workerQrl(sync$((count: number) => count + 1));
+
+    expectTypeOf(plain(1)).toEqualTypeOf<Promise<number>>();
+    expectTypeOf(qrl(1)).toEqualTypeOf<Promise<number>>();
+    expectTypeOf(legacy(1)).toEqualTypeOf<Promise<number>>();
+    expectTypeOf(qrlOnly(1)).toEqualTypeOf<Promise<number>>();
   });
 
   it('falls back to direct invocation when Worker is unavailable', async () => {


### PR DESCRIPTION
## Why

This adds markerless API entry points so users can write the major callback APIs without the QRL suffix or JSX event marker, while existing QRL-based usage continues to work.

The design is intentionally compatibility-first: these new APIs accept already-created QRLs as well as plain functions. That gives us the runtime/type surface needed for the markerless AI inferred compiler approach, where a future compiler pass can auto-inject QRL wrappers before the Qwik optimizer runs.

## What changed

- Add non-QRL aliases such as `component()`, `useTask()`, `useComputed()`, `useResource()`, `useSerializer()`, `useStyles()`, `useVisibleTask()`, and related callback APIs.
- Add no-dollar JSX event typings and optimizer support so `onClick` can lower like `onClick$` when a QRL is supplied.
- Keep existing QRL APIs working unchanged.
- Add tests, including an E2E case for `onClick={$(() => {})}`, proving the compiler-backed path works.

## Testing

- `pnpm build.full`
- `pnpm vitest run packages/qwik/src/core/shared/jsx/types/jsx-types.unit.tsx packages/qwik/src/core/shared/utils/event-names.unit.ts packages/qwik/src/core/use/use-computed.unit.ts packages/qwik/src/core/use/use-task.unit.ts packages/qwik-router/src/runtime/src/use-functions.unit.ts packages/qwik-react/src/react/qwik-react-aliases.unit.tsx`
- `pnpm playwright test e2e/qwik-e2e/tests/events.e2e.ts -g "qrl handler passed to no-dollar event" --browser=chromium --config e2e/qwik-e2e/playwright.config.ts --workers=1 --max-failures=1`
- `INSTA_UPDATE=always cargo test --lib`
- `cargo test example_2 -- --nocapture`
