### PR TITLE
fix(qwik-router): use z.ZodType instead of removed z.Schema for zod 4 compatibility

### DIFF
--- a/.changeset/router-zod-zodtype.md
+++ b/.changeset/router-zod-zodtype.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+`zod$` now detects schemas via `z.ZodType` instead of the zod-3-only `z.Schema` alias, fixing a server-side TypeError (and 500s on every zod$ action) when the router resolves zod 4 in hoisted installs.

--- a/packages/docs/src/routes/api/qwik-router/api.json
+++ b/packages/docs/src/routes/api/qwik-router/api.json
@@ -1342,7 +1342,7 @@
         }
       ],
       "kind": "TypeAlias",
-      "content": "```typescript\nexport type ZodConstructor = {\n    <T extends z.ZodRawShape>(schema: T): ZodDataValidator<z.ZodObject<T>>;\n    <T extends z.ZodRawShape>(schema: (zod: typeof z.z, ev: RequestEvent) => T): ZodDataValidator<z.ZodObject<T>>;\n    <T extends z.Schema>(schema: T): ZodDataValidator<T>;\n    <T extends z.Schema>(schema: (zod: typeof z.z, ev: RequestEvent) => T): ZodDataValidator<T>;\n};\n```",
+      "content": "```typescript\nexport type ZodConstructor = {\n    <T extends z.ZodRawShape>(schema: T): ZodDataValidator<z.ZodObject<T>>;\n    <T extends z.ZodRawShape>(schema: (zod: typeof z.z, ev: RequestEvent) => T): ZodDataValidator<z.ZodObject<T>>;\n    <T extends z.ZodType>(schema: T): ZodDataValidator<T>;\n    <T extends z.ZodType>(schema: (zod: typeof z.z, ev: RequestEvent) => T): ZodDataValidator<T>;\n};\n```",
       "editUrl": "https://github.com/QwikDev/qwik/tree/main/packages/qwik-router/src/runtime/src/types.ts",
       "mdFile": "router.zodconstructor.md"
     }

