### PR TITLE
fix(docs): fix overflowing toc element

### DIFF
--- a/packages/docs/src/routes/docs/docs.css
+++ b/packages/docs/src/routes/docs/docs.css
@@ -43,9 +43,7 @@
   @apply hidden;
 
   @variant xl {
-    @apply block order-2 self-start sticky pt-10;
-    top: 0;
-    max-height: 100vh;
+    @apply block order-2 self-start sticky top-0 pt-10;
   }
 }
 


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Docs / tests / types / typos

# Description

<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

The table of contents (or "toc") is currently overlapping the content below it.

This is happening because a max-height is currently being set without specifying the overflow behavior thus resulting in the content overflowing when it is bigger than the specified maximum height.
This PR removes the max-height.

Note that this can also be resolved by specifying the overflow behavior instead; however, making an element with sticky positioning scrollable can have unintended effects regarding accessibility.

*Before:*
<img width="1677" height="975" alt="before" src="https://github.com/user-attachments/assets/e91afafc-e545-4223-9320-aa942ad3d98c" />

*And after:*
<img width="1674" height="978" alt="after" src="https://github.com/user-attachments/assets/e225cad7-0fbd-4b5d-996c-c3f0bf976cad" />


# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I made corresponding changes to the Qwik docs
