### PR TITLE
feat(router): loader errors settle into the signal .error channel

### DIFF
--- a/.changeset/loader-errors-settle.md
+++ b/.changeset/loader-errors-settle.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': minor
+---
+
+feat: a plain `throw new Error` in a loader settles the loader's `.error` instead of failing the response; `error()`/`ServerError` and redirects still abort, and loader error envelopes are never HTTP-cached

--- a/.changeset/stale-value-on-error.md
+++ b/.changeset/stale-value-on-error.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': minor
+---
+
+feat: an errored async signal keeps its stale value — `.value` returns it alongside `.error`, and throws only when no value ever settled; a resumed errored signal is settled instead of refetching on first read

--- a/e2e/qwik-e2e/apps/error-handling.prod/src/routes/loader-error-inline/index.tsx
+++ b/e2e/qwik-e2e/apps/error-handling.prod/src/routes/loader-error-inline/index.tsx
@@ -1,0 +1,4 @@
+export {
+  default,
+  useFailingLoader,
+} from '../../../../error-handling/src/routes/loader-error-inline/index';

--- a/e2e/qwik-e2e/apps/error-handling.prod/src/routes/loader-error-throw/index.tsx
+++ b/e2e/qwik-e2e/apps/error-handling.prod/src/routes/loader-error-throw/index.tsx
@@ -1,0 +1,4 @@
+export {
+  default,
+  useThrowingLoader,
+} from '../../../../error-handling/src/routes/loader-error-throw/index';

--- a/e2e/qwik-e2e/apps/error-handling/src/routes/loader-error-inline/index.tsx
+++ b/e2e/qwik-e2e/apps/error-handling/src/routes/loader-error-inline/index.tsx
@@ -1,0 +1,27 @@
+import { component$, ErrorBoundary } from '@qwik.dev/core';
+import { routeLoader$ } from '@qwik.dev/router';
+import { defaultFallback } from '../../components/error-boundary/error-boundary';
+
+export const useFailingLoader = routeLoader$(async () => {
+  throw new Error('loader-inline-boom');
+});
+
+const GuardedConsumer = component$(() => {
+  const data = useFailingLoader();
+  if (data.error) {
+    const digest = (data.error as Error & { digest?: string }).digest;
+    return (
+      <p id="loader-error-inline">
+        inline: {data.error.message}
+        {digest && <code id="loader-error-digest">{digest}</code>}
+      </p>
+    );
+  }
+  return <p id="loader-error-value">value: {String(data.value)}</p>;
+});
+
+export default component$(() => (
+  <ErrorBoundary fallback$={defaultFallback}>
+    <GuardedConsumer />
+  </ErrorBoundary>
+));

--- a/e2e/qwik-e2e/apps/error-handling/src/routes/loader-error-nav/index.tsx
+++ b/e2e/qwik-e2e/apps/error-handling/src/routes/loader-error-nav/index.tsx
@@ -1,0 +1,8 @@
+import { component$ } from '@qwik.dev/core';
+import { Link } from '@qwik.dev/router';
+
+export default component$(() => (
+  <Link id="to-loader-error" href="/error-handling/loader-error-inline/">
+    go to erroring loader
+  </Link>
+));

--- a/e2e/qwik-e2e/apps/error-handling/src/routes/loader-error-throw/index.tsx
+++ b/e2e/qwik-e2e/apps/error-handling/src/routes/loader-error-throw/index.tsx
@@ -1,0 +1,18 @@
+import { component$, ErrorBoundary } from '@qwik.dev/core';
+import { routeLoader$ } from '@qwik.dev/router';
+import { defaultFallback } from '../../components/error-boundary/error-boundary';
+
+export const useThrowingLoader = routeLoader$(async () => {
+  throw new Error('loader-throw-boom');
+});
+
+const UnguardedConsumer = component$(() => {
+  const data = useThrowingLoader();
+  return <p id="loader-error-value">value: {String(data.value)}</p>;
+});
+
+export default component$(() => (
+  <ErrorBoundary fallback$={defaultFallback}>
+    <UnguardedConsumer />
+  </ErrorBoundary>
+));