--- a/packages/docs/src/routes/api/qwik-router/index.mdx
+++ b/packages/docs/src/routes/api/qwik-router/index.mdx
@@ -3144,8 +3144,8 @@ export type ZodConstructor = {
   <T extends z.ZodRawShape>(
     schema: (zod: typeof z.z, ev: RequestEvent) => T,
   ): ZodDataValidator<z.ZodObject<T>>;
-  <T extends z.Schema>(schema: T): ZodDataValidator<T>;
-  <T extends z.Schema>(
+  <T extends z.ZodType>(schema: T): ZodDataValidator<T>;
+  <T extends z.ZodType>(
     schema: (zod: typeof z.z, ev: RequestEvent) => T,
   ): ZodDataValidator<T>;
 };

--- a/packages/qwik-router/src/runtime/src/qwik-router.runtime.api.md
+++ b/packages/qwik-router/src/runtime/src/qwik-router.runtime.api.md
@@ -679,8 +679,8 @@ export const zod$: ZodConstructor;
 export type ZodConstructor = {
     <T extends z_2.ZodRawShape>(schema: T): ZodDataValidator<z_2.ZodObject<T>>;
     <T extends z_2.ZodRawShape>(schema: (zod: typeof z_2.z, ev: RequestEvent) => T): ZodDataValidator<z_2.ZodObject<T>>;
-    <T extends z_2.Schema>(schema: T): ZodDataValidator<T>;
-    <T extends z_2.Schema>(schema: (zod: typeof z_2.z, ev: RequestEvent) => T): ZodDataValidator<T>;
+    <T extends z_2.ZodType>(schema: T): ZodDataValidator<T>;
+    <T extends z_2.ZodType>(schema: (zod: typeof z_2.z, ev: RequestEvent) => T): ZodDataValidator<T>;
 };
 
 // Warning: (ae-forgotten-export) The symbol "ZodConstructorQRL" needs to be exported by the entry point index.d.ts

--- a/packages/qwik-router/src/runtime/src/server-functions.ts
+++ b/packages/qwik-router/src/runtime/src/server-functions.ts
@@ -310,18 +310,18 @@ const flattenZodIssues = (issues: z.ZodIssue | z.ZodIssue[]) => {
 /** @internal */
 export const zodQrl: ZodConstructorQRL = (
   qrl: QRL<
-    z.ZodRawShape | z.Schema | ((z: typeof import('zod').z, ev: RequestEvent) => z.ZodRawShape)
+    z.ZodRawShape | z.ZodType | ((z: typeof import('zod').z, ev: RequestEvent) => z.ZodRawShape)
   >
 ): ZodDataValidator => {
   if (isServer) {
     return {
       __brand: 'zod',
       async validate(ev, inputData) {
-        const schema: z.Schema = await qrl.resolve().then((obj) => {
+        const schema: z.ZodType = await qrl.resolve().then((obj) => {
           if (typeof obj === 'function') {
             obj = obj(z, ev);
           }
-          if (obj instanceof z.Schema) {
+          if (obj instanceof z.ZodType) {
             return obj;
           } else {
             return z.object(obj);

--- a/packages/qwik-router/src/runtime/src/types.ts
+++ b/packages/qwik-router/src/runtime/src/types.ts
@@ -1129,8 +1129,8 @@ export type ZodConstructor = {
   <T extends z.ZodRawShape>(
     schema: (zod: typeof z.z, ev: RequestEvent) => T
   ): ZodDataValidator<z.ZodObject<T>>;
-  <T extends z.Schema>(schema: T): ZodDataValidator<T>;
-  <T extends z.Schema>(schema: (zod: typeof z.z, ev: RequestEvent) => T): ZodDataValidator<T>;
+  <T extends z.ZodType>(schema: T): ZodDataValidator<T>;
+  <T extends z.ZodType>(schema: (zod: typeof z.z, ev: RequestEvent) => T): ZodDataValidator<T>;
 };
 
 /** @public */
@@ -1139,8 +1139,8 @@ export type ZodConstructorQRL = {
   <T extends z.ZodRawShape>(
     schema: QRL<(zod: typeof z.z, ev: RequestEvent) => T>
   ): ZodDataValidator<z.ZodObject<T>>;
-  <T extends z.Schema>(schema: QRL<T>): ZodDataValidator<T>;
-  <T extends z.Schema>(schema: QRL<(zod: typeof z.z, ev: RequestEvent) => T>): ZodDataValidator<T>;
+  <T extends z.ZodType>(schema: QRL<T>): ZodDataValidator<T>;
+  <T extends z.ZodType>(schema: QRL<(zod: typeof z.z, ev: RequestEvent) => T>): ZodDataValidator<T>;
 };
 
 /** @public */


### PR DESCRIPTION
Fixes #8896

`zodQrl` decided whether a resolved value was already a schema with `obj instanceof z.Schema`. `Schema` was a zod-3-only alias for `ZodType` and was removed in zod 4, so as soon as the router's `zod` specifier resolves to a v4 copy — which is what happens in hoisted/deduped installs where the app depends on zod 4 — `z.Schema` is `undefined` and the `instanceof` throws `TypeError: Right-hand side of 'instanceof' is not callable` on the server, turning every `zod$` action into a 500. This is not a version-mixing problem: the schema object and the `instanceof` check come from the same resolved zod module, the alias simply no longer exists. `z.ZodType` is exported by both zod 3 and zod 4 (in v3 `Schema` was literally an alias of it), so switching the runtime check — and the matching `z.Schema` type positions in `ZodConstructor` / `ZodConstructorQRL` — to `z.ZodType` is behaviour-preserving against the repo's pinned zod 3 and correct against zod 4. The API report and generated docs were regenerated with `pnpm api.update`; the only change there is `z_2.Schema` → `z_2.ZodType`.

Minimal reproduction: https://github.com/blakeley/zod4-zodschema-crash — it 500s on the pinned router build and passes with this patch applied, so the fix is verified empirically and not just by inspection.

Relationship to #8887 (zod export tree-shaking): orthogonal. That PR changes how zod is imported/re-exported for bundle size and keeps `z.Schema` as the detection mechanism, so it does not address this crash; the two should merge cleanly in either order, and if #8887 lands first the `z.Schema` reference it preserves still needs this change.