### PR TITLE
docs: blog images loading as lazy

### DIFF
--- a/packages/docs/src/routes/(blog)/blog/(articles)/fontless/index.mdx
+++ b/packages/docs/src/routes/(blog)/blog/(articles)/fontless/index.mdx
@@ -8,7 +8,7 @@ canonical: 'https://qwik.dev/blog/fontless'
 ---
 
 import { ArticleBlock } from '~/routes/(blog)/blog/components/mdx/article-block';
-import { Image } from 'qwik-image';
+import { Image } from '~/routes/(blog)/blog/components/blog-image';
 import firstMeeting from './first-meeting.webp';
 import secondMeeting from './second-meeting.webp';
 

--- a/packages/docs/src/routes/(blog)/blog/(articles)/qwik-1-14-preloader/index.mdx
+++ b/packages/docs/src/routes/(blog)/blog/(articles)/qwik-1-14-preloader/index.mdx
@@ -11,7 +11,7 @@ canonical: 'https://qwik.dev/blog/qwik-1-14-preloader'
 
 import { ArticleBlock } from '~/routes/(blog)/blog/components/mdx/article-block';
 import { DiscordLink } from '~/routes/(blog)/blog/components/mdx/discord-link';
-import { Image } from 'qwik-image';
+import { Image } from '~/routes/(blog)/blog/components/blog-image';
 import CodeSandbox from '~/components/code-sandbox/index.tsx';
 import serviceWorkerDelayDemo from './service-worker-delay-demo-crop.webm';
 import modulepreloadNoDelayDemo from './modulepreload-no-delay-demo-crop.webm';

--- a/packages/docs/src/routes/(blog)/blog/components/articles-grid.tsx
+++ b/packages/docs/src/routes/(blog)/blog/components/articles-grid.tsx
@@ -17,6 +17,7 @@ export const ArticlesGrid = component$(() => {
             <div class="relative h-48 overflow-hidden">
               <Image
                 layout="constrained"
+                loading="lazy"
                 class="w-full h-full object-cover transform group-hover:scale-105 transition-transform duration-500"
                 src={post.image}
                 alt={post.title}

--- a/packages/docs/src/routes/(blog)/blog/components/blog-image.tsx
+++ b/packages/docs/src/routes/(blog)/blog/components/blog-image.tsx
@@ -1,0 +1,10 @@
+import { component$ } from '@qwik.dev/core';
+import { Image as QwikImage, type ImageProps } from 'qwik-image';
+
+/**
+ * Blog body image. Lazy-loads by default so below-the-fold images don't compete with the hero (LCP)
+ * for bandwidth. Pass `loading="eager"` to override for any image that is above the fold.
+ */
+export const Image = component$<ImageProps>((props) => {
+  return <QwikImage loading="lazy" {...props} />;
+});

--- a/packages/docs/src/routes/(blog)/blog/components/featured-article.tsx
+++ b/packages/docs/src/routes/(blog)/blog/components/featured-article.tsx
@@ -13,6 +13,8 @@ export const FeaturedArticle = component$(() => {
           <Image
             layout="fullWidth"
             objectFit="fill"
+            loading="eager"
+            fetchpriority="high"
             class="transform group-hover:scale-105 transition-transform duration-500"
             src={blogArticles[0].image}
             alt={blogArticles[0].title}

--- a/packages/docs/src/routes/(blog)/blog/components/mdx/article-hero.tsx
+++ b/packages/docs/src/routes/(blog)/blog/components/mdx/article-hero.tsx
@@ -62,7 +62,7 @@ export const ArticleHero = component$<Props>(({ image, authorLinks }) => {
         </div>
       </div>
       <div class="relative max-w-[1280px] pb-4">
-        <Image alt={title} src={image} layout="fullWidth" />
+        <Image alt={title} src={image} layout="fullWidth" loading="eager" fetchpriority="high" />
       </div>
     </>
   );


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Feature / enhancement
- Bug
- Docs / tests / types / typos
- Infra

# Description

Too many images at once on 3G means the bandwidth is cluttered.

Maybe worth fixing upstream in qwik-image.

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [ ] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [ ] I performed a self-review of my own code
- [ ] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
