### PR TITLE
fix(qwik-router): never cache loader error/redirect envelopes

### DIFF
--- a/.changeset/loader-envelope-no-cache.md
+++ b/.changeset/loader-envelope-no-cache.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+Loader error and redirect envelopes are no longer sent with a `Cache-Control: max-age` header — only successful data envelopes are cacheable.

--- a/packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.ts
+++ b/packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.ts
@@ -109,7 +109,7 @@ export function loaderHandler(
       return;
     }
 
-    await sendLoaderResponse(requestEv, data, loader);
+    await sendLoaderResponse(requestEv, data, loader, !responseData.r && !responseData.e);
   };
 }
 
@@ -139,11 +139,12 @@ function resolvePreETag(
 async function sendLoaderResponse(
   requestEv: RequestEventInternal,
   data: string,
-  loader?: LoaderInternal
+  loader?: LoaderInternal,
+  cacheable = true
 ) {
   requestEv.headers.set('Content-Type', 'application/json; charset=utf-8');
   addVaryHeader(requestEv, FULLPATH_HEADER);
-  if (loader?.__expires && loader.__expires > 0) {
+  if (cacheable && loader?.__expires && loader.__expires > 0) {
     requestEv.cacheControl({ maxAge: Math.ceil(loader.__expires / 1000) });
   }
   requestEv.send(200, data);


### PR DESCRIPTION
# What is it?

- Bug

# Description

`sendLoaderResponse` applied the loader's `expires` max-age to every envelope, so error and redirect responses were cacheable. Only successful data envelopes get the header now.