### PR TITLE
fix(qwik-vite): keep reachable deps when reducing cyclic bundle graphs

### DIFF
--- a/.changeset/bundle-graph-cyclic-deps.md
+++ b/.changeset/bundle-graph-cyclic-deps.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: bundle-graph no longer drops reachable dependencies while it gets optimized to avoid transitive duplicates.

--- a/packages/qwik-vite/src/manifest.ts
+++ b/packages/qwik-vite/src/manifest.ts
@@ -1,5 +1,6 @@
 import type { Rollup } from 'vite';
 import { type NormalizedQwikPluginOptions } from './plugins/plugin';
+import { condenseImportGraph } from './plugins/bundle-graph';
 import type { GlobalInjections, Path, QwikBundle, QwikManifest, SegmentAnalysis } from './types';
 
 // The handlers that are exported by the core package
@@ -291,76 +292,9 @@ const getBundleInteractivity = (bundle: QwikBundle, manifest: QwikManifest) => {
  * harder than you think to total nodes in a directed cyclic graph
  */
 export function computeTotals(graph: QwikManifest['bundles']): void {
-  // 1) Prepare Tarjan's structures
-  let index = 0;
-  const stack: string[] = [];
-  const sccList: string[][] = [];
+  const { components: sccList, successors: sccDAG } = condenseImportGraph(graph);
 
-  // Maps for Tarjan
-  const idx = new Map<string, number>(); // node -> index
-  const low = new Map<string, number>(); // node -> low-link
-  const onStack = new Set<string>();
-
-  function strongConnect(v: string) {
-    idx.set(v, index);
-    low.set(v, index);
-    index++;
-    stack.push(v);
-    onStack.add(v);
-
-    // Explore children
-    const children = graph[v].imports || [];
-    for (const w of children) {
-      if (!idx.has(w)) {
-        strongConnect(w);
-        low.set(v, Math.min(low.get(v)!, low.get(w)!));
-      } else if (onStack.has(w)) {
-        low.set(v, Math.min(low.get(v)!, idx.get(w)!));
-      }
-    }
-
-    // If v is a root node, pop stack to form an SCC
-    if (low.get(v) === idx.get(v)) {
-      const comp: string[] = [];
-      let x: string;
-      do {
-        x = stack.pop()!;
-        onStack.delete(x);
-        comp.push(x);
-      } while (x !== v);
-      sccList.push(comp);
-    }
-  }
-
-  // Run Tarjan over all nodes
-  for (const v of Object.keys(graph)) {
-    if (!idx.has(v)) {
-      strongConnect(v);
-    }
-  }
-
-  // 2) Build DAG of SCCs
-  // sccIndex: which SCC a node belongs to
-  const sccIndex = new Map<string, number>();
-  sccList.forEach((comp, i) => {
-    for (const v of comp) {
-      sccIndex.set(v, i);
-    }
-  });
-
-  // Create adjacency for the SCC graph
-  const sccDAG: Set<number>[] = Array.from({ length: sccList.length }, () => new Set());
-  for (const v of Object.keys(graph)) {
-    const i = sccIndex.get(v)!;
-    for (const w of graph[v].imports || []) {
-      const j = sccIndex.get(w)!;
-      if (i !== j) {
-        sccDAG[i].add(j);
-      }
-    }
-  }
-
-  // 3) Topological sort the SCC DAG
+  // 1) Topological sort the SCC DAG
   const visited = new Set<number>();
   const order: number[] = [];
 
@@ -381,7 +315,7 @@ export function computeTotals(graph: QwikManifest['bundles']): void {
   }
   order.reverse(); // Now it's a topological order
 
-  // 4) Compute totals from bottom to top
+  // 2) Compute totals from bottom to top
   const sccTotals = new Array<number>(sccList.length).fill(0);
 
   // First compute the sum of 'size' in each SCC
@@ -403,7 +337,7 @@ export function computeTotals(graph: QwikManifest['bundles']): void {
     sccTotals[sccId] = total;
   }
 
-  // 5) Assign computed totals back to each node in the original graph
+  // 3) Assign computed totals back to each node in the original graph
   for (let i = 0; i < sccList.length; i++) {
     const total = sccTotals[i];
     for (const nodeId of sccList[i]) {

--- a/packages/qwik-vite/src/plugins/bundle-graph.ts
+++ b/packages/qwik-vite/src/plugins/bundle-graph.ts
@@ -115,22 +115,7 @@ export function convertManifestToBundleGraph(
 
   const names = Object.keys(graph);
   const map = new Map<string, { index: number; deps: Set<string> }>();
-  const clearTransitiveDeps = (
-    parentDeps: Set<string>,
-    bundleName: string,
-    seen: Set<string> = new Set()
-  ) => {
-    const bundle = graph[bundleName];
-    for (const dep of bundle.imports!) {
-      if (parentDeps.has(dep)) {
-        parentDeps.delete(dep);
-      }
-      if (!seen.has(dep)) {
-        seen.add(dep);
-        clearTransitiveDeps(parentDeps, dep, seen);
-      }
-    }
-  };
+  const reduceDeps = createTransitiveReducer(graph);
 
   /**
    * First pass to collect minimal dependency lists and allocate space for dependencies. Minimal
@@ -141,13 +126,11 @@ export function convertManifestToBundleGraph(
     const bundle = graph[bundleName];
     // external dependencies are not included in `graph`
     const deps = new Set(bundle.imports!);
-    for (const depName of deps) {
-      clearTransitiveDeps(deps, depName);
-    }
+    reduceDeps(deps, bundleName);
     const dynDeps = new Set(bundle.dynamicImports!);
+    reduceDeps(dynDeps, bundleName);
     const depProbability = new Map<string, number>();
     for (const depName of dynDeps) {
-      clearTransitiveDeps(dynDeps, depName);
       const dep = graph[depName];
 
       // Calculate the probability of the dependency
@@ -221,4 +204,114 @@ export function convertManifestToBundleGraph(
   }
 
   return bundleGraph;
+}
+
+/** Builds a reachability-preserving transitive reducer over the static-import graph. */
+function createTransitiveReducer(graph: Record<string, QwikBundle>) {
+  const { componentOf, successors } = condenseImportGraph(graph);
+
+  const reachCache: (Set<number> | undefined)[] = new Array(successors.length);
+  const reachOf = (component: number): Set<number> => {
+    const cached = reachCache[component];
+    if (cached) {
+      return cached;
+    }
+    const reach = new Set<number>();
+    reachCache[component] = reach;
+    for (const next of successors[component]) {
+      reach.add(next);
+      for (const beyond of reachOf(next)) {
+        reach.add(beyond);
+      }
+    }
+    return reach;
+  };
+
+  return (ownerDeps: Set<string>, ownerBundle: string) => {
+    const owner = componentOf.get(ownerBundle)!;
+    const targetComponents = new Set<number>();
+    for (const dep of ownerDeps) {
+      const component = componentOf.get(dep)!;
+      if (component !== owner) {
+        targetComponents.add(component);
+      }
+    }
+    for (const dep of [...ownerDeps]) {
+      const component = componentOf.get(dep)!;
+      if (component === owner) {
+        continue;
+      }
+      for (const sibling of targetComponents) {
+        if (sibling !== component && reachOf(sibling).has(component)) {
+          ownerDeps.delete(dep);
+          break;
+        }
+      }
+    }
+  };
+}
+
+export interface CondensedGraph {
+  componentOf: Map<string, number>;
+  components: string[][];
+  successors: Set<number>[];
+}
+
+export function condenseImportGraph(graph: Record<string, QwikBundle>): CondensedGraph {
+  const componentOf = new Map<string, number>();
+  const index = new Map<string, number>();
+  const lowLink = new Map<string, number>();
+  const onStack = new Set<string>();
+  const stack: string[] = [];
+  const components: string[][] = [];
+  let counter = 0;
+
+  const strongConnect = (node: string) => {
+    index.set(node, counter);
+    lowLink.set(node, counter);
+    counter++;
+    stack.push(node);
+    onStack.add(node);
+    for (const next of graph[node].imports || []) {
+      if (!graph[next]) {
+        continue;
+      }
+      if (!index.has(next)) {
+        strongConnect(next);
+        lowLink.set(node, Math.min(lowLink.get(node)!, lowLink.get(next)!));
+      } else if (onStack.has(next)) {
+        lowLink.set(node, Math.min(lowLink.get(node)!, index.get(next)!));
+      }
+    }
+    if (lowLink.get(node) === index.get(node)) {
+      const component: string[] = [];
+      let member: string;
+      do {
+        member = stack.pop()!;
+        onStack.delete(member);
+        componentOf.set(member, components.length);
+        component.push(member);
+      } while (member !== node);
+      components.push(component);
+    }
+  };
+
+  for (const node of Object.keys(graph)) {
+    if (!index.has(node)) {
+      strongConnect(node);
+    }
+  }
+
+  const successors: Set<number>[] = Array.from({ length: components.length }, () => new Set());
+  for (const node of Object.keys(graph)) {
+    const from = componentOf.get(node)!;
+    for (const next of graph[node].imports || []) {
+      const to = componentOf.get(next);
+      if (to !== undefined && to !== from) {
+        successors[from].add(to);
+      }
+    }
+  }
+
+  return { componentOf, components, successors };
 }

--- a/packages/qwik-vite/src/plugins/bundle-graph.unit.ts
+++ b/packages/qwik-vite/src/plugins/bundle-graph.unit.ts
@@ -103,6 +103,48 @@ describe('convertManifestToBundleGraph', () => {
     ]);
   });
 
+  test('import cycle through the reduced bundle keeps reachable deps', () => {
+    const manifest = {
+      bundles: {
+        'x.js': { size, total, imports: ['a.js', 'd.js'] },
+        'a.js': { size, total, imports: ['x.js'] },
+        'd.js': { size, total },
+      } as Record<string, QwikBundle>,
+      mapping: {},
+    } as QwikManifest;
+    expect(convertManifestToBundleGraph(manifest)).toEqual([
+      'x.js', // 0
+      3,
+      5,
+      'a.js', // 3
+      0,
+      'd.js', // 5
+    ]);
+  });
+
+  test('import cycle keeps dynamic deps but still reduces them', () => {
+    const manifest = {
+      bundles: {
+        'x.js': { size, total, imports: ['a.js'], dynamicImports: ['a.js', 'd.js', 'e.js'] },
+        'a.js': { size, total, imports: ['x.js'], symbols: ['sym1'] },
+        'd.js': { size, total, symbols: ['sym2'] },
+        'e.js': { size, total, imports: ['d.js'], symbols: ['sym3'] },
+      } as Record<string, QwikBundle>,
+      mapping: {},
+    } as QwikManifest;
+    expect(convertManifestToBundleGraph(manifest)).toEqual([
+      'x.js', // 0
+      4,
+      -7,
+      7,
+      'a.js', // 4
+      0,
+      'd.js', // 6
+      'e.js', // 7
+      6,
+    ]);
+  });
+
   test('adder', () => {
     expect(
       convertManifestToBundleGraph(


### PR DESCRIPTION
# What is it?

- Bug

# Description

When a bundle's imports form a cycle, the preload graph dropped deps it should have kept. The old
reduction walked out from each dep, came back around the cycle, and deleted that dep from its own
parent's set — so cyclic bundles could end up with an empty dep list and never get preloaded.

Reducing over the SCC condensation instead makes it a DAG problem, and intra-component deps are
always kept so each cycle stays connected. Output is unchanged for acyclic graphs (the existing
snapshot doesn't move).

Both new tests fail on `main` and pass here. Split out of #8785 so it can land on its own.
