### PR TITLE
feat(utils): new @qwik.dev/utils package with usePoll hook

### DIFF
--- a/e2e/qwik-e2e/apps/qwikrouter-ssg-snapshot/expected.state.txt
+++ b/e2e/qwik-e2e/apps/qwikrouter-ssg-snapshot/expected.state.txt
@@ -71,9 +71,7 @@
             Constant undefined
             Constant undefined
             Constant undefined
-            {number} 772
-            Constant NEEDS_COMPUTATION
-            {number} 120000
+            {number} 516
           ]
           Constant '.'
         ]
@@ -365,7 +363,9 @@
 19 RootRef [omitted]
 20 RootRef [omitted]
 21 {string} "ssg-snapshot-loader"
-22 Object 0
+22 Object [
+  {string} "raw"
+]
 23 {string} "__qwik_route_loader_value__ssg-snapshot-loader"
 24 RootRef [omitted]
 25 Array []
@@ -511,7 +511,6 @@
           ]
         ]
       ]
-      Constant undefined
       {number} 0
     ]
     {string} "value"

--- a/packages/qwik-router/src/runtime/src/link-prefetch.unit.ts
+++ b/packages/qwik-router/src/runtime/src/link-prefetch.unit.ts
@@ -99,7 +99,7 @@ describe('link prefetch observer', () => {
     init(new Event('qcinit'), anchor);
     MockIntersectionObserver.instances[0].trigger(anchor);
 
-    expectPrefetchRouteCall(0, '/next/', true, 0.8, manifestHash, false, undefined);
+    expectPrefetchRouteCall(0, '/next/', true, 0.8, manifestHash, false);
   });
 
   it('prefetches route bundles and visible route data according to the mode', () => {

--- a/packages/qwik-router/src/runtime/src/qwik-router-component.tsx
+++ b/packages/qwik-router/src/runtime/src/qwik-router-component.tsx
@@ -88,6 +88,7 @@ import spaInit from './spa-init';
 import {
   clearNavFetchCache,
   ensureRouteLoaderSignals,
+  invalidateNavRouteLoaders,
   isImmutableLoader,
   setLoaderSignalValue,
   updateRouteLoaderPaths,
@@ -611,15 +612,7 @@ export const useQwikRouter = (props?: QwikRouterProps) => {
       updateRouteLoaderPaths(routeLoaderCtx, loadedRoute.$loaderPaths$, trackUrl);
       const routeLoaders = ensureRouteLoaderSignals(contentModules, loaderState, routeLoaderCtx);
       if (!isServer) {
-        // Every nav invalidates every loader: the browser HTTP cache (driven by each
-        // loader's cacheControl) decides freshness. Unsubscribed signals only mark
-        // stale and refetch lazily when read again. Immutable loaders are skipped —
-        // their data cannot change until a rebuild; tracked URL inputs still invalidate them.
-        for (const id in loaderState) {
-          if (!isImmutableLoader(id)) {
-            loaderState[id].invalidate();
-          }
-        }
+        invalidateNavRouteLoaders(loaderState);
       }
       if (shouldInvalidateActionLoaders) {
         // Actions force revalidation (fetch cache: 'reload') for their loaders

--- a/packages/qwik-router/src/runtime/src/route-loaders.ts
+++ b/packages/qwik-router/src/runtime/src/route-loaders.ts
@@ -631,6 +631,21 @@ const immutableLoaderIds = new Set<string>();
 
 export const isImmutableLoader = (loaderId: string) => immutableLoaderIds.has(loaderId);
 
+/**
+ * Invalidate every loader signal on navigation: the browser HTTP cache (driven by each loader's
+ * cacheControl) decides freshness. Unsubscribed signals only mark stale and refetch lazily when
+ * read again. Immutable loaders are skipped — their data cannot change until a rebuild; tracked URL
+ * inputs still invalidate them.
+ */
+export const invalidateNavRouteLoaders = (state: RouteLoaderState) => {
+  for (const id in state) {
+    // The state also holds resumed loader values under prefixed keys, which are not signals
+    if (!id.startsWith(ROUTE_LOADER_VALUE_PREFIX) && !immutableLoaderIds.has(id)) {
+      state[id].invalidate();
+    }
+  }
+};
+
 export const ensureRouteLoaderSignal = (
   loader: LoaderInternal,
   state: RouteLoaderState,

--- a/packages/qwik-router/src/runtime/src/route-loaders.unit.ts
+++ b/packages/qwik-router/src/runtime/src/route-loaders.unit.ts
@@ -3,6 +3,7 @@ import { _UNINITIALIZED, type SerializationStrategy } from '@qwik.dev/core/inter
 import {
   ensureRouteLoaderSignal,
   getRouteLoaderResponse,
+  invalidateNavRouteLoaders,
   isImmutableLoader,
   loadRouteLoader,
   routeLoaderQrl,
@@ -41,6 +42,25 @@ describe('route loader execution', () => {
 
     expect(isImmutableLoader(immutable.__id)).toBe(true);
     expect(isImmutableLoader(normal.__id)).toBe(false);
+  });
+
+  it('invalidates loader signals on nav, skipping resumed values and immutable loaders', () => {
+    const state = {} as RouteLoaderState;
+    const routeLoaderCtx = { loaderPaths: {} };
+    const immutable = routeLoaderQrl(createQrl('nav-immutable-loader'), {
+      cacheControl: 'immutable',
+    }) as LoaderInternal;
+    const normal = createLoader('nav-normal-loader', async () => undefined);
+
+    ensureRouteLoaderSignal(immutable, state, routeLoaderCtx);
+    ensureRouteLoaderSignal(normal, state, routeLoaderCtx);
+    const immutableInvalidate = vi.spyOn(state[immutable.__id], 'invalidate');
+    const normalInvalidate = vi.spyOn(state['nav-normal-loader'], 'invalidate');
+
+    invalidateNavRouteLoaders(state);
+
+    expect(normalInvalidate).toHaveBeenCalledOnce();
+    expect(immutableInvalidate).not.toHaveBeenCalled();
   });
 
   it('memoizes in-flight loader executions on the request', async () => {

--- a/packages/qwik-utils/src/use-poll.ts
+++ b/packages/qwik-utils/src/use-poll.ts
@@ -1,17 +1,21 @@
 import { useVisibleTask$, type ComputedSignal } from '@qwik.dev/core';
 
+/** Smallest allowed poll interval, so a `0` or negative `expires` can't spin the event loop. */
+const MIN_EXPIRES_MS = 5;
+
 /**
- * Poll a computed/async signal: invalidate it every `expires` milliseconds so it recomputes.
+ * Poll a computed/async signal: invalidate it every `expires` milliseconds so it recomputes. The
+ * signal is returned so it can be wrapped inline.
  *
  * Polling starts once the document is idle and is client-only. The timer resets whenever a new
  * result lands (the `pending` flip), so `expires` counts from the last result, not from mount.
- * Polling continues after a failed computation.
+ * Polling continues after a failed computation. `expires` is clamped to 5ms.
  *
  * Multiple components may call `usePoll` on the same signal; the redundant timers are harmless.
  *
  * @public
  */
-export const usePoll = (signal: ComputedSignal<unknown>, expires: number) => {
+export const usePoll = <T>(signal: ComputedSignal<T>, expires: number): ComputedSignal<T> => {
   useVisibleTask$(
     ({ track, cleanup }) => {
       const pending = track(() => signal.pending);
@@ -19,10 +23,14 @@ export const usePoll = (signal: ComputedSignal<unknown>, expires: number) => {
       if (!pending) {
         // Interval, not timeout: a recompute that never flips `pending` (sync compute,
         // injected value) would otherwise stop the poll after one tick.
-        const intervalId = setInterval(() => signal.invalidate(), expires);
+        const intervalId = setInterval(
+          () => signal.invalidate(),
+          Math.max(expires, MIN_EXPIRES_MS)
+        );
         cleanup(() => clearInterval(intervalId));
       }
     },
     { strategy: 'document-idle' }
   );
+  return signal;
 };

--- a/packages/qwik-utils/src/use-poll.unit.tsx
+++ b/packages/qwik-utils/src/use-poll.unit.tsx
@@ -1,6 +1,6 @@
-import { component$, useComputed$ } from '@qwik.dev/core';
+import { component$, useComputed$, type ComputedSignal } from '@qwik.dev/core';
 import { domRender, ssrRenderToDom, trigger } from '@qwik.dev/core/testing';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { usePoll } from './use-poll';
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -13,11 +13,18 @@ describe.each([
   { render: ssrRenderToDom }, //
   { render: domRender }, //
 ])('$render.name: usePoll', ({ render }) => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('re-runs the signal after `expires` and keeps polling', async () => {
     counters.pollRuns = 0;
     const Cmp = component$(() => {
-      const signal = useComputed$(async () => ++(globalThis as any).pollRuns);
-      usePoll(signal, 20);
+      // Typed signal in, same typed signal out
+      const signal: ComputedSignal<number> = usePoll(
+        useComputed$(async () => ++(globalThis as any).pollRuns),
+        20
+      );
       return <span>{signal.value}</span>;
     });
 
@@ -47,5 +54,19 @@ describe.each([
     await trigger(document.body, 'span', 'd:qidle');
     await delay(150);
     expect(counters.failRuns).toBeGreaterThan(2);
+  });
+
+  it('clamps `expires` to the 5ms minimum', async () => {
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+    const Cmp = component$(() => {
+      const signal = useComputed$(async () => 1);
+      usePoll(signal, 0);
+      return <span>{signal.value}</span>;
+    });
+
+    const { document } = await render(<Cmp />, { debug: false });
+    await trigger(document.body, 'span', 'd:qidle');
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 5);
   });
 });


### PR DESCRIPTION
Polling moves out of the async signal engine: usePoll(signal, expires)
invalidates the signal on an interval that starts on document idle and
resets whenever a new result lands.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>