### PR TITLE
fix(core): _restProps falls back to plain-object copy for non-props inputs

### DIFF
--- a/.changeset/core-restprops-plain-object.md
+++ b/.changeset/core-restprops-plain-object.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+`_restProps` now handles plain objects: rest destructuring compiled to it no longer returns an empty object, fixing silent data loss in route loaders and other non-props contexts.

--- a/packages/qwik/src/core/shared/utils/prop.ts
+++ b/packages/qwik/src/core/shared/utils/prop.ts
@@ -17,6 +17,15 @@ export function isSlotProp(prop: string): boolean {
 
 /** @internal */
 export const _restProps = (props: PropsProxy, omit: string[] = [], target: Props = {}) => {
+  if (props[_VAR_PROPS] === undefined && props[_CONST_PROPS] === undefined) {
+    // not a props proxy, so behave like a native rest destructure
+    for (const key in props) {
+      if (!omit.includes(key) && _hasOwnProperty.call(props, key)) {
+        target[key] = props[key];
+      }
+    }
+    return target;
+  }
   let constPropsTarget: Props | null = null;
   const constProps = props[_CONST_PROPS];
   if (constProps) {

--- a/packages/qwik/src/core/shared/utils/prop.unit.ts
+++ b/packages/qwik/src/core/shared/utils/prop.unit.ts
@@ -1,0 +1,27 @@
+import { assert, suite, test } from 'vitest';
+import { isPropsProxy, type PropsProxy } from '../jsx/props-proxy';
+import { _restProps } from './prop';
+
+const plainProps = (props: Record<string, unknown>) => props as unknown as PropsProxy;
+
+suite('_restProps', () => {
+  test('should copy the own keys of a plain object', () => {
+    assert.deepEqual(_restProps(plainProps({ a: 1, b: 2, c: 3 }), ['a']), { b: 2, c: 3 });
+  });
+
+  test('should copy every key of a plain object when nothing is omitted', () => {
+    assert.deepEqual(_restProps(plainProps({ a: 1, b: 2 })), { a: 1, b: 2 });
+  });
+
+  test('should return a plain object for a plain object', () => {
+    const rest = _restProps(plainProps({ a: 1, b: 2 }), ['a']);
+    assert.isFalse(isPropsProxy(rest));
+    assert.deepEqual(Object.keys(rest), ['b']);
+  });
+
+  test('should write into the given target for a plain object', () => {
+    const target = { existing: true };
+    assert.strictEqual(_restProps(plainProps({ a: 1, b: 2 }), ['a'], target), target);
+    assert.deepEqual(target, { existing: true, b: 2 });
+  });
+});


### PR DESCRIPTION
Fixes #8894

## Problem

The optimizer emits `_restProps` for **any** rest destructure it hoists into a QRL segment, not just component prop destructures. A `routeLoader$` such as:

```ts
export const useThing = routeLoader$(async () => {
  const { secret, ...rest } = await fetchThing();
  return rest;
});
```

is compiled to `_restProps(await fetchThing(), ["secret"])` (visible in the SSR transform output of the repro below).

But `_restProps` only knew how to read the `_VAR_PROPS` / `_CONST_PROPS` symbols, which exist solely on component props proxies. Given a plain object neither symbol is present, both loops iterate nothing, and the helper returns an **empty** props proxy. The rest object silently loses every key — no error, no warning, just missing data in the loader payload.

## Fix

`_restProps` now detects a non-props input (both `_VAR_PROPS` and `_CONST_PROPS` are `undefined`) and falls back to native rest-destructure semantics: copy the input's own enumerable keys, minus the omit list, into `target` and return `target` itself — a plain object, not a props proxy.

The existing props-proxy path is untouched, so there is **no behavior change for component props**.

## Repro

Minimal reproduction: https://github.com/blakeley/restprops-plain-object-empty

## Tests

Added `packages/qwik/src/core/shared/utils/prop.unit.ts` with four cases, all of which fail on `main` and pass with the fix:

- plain object `{a:1,b:2,c:3}` with omit `["a"]` → `{b:2,c:3}`
- plain object with an empty omit list → every key copied
- the result for a plain object is a plain object, not a props proxy
- the provided `target` is written into and returned

The full `packages/qwik/src/core` vitest suite is green (2057 passed).