--- a/e2e/qwik-e2e/tests/error-handling.e2e.ts
+++ b/e2e/qwik-e2e/tests/error-handling.e2e.ts
@@ -406,6 +406,36 @@ test.describe('ErrorBoundary + fallback$', () => {
         await expect(page.locator('#loader-500-body')).toHaveCount(0);
       });
 
+      test('a loader `.error` guard renders inline at 200, boundary untouched', async ({
+        page,
+      }) => {
+        assertNoBrowserErrors(page);
+        const response = await page.goto(routeUrl('loader-error-inline'), { waitUntil: 'commit' });
+        expect(response!.status()).toBe(200);
+        await expect(page.locator('#loader-error-inline')).toContainText('inline:', {
+          timeout: 10000,
+        });
+        await expect(page.locator('#eb-fallback')).toHaveCount(0);
+      });
+
+      test('an unguarded loader `.value` read renders the EB fallback at 200', async ({ page }) => {
+        assertNoBrowserErrors(page);
+        const response = await page.goto(routeUrl('loader-error-throw'), { waitUntil: 'commit' });
+        expect(response!.status()).toBe(200);
+        await expect(page.locator('#eb-fallback')).toBeVisible({ timeout: 10000 });
+        await expect(page.locator('#eb-fallback-msg')).toHaveText(caughtError);
+        await expect(page.locator('#loader-error-value')).toHaveCount(0);
+      });
+
+      test('SPA nav settles a loader error client-side', async ({ page }) => {
+        assertNoBrowserErrors(page);
+        await page.goto(routeUrl('loader-error-nav'), { waitUntil: 'commit' });
+        await page.locator('#to-loader-error').click();
+        await expect(page.locator('#loader-error-inline')).toContainText('inline:', {
+          timeout: 10000,
+        });
+      });
+
       // reset re-invokes the loader; this asserts the opposite
       test.fixme('reset re-derives the identical fallback from the serialized loader value', async ({
         page,
@@ -792,6 +822,31 @@ test.describe('ErrorBoundary in a production build (qDev=false)', () => {
       .poll(() => page.evaluate(() => (window as any).__ebRederiveRuns ?? 0), { timeout: 10000 })
       .toBe(1);
     await expect(page.locator('#eb-fallback-msg')).toHaveText('caught: eb always boom');
+  });
+
+  test('a guarded loader error renders the generic message + digest inline, raw nowhere', async ({
+    page,
+  }) => {
+    assertNoBrowserErrors(page);
+    const response = await page.goto(prodUrl('loader-error-inline'), { waitUntil: 'commit' });
+    expect(response!.status()).toBe(200);
+
+    await expect(page.locator('#loader-error-inline')).toContainText('inline: An error occurred', {
+      timeout: 10000,
+    });
+    await expect(page.locator('#loader-error-digest')).not.toBeEmpty();
+    expect(await response!.text()).not.toContain('loader-inline-boom');
+  });
+
+  test('an unguarded loader error renders the redacted EB fallback at 200', async ({ page }) => {
+    assertNoBrowserErrors(page);
+    const response = await page.goto(prodUrl('loader-error-throw'), { waitUntil: 'commit' });
+    expect(response!.status()).toBe(200);
+
+    await expect(page.locator('#eb-fallback-msg')).toHaveText('caught: An error occurred', {
+      timeout: 10000,
+    });
+    expect(await response!.text()).not.toContain('loader-throw-boom');
   });
 
   test('reset round-trips through the prod serializer and re-executes the children', async ({

--- a/packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.ts
+++ b/packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.ts
@@ -113,7 +113,7 @@ export function loaderHandler(
       return;
     }
 
-    await sendLoaderResponse(requestEv, data, loader);
+    await sendLoaderResponse(requestEv, data, loader, responseData.e !== undefined);
   };
 }
 
@@ -158,11 +158,14 @@ function resolvePreETag(
 async function sendLoaderResponse(
   requestEv: RequestEventInternal,
   data: string,
-  loader?: LoaderInternal
+  loader?: LoaderInternal,
+  isErrorEnvelope = false
 ) {
   requestEv.headers.set('Content-Type', 'application/json; charset=utf-8');
   addVaryHeader(requestEv, FULLPATH_HEADER);
-  if (loader?.__expires && loader.__expires > 0) {
+  if (isErrorEnvelope) {
+    requestEv.cacheControl({ noStore: true });
+  } else if (loader?.__expires && loader.__expires > 0) {
     requestEv.cacheControl({ maxAge: Math.ceil(loader.__expires / 1000), private: true });
   }
   requestEv.send(200, data);

--- a/packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.unit.ts
@@ -49,6 +49,29 @@ describe('loaderHandler', () => {
     expect(requestEv.send).toHaveBeenCalledWith(200, expect.any(String));
   });
 
+  it('an error envelope responds no-store instead of the loader max-age', async () => {
+    const requestEv = createRequestEv();
+    const loader = {
+      __id: 'loader-id',
+      __qrl: {
+        call: vi.fn(async () => {
+          throw new Error('loader boom');
+        }),
+      },
+      __validators: undefined,
+      __expires: 1500,
+      __eTag: undefined,
+      __cacheKey: undefined,
+      __search: undefined,
+    };
+
+    await loaderHandler([loader as any])(requestEv as any);
+
+    expect(requestEv.cacheControl).toHaveBeenCalledWith({ noStore: true });
+    expect(requestEv.cacheControl).not.toHaveBeenCalledWith({ maxAge: 2, private: true });
+    expect(requestEv.send).toHaveBeenCalledWith(200, expect.any(String));
+  });
+
   it('passes normalized unquoted eTags to cacheKey callbacks and quotes only response headers', async () => {
     const requestEv = createRequestEv();
     const cacheKey = vi.fn((_ev: any, _eTag: string) => `loader-cache-${Date.now()}`);

--- a/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers-core.ts
+++ b/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers-core.ts
@@ -52,6 +52,7 @@ import {
 import { HttpStatus } from './http-status-codes';
 import { getQwikRouterServerData } from './response-page';
 import { encoder, isContentType } from './request-utils';
+import { AbortMessage } from './redirect-handler';
 import { ServerError, throwIfControlFlowSignal } from './server-error';
 
 const loadHttpError = () => import('../../runtime/src/http-error');
@@ -345,7 +346,13 @@ function createResolveRequestHandlers() {
           ) as Promise<void>;
         }
       }
-      return allBlockSSRLoaders;
+      // Outcomes abort the response; a plain throw settles the loader's `.error` and rendering
+      // decides how it surfaces.
+      return allBlockSSRLoaders?.catch((err) => {
+        if (err instanceof ServerError || err instanceof AbortMessage) {
+          throw err;
+        }
+      });
     };
   }
 

--- a/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers.unit.ts
@@ -563,6 +563,21 @@ describe('resolve-request-handler', () => {
       expect(requestEv.sharedMap.get(RequestEvHttpStatusMessage)).toBe('first-error');
     });
 
+    it('a plain Error thrown in a blockSSR loader settles and still renders the page', async () => {
+      const route = pageRouteWithLoaders(
+        makeLoader('l1', () => {
+          throw new Error('loader boom');
+        })
+      );
+      const renderHandler = exitRender();
+      const requestEv = runPage(route, renderHandler);
+
+      await expect(requestEv.next()).resolves.toBeUndefined();
+
+      expect(renderHandler).toHaveBeenCalledOnce();
+      expect(requestEv.status()).toBe(200);
+    });
+
     it('a failing blockSSR:false loader does not affect the response when unread', async () => {
       const route = pageRouteWithLoaders(
         makeLoader(

--- a/packages/qwik-router/src/runtime/src/route-loaders.ts
+++ b/packages/qwik-router/src/runtime/src/route-loaders.ts
@@ -28,7 +28,7 @@ import type {
 // route-loaders.ts → middleware barrel → runtime/src/ (same module group)
 import { _asyncRequestStore } from '../../middleware/request-handler/async-request-store';
 import { getLoaderName } from '../../middleware/request-handler/request-path';
-import { RedirectMessage } from '../../middleware/request-handler/redirect-handler';
+import { AbortMessage, RedirectMessage } from '../../middleware/request-handler/redirect-handler';
 import {
   ServerError,
   throwIfControlFlowSignal,
@@ -758,6 +758,10 @@ export const loadRouteLoaderByQrl = (
       },
       (err) => {
         // Keep the rejection memoized so re-reads settle instead of re-executing the loader.
+        // Server-origin failures settle redacted; outcomes must stay recognizable for the abort path.
+        if (isServer && !isDev && !(err instanceof ServerError) && !(err instanceof AbortMessage)) {
+          throw _redactToGeneric(err);
+        }
         throw err;
       }
     );

--- a/packages/qwik-router/src/runtime/src/route-loaders.ts
+++ b/packages/qwik-router/src/runtime/src/route-loaders.ts
@@ -13,6 +13,7 @@ import {
   _getContextEvent,
   _injectAsyncSignalValue,
   _markSignalAsExternallyOwned,
+  _redactToGeneric,
   _resolveContextWithoutSequentialScope,
   _verifySerializable,
   _UNINITIALIZED,
@@ -79,7 +80,7 @@ export const ROUTE_PATH_HEADER = 'X-Qwik-route-path';
 export type LoaderResponse = {
   d?: unknown;
   r?: string;
-  e?: InstanceType<typeof ServerError>;
+  e?: Error;
 };
 
 type LoaderFetchCacheEntry = {
@@ -756,7 +757,7 @@ export const loadRouteLoaderByQrl = (
         return value;
       },
       (err) => {
-        delete promises[loaderId];
+        // Keep the rejection memoized so re-reads settle instead of re-executing the loader.
         throw err;
       }
     );
@@ -909,6 +910,9 @@ export const getRouteLoaderResponse = async (
     }
     if (err instanceof ServerError) {
       return { e: err };
+    }
+    if (err instanceof Error) {
+      return { e: isDev ? err : _redactToGeneric(err) };
     }
     throw err;
   }

--- a/packages/qwik-router/src/runtime/src/route-loaders.unit.ts
+++ b/packages/qwik-router/src/runtime/src/route-loaders.unit.ts
@@ -86,6 +86,21 @@ describe('route loader execution', () => {
     expect(parentLoader.__qrl.call).toHaveBeenCalledOnce();
   });
 
+  it('settles a rejected loader per-request: a re-read does not re-execute', async () => {
+    const requestEv: any = {
+      sharedMap: new Map(),
+      url: new URL('http://localhost/products/'),
+    };
+    const failing = createLoader('failing', async () => {
+      throw new Error('loader boom');
+    });
+
+    await expect(loadRouteLoader(failing, requestEv)).rejects.toThrow('loader boom');
+    await expect(loadRouteLoader(failing, requestEv)).rejects.toThrow('loader boom');
+
+    expect(failing.__qrl.call).toHaveBeenCalledOnce();
+  });
+
   it('stores loader expires values in milliseconds', () => {
     const loader = routeLoaderQrl(createQrl('timed-loader'), { expires: 60_000 }) as LoaderInternal;
 
@@ -111,6 +126,17 @@ describe('getRouteLoaderResponse envelope', () => {
     expect(response.e).toBeUndefined();
   });
 
+  it('routes a plain thrown Error to the error channel', async () => {
+    const qrl = createQrl('plain-error-loader', async () => {
+      throw new Error('plain boom');
+    });
+
+    const response = await getRouteLoaderResponse(qrl, undefined, requestEv);
+
+    expect(response.d).toBeUndefined();
+    expect(response.e).toBeInstanceOf(Error);
+  });
+
   it('routes a thrown ServerError to the error channel', async () => {
     const qrl = createQrl('error-loader', async () => {
       throw new ServerError(500, 'boom');
@@ -120,7 +146,7 @@ describe('getRouteLoaderResponse envelope', () => {
 
     expect(response.d).toBeUndefined();
     expect(response.e).toBeInstanceOf(ServerError);
-    expect(response.e?.status).toBe(500);
+    expect((response.e as InstanceType<typeof ServerError>)?.status).toBe(500);
   });
 });
 

--- a/packages/qwik/src/core/internal.ts
+++ b/packages/qwik/src/core/internal.ts
@@ -74,6 +74,7 @@ export {
   _serialize,
 } from './shared/serdes/index';
 export { SubscriptionPatch as _SubscriptionPatch } from './shared/serdes/subscription-patch';
+export { redactToGeneric as _redactToGeneric } from './shared/error/error-handling';
 export { verifySerializable as _verifySerializable } from './shared/serdes/verify';
 export { _SharedContainer } from './shared/shared-container';
 export { _CONST_PROPS, _IMMUTABLE, _UNINITIALIZED, _VAR_PROPS } from './shared/utils/constants';

--- a/packages/qwik/src/core/qwik.core.api.md
+++ b/packages/qwik/src/core/qwik.core.api.md
@@ -1046,6 +1046,11 @@ name?: string;
 children?: JSXChildren;
 }>> | JSXNodeInternal<InternalServerComponent<SSRRevealSlotProps>>;
 
+// @internal (undocumented)
+export const _redactToGeneric: (err: unknown) => Error & {
+    digest: string;
+};
+
 // @internal
 export const _regSymbol: (symbol: any, hash: string) => any;
 

--- a/packages/qwik/src/core/reactive-primitives/impl/async-signal.unit.tsx
+++ b/packages/qwik/src/core/reactive-primitives/impl/async-signal.unit.tsx
@@ -767,7 +767,79 @@ describe('async signal', () => {
       });
     });
 
-    it('should throw the retried promise instead of returning a stale value after an error', async () => {
+    it('keeps the stale value when a recompute errors: .value returns it and .error is set', async () => {
+      await withContainer(async () => {
+        const ref = {
+          started: 0,
+          resolveFirst: undefined as ((value: number) => void) | undefined,
+          rejectSecond: undefined as ((error: Error) => void) | undefined,
+        };
+        const signal = createAsync$(
+          async () => {
+            ref.started++;
+            if (ref.started === 1) {
+              return new Promise<number>((resolve) => {
+                ref.resolveFirst = resolve;
+              });
+            }
+            return new Promise<number>((_resolve, reject) => {
+              ref.rejectSecond = reject;
+            });
+          },
+          { initial: 0 }
+        ) as AsyncSignalImpl<number>;
+
+        effect$(() => signal.value);
+
+        await retryOnPromise(() => {
+          if (!ref.resolveFirst) {
+            throw new Promise((resolve) => setTimeout(resolve, 0));
+          }
+          return ref.started;
+        });
+        ref.resolveFirst!(1);
+        await signal.promise();
+        expect(signal.value).toBe(1);
+
+        await signal.invalidate();
+        expect(signal.value).toBe(1);
+        await retryOnPromise(() => {
+          if (!ref.rejectSecond) {
+            throw new Promise((resolve) => setTimeout(resolve, 0));
+          }
+          return ref.started;
+        });
+        const failure = new Error('recompute failure');
+        ref.rejectSecond!(failure);
+        await signal.promise().catch(() => {});
+
+        expect(signal.error).toBe(failure);
+        expect(signal.value).toBe(1);
+        expect(signal.$untrackedValue$).toBe(1);
+      });
+    });
+
+    it('throws the stored error on .value when it errored with no settled value', async () => {
+      await withContainer(async () => {
+        const failure = new Error('first failure');
+        const signal = createAsync$(async () => {
+          throw failure;
+        }) as AsyncSignalImpl<number>;
+
+        await signal.promise().catch(() => {});
+
+        let thrown: unknown;
+        try {
+          signal.value;
+        } catch (err) {
+          thrown = err;
+        }
+        expect(thrown).toBe(failure);
+        expect(signal.error).toBe(failure);
+      });
+    });
+
+    it('returns the stale value while retrying after an error', async () => {
       await withContainer(async () => {
         const ref = {
           started: 0,
@@ -810,16 +882,9 @@ describe('async signal', () => {
           return ref.started;
         });
 
-        let thrown: unknown;
-        try {
-          signal.value;
-        } catch (err) {
-          thrown = err;
-        }
-
-        expect(thrown).toBeInstanceOf(Promise);
+        expect(signal.value).toBe(0);
         expect(signal.error).toBe(failure);
-        expect(signal.$untrackedValue$).toBe(NEEDS_COMPUTATION);
+        expect(signal.$untrackedValue$).toBe(0);
 
         ref.resolveSecond!(2);
         await signal.promise();

--- a/packages/qwik/src/core/reactive-primitives/impl/async-signal.unit.tsx
+++ b/packages/qwik/src/core/reactive-primitives/impl/async-signal.unit.tsx
@@ -822,7 +822,7 @@ describe('async signal', () => {
     it('throws the stored error on .value when it errored with no settled value', async () => {
       await withContainer(async () => {
         const failure = new Error('first failure');
-        const signal = createAsync$(async () => {
+        const signal = createAsync$(async (): Promise<number> => {
           throw failure;
         }) as AsyncSignalImpl<number>;
 

--- a/packages/qwik/src/core/reactive-primitives/impl/computed-signal-impl.ts
+++ b/packages/qwik/src/core/reactive-primitives/impl/computed-signal-impl.ts
@@ -263,8 +263,12 @@ export class ComputedSignalImpl<T, S extends QRLInternal = ComputeQRL<T>>
       return this.$untrackedValue$;
     }
     if (this.$untrackedError$) {
-      DEBUG && log('Throwing error while reading value', this);
-      throw this.$untrackedError$;
+      if (this.$untrackedValue$ === NEEDS_COMPUTATION) {
+        DEBUG && log('Throwing error while reading value', this);
+        throw this.$untrackedError$;
+      }
+      DEBUG && log('Returning stale value while errored', this);
+      return this.$untrackedValue$;
     }
     // For clientOnly signals without initial value during SSR, throw if trying to read value
     // During SSR, clientOnly signals are skipped, so there's no computed value available
@@ -717,8 +721,6 @@ export class ComputedSignalImpl<T, S extends QRLInternal = ComputeQRL<T>>
       return;
     }
     this.untrackedError = error;
-    // Job failures should be rare and require retrying
-    this.untrackedValue = NEEDS_COMPUTATION;
   }
 
   /** Called after SSR/unmount */

--- a/packages/qwik/src/core/shared/error/error-handling.ts
+++ b/packages/qwik/src/core/shared/error/error-handling.ts
@@ -70,6 +70,7 @@ const errorBoundaryDigest = (err: unknown): string =>
 
 const REDACTED = /*#__PURE__*/ Symbol();
 
+/** @internal */
 export const redactToGeneric = (err: unknown): Error & { digest: string } => {
   const redacted = new Error(GENERIC_BOUNDARY_ERROR_MESSAGE) as Error & { digest: string };
   redacted.digest = errorBoundaryDigest(err);

--- a/packages/qwik/src/core/shared/serdes/inflate.ts
+++ b/packages/qwik/src/core/shared/serdes/inflate.ts
@@ -309,8 +309,8 @@ function* inflateIterator(
       if (hasValue) {
         asyncSignal.$untrackedValue$ = d[6];
       }
-      // can happen when never serialize etc
-      if (asyncSignal.$untrackedValue$ === NEEDS_COMPUTATION) {
+      // can happen when never serialize etc; a restored error is a settled state, not stale
+      if (asyncSignal.$untrackedValue$ === NEEDS_COMPUTATION && !asyncSignal.$untrackedError$) {
         asyncSignal.$flags$ |= ComputedSignalFlags.INVALID;
       }
 

--- a/packages/qwik/src/core/shared/serdes/serdes.unit.ts
+++ b/packages/qwik/src/core/shared/serdes/serdes.unit.ts
@@ -1470,6 +1470,42 @@ describe('shared-serialization', () => {
       expect((restored as AsyncSignalImpl<number>).$concurrency$).toBe(3);
       expect((restored as AsyncSignalImpl<number>).$timeoutMs$).toBe(1000);
     });
+    it(`${title(TypeIds.AsyncSignal)} errored: resumes settled and .value throws the restored error`, async () => {
+      const asyncSignal = createAsync$(async () => {
+        throw new Error('ssr boom');
+      });
+      await (asyncSignal as AsyncSignalImpl<never>).promise().catch(() => {});
+      const objs = await serialize(asyncSignal);
+      const restored = deserialize(objs)[0] as AsyncSignalImpl<number>;
+      expect(restored.$flags$ & ComputedSignalFlags.INVALID).toBeFalsy();
+      expect(restored.untrackedError?.message).toBe('ssr boom');
+      let thrown: unknown;
+      try {
+        restored.value;
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBe(restored.untrackedError);
+    });
+    it(`${title(TypeIds.AsyncSignal)} errored with a stale value: resumes with both`, async () => {
+      const ref = { fail: false };
+      const asyncSignal = createAsync$(async () => {
+        if (ref.fail) {
+          throw new Error('later boom');
+        }
+        return 7;
+      });
+      await asyncSignal.promise();
+      ref.fail = true;
+      await asyncSignal.invalidate();
+      await (asyncSignal as AsyncSignalImpl<number>).promise().catch(() => {});
+
+      const objs = await serialize(asyncSignal);
+      const restored = deserialize(objs)[0] as AsyncSignalImpl<number>;
+      expect(restored.$flags$ & ComputedSignalFlags.INVALID).toBeFalsy();
+      expect(restored.value).toBe(7);
+      expect(restored.untrackedError?.message).toBe('later boom');
+    });
     // this requires a domcontainer
     it(title(TypeIds.Store), async () => {
       const orig: any = { a: { b: true } };

--- a/packages/qwik/src/core/shared/serdes/serialize.ts
+++ b/packages/qwik/src/core/shared/serdes/serialize.ts
@@ -648,7 +648,6 @@ export class Serializer {
         const isSkippable = fastSkipSerialize(value.$untrackedValue$);
         // async-mode computeds carry the same engine state and must round-trip like AsyncSignals
         const isAsync = !!(value.$flags$ & AsyncSignalFlags.ASYNC_MODE);
-        const isErrored = isAsync && !!value.$untrackedError$;
         const expires = isAsync && value.$expires$ !== 0 ? value.$expires$ : undefined;
         const concurrency = isAsync && value.$concurrency$ !== 1 ? value.$concurrency$ : undefined;
         const timeout = isAsync && value.$timeoutMs$ !== 0 ? value.$timeoutMs$ : undefined;
@@ -658,7 +657,7 @@ export class Serializer {
           (isAsync && value.$flags$ & ~SerializationSignalFlags.SERIALIZATION_ALL_STRATEGIES) ||
           undefined;
 
-        if (isInvalid || isSkippable || isErrored) {
+        if (isInvalid || isSkippable) {
           v = NEEDS_COMPUTATION;
         } else if (shouldAlwaysSerialize) {
           v = value.$untrackedValue$;


### PR DESCRIPTION
# What is it?

- Feature / enhancement

# Description

A plain `throw new Error` in a loader now settles the loader signal's `.error` instead of failing the response: an `.error` guard renders it inline, an unguarded `.value` read throws into the closest `<ErrorBoundary>`, and the page stays 200. Server-origin errors settle redacted (generic message + digest) at the settle site, so display, state, and the loader.json envelope carry the same redacted error. `error()`/`ServerError` and redirects still abort.

Also: an errored async signal keeps its stale value (`.value` returns it alongside `.error`, throwing only when nothing ever settled), a resumed errored signal is settled instead of refetching on first read, and loader error envelopes are never HTTP-cached.