### PR TITLE
docs(qwik-router): document redirect after POST using PRG pattern

### DIFF
--- a/packages/docs/src/routes/docs/(qwikrouter)/action/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikrouter)/action/index.mdx
@@ -26,7 +26,8 @@ contributors:
   - jemsco
   - tzdesign
   - shairez
-updated_at: '2023-12-15T11:00:00Z'
+  - syrfmy
+updated_at: '2026-08-10T21:28:00Z'
 created_at: '2023-03-20T23:45:13Z'
 ---
 
@@ -469,3 +470,81 @@ export const useLogin = globalAction$((data) => {
   // ...
 });
 ```
+
+## Redirecting after a POST
+
+When JavaScript is disabled, a native form `POST` is stored in browser history. Reloading the page triggers a **"Confirm Form Resubmission"** warning and re-runs the action. To prevent this, use the [Post/Redirect/Get (PRG)](https://en.wikipedia.org/wiki/Post/Redirect/Get) pattern: detect if the submission came from the browser (no-JS) and redirect to a `GET` request instead.
+
+A native browser form submission always includes `text/html` in the `Accept` header. Use that to detect when to apply the redirect:
+
+```tsx title="src/routes/index.tsx" // ⚠️ without PRG
+import { component$ } from '@qwik.dev/core';
+import { routeAction$, zod$, z } from '@qwik.dev/router';
+
+export const useCreatePost = routeAction$(
+  async (data) => {
+    const postId = await db.posts.create(data);
+    return { postId };
+  },
+  zod$({ title: z.string() })
+);
+
+export default component$(() => {
+  const action = useCreatePost();
+  return (
+    // ⚠️ Native form POST — reloading the result page triggers "Confirm Form Resubmission"
+    <form method="POST" action={action.actionPath}>
+      <input name="title" />
+      <button type="submit">Create post</button>
+    </form>
+  );
+});
+```
+
+To fix this, detect the submission type using the `Accept` header and `throw redirect()` for browser submissions:
+
+```tsx title="src/routes/index.tsx"
+import { component$ } from '@qwik.dev/core';
+import { routeAction$, routeLoader$, Form, zod$, z } from '@qwik.dev/router';
+
+export const useCreatePost = routeAction$(
+  async (data, { request, redirect }) => {
+    const postId = await db.posts.create(data);
+
+    // Browser (no-JS) submissions include text/html in the Accept header.
+    // Redirect to a GET so the user can safely reload the result page.
+    if (request.headers.get('accept')?.includes('text/html')) {
+      throw redirect(303, `/?created=${postId}`);
+    }
+
+    return { postId };
+  },
+  zod$({ title: z.string() })
+);
+
+// Read the search param set by the redirect on the destination page
+export const useCreatedId = routeLoader$(({ url }) => {
+  return { createdId: url.searchParams.get('created') };
+});
+
+export default component$(() => {
+  const action = useCreatePost();
+  const loader = useCreatedId();
+
+  // JS path: action.value holds the result directly.
+  // No-JS path: loader.value holds the param passed via the redirect.
+  const createdId = action.value?.postId ?? loader.value.createdId;
+
+  return (
+    <Form action={action}>
+      <input name="title" />
+      <button type="submit">Create post</button>
+      {createdId && <p>Post {createdId} created!</p>}
+    </Form>
+  );
+});
+```
+
+When JS is enabled, Qwik intercepts the form submission as a fetch and the redirect is never triggered — `action.value` holds the result as usual. The redirect only fires for native browser submissions. However, `<Form/>` uses [progressive enhancement](https://developer.mozilla.org/en-US/docs/Glossary/Progressive_Enhancement) and falls back to a native form `POST` if JS has not yet loaded or fails to load, so the PRG pattern is still needed for these cases.
+
+<Note>You can also pass state across a redirect using cookies instead of search params, which is useful for flash messages or session data. See the [cookie section in the middleware docs](/docs/(qwikrouter)/middleware/#cookie) for usage.</Note>


### PR DESCRIPTION
<!--
The Qwik Team and Community appreciate all PRs. Thank you for your effort! Not all PRs can be merged, but those that meet the following criteria will be prioritized:

a) Core fixes, and

b) Framework functionality achievable only by the core.

If this PR can be done as a 3rd-Party Community Add-On, we encourage that for quicker adoption.

If you believe your functionality is valuable to the entire Qwik Community, discuss it in the Qwik Discord channels for potential inclusion in the core.

First of all, make sure your PR title is descriptive and matches our commit title guidelines.

Also make sure your PR follows all the guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) document.

-->

# What is it?

<!-- pick one and remove the others -->

- Docs / tests / types / typos


# Description
Closes #8531
Documents how to avoid the "Confirm Form Resubmission" browser warning when using `routeAction$` with native form submissions, using the Post/Redirect/Get (PRG) pattern.
Detects browser submissions via the `Accept: text/html` header and calls `throw redirect(303, ...)` to transition to a safe `GET` request.
<!--
* Include a summary of the motivation and context for this PR
* Is it related to any opened issues? (please add them here)
-->

# Checklist

<!--
* delete the items that are not relevant, so it's easy to tell if the PR is ready to be merged
* add items that are relevant and need to be done before merging
-->

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [x] I made corresponding changes to the Qwik docs
- [ ] I added new tests to cover the fix / functionality
