### PR TITLE
fix(qwik): emit valid @__PURE__ annotations from the minified dist build

### DIFF
--- a/.changeset/dist-pure-annotations.md
+++ b/.changeset/dist-pure-annotations.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: the minified build now emits valid `@__PURE__` annotations so downstream bundlers can tree-shake it

--- a/scripts/submodule-core.ts
+++ b/scripts/submodule-core.ts
@@ -18,6 +18,13 @@ import {
  */
 export const MANGLE_PROPS_REGEX = '^\\$.+\\$$';
 
+/** Terser strands these annotations, so bundlers silently drop the tree-shaking hint. */
+function fixPureAnnotations(code: string): string {
+  return code
+    .replace(/\/\*\s*[@#]__PURE__\s*\*\/\s*return\s+/g, 'return /* @__PURE__ */ ')
+    .replace(/\/\*\s*[@#]__PURE__\s*\*\/(\s*)(?=[^\sA-Za-z_$(])/g, '$1');
+}
+
 /**
  * Build the core package which is also the root package: @qwik.dev/core
  *
@@ -158,7 +165,7 @@ async function submoduleCoreProd(config: BuildConfig): Promise<object | undefine
             },
           });
           const esmMinCode = esmMinifyResult.code!;
-          const esmCleanCode = esmMinCode.replace(/__self__/g, '__SELF__');
+          const esmCleanCode = fixPureAnnotations(esmMinCode.replace(/__self__/g, '__SELF__'));
           validateNoBareExperimentalReferences(esmCleanCode, 'core.min.mjs');
 
           const selfIdx = esmCleanCode.indexOf('self');
@@ -311,7 +318,7 @@ async function submoduleCoreProduction(
     },
     mangle,
   });
-  code = result.code!;
+  code = fixPureAnnotations(result.code!);
   validateNoBareExperimentalReferences(code, 'core.prod.mjs');
 
   await writeFile(outPath, code + '\n');


### PR DESCRIPTION
# What is it?

- Bug

# Description

Terser moves some `__PURE__` annotations away from the call they belong to, so bundlers can't
attach them and silently drop the hint. Bundling our dist with rolldown reports 6
`INVALID_ANNOTATION` today and 0 after this change, which means apps get the tree-shaking those
annotations were supposed to buy. Same approach as #8379: keep terser and repair the two patterns
it strands — an annotation hoisted in front of a `return`, and one left in front of a `"" + fn`
concatenation after terser rewrites `fn.toString()`. Widened to match both the `@` and `#`
spellings, since terser emits both. No size change; output is byte-for-byte main plus the repair.

Split out of #8785 so it can land on its own.
