### PR TITLE
fix: avoid rerendering unchanged components after resume

### DIFF
--- a/.changeset/cold-components-remember.md
+++ b/.changeset/cold-components-remember.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: avoid rerendering unchanged components after resume

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -45,6 +45,7 @@ import {
   ITERATION_ITEM_SINGLE,
   OnRenderProp,
   QBackRefs,
+  QComponentHash,
   QContainerAttr,
   QDefaultSlot,
   QCursorBoundary,
@@ -1764,7 +1765,9 @@ function getComponentHash(vNode: VNode | null, getObject: (id: string) => any): 
     return null;
   }
   const qrl = vnode_getProp<QRLInternal>(vNode as VirtualVNode, OnRenderProp, getObject);
-  return qrl ? qrl.$hash$ : null;
+  return qrl
+    ? qrl.$hash$
+    : vnode_getProp<string | null>(vNode as VirtualVNode, QComponentHash, null);
 }
 
 /**

--- a/packages/qwik/src/core/client/vnode-utils.ts
+++ b/packages/qwik/src/core/client/vnode-utils.ts
@@ -141,6 +141,7 @@ import {
   ITERATION_ITEM_MULTI,
   ITERATION_ITEM_SINGLE,
   OnRenderProp,
+  QComponentHash,
   Q_PROPS_SEPARATOR,
   QContainerAttr,
   QContainerAttrEnd,
@@ -2163,8 +2164,17 @@ function materializeFromVNodeData(
     } else if (peek() === VNodeDataChar.SCOPED_STYLE) {
       vnode_setProp(vParent, QScopedStyle, consumeValue());
     } else if (peek() === VNodeDataChar.RENDER_FN) {
-      (components ||= []).push(vParent as VirtualVNode);
-      vnode_setProp(vParent, OnRenderProp, consumeValue());
+      const renderRef = consumeValue();
+      if (renderRef.charCodeAt(0) === VNodeDataChar.RENDER_HASH_PREFIX) {
+        vnode_setProp(
+          vParent,
+          QComponentHash,
+          decodeURIComponent(decodeVNodeDataString(renderRef.slice(1)))
+        );
+      } else {
+        (components ||= []).push(vParent as VirtualVNode);
+        vnode_setProp(vParent, OnRenderProp, renderRef);
+      }
     } else if (peek() === VNodeDataChar.ID) {
       if (!container) {
         container = getDomContainer(element);

--- a/packages/qwik/src/core/client/vnode.unit.tsx
+++ b/packages/qwik/src/core/client/vnode.unit.tsx
@@ -27,7 +27,7 @@ import type { VNode } from '../shared/vnode/vnode';
 import type { TextVNode } from '../shared/vnode/text-vnode';
 import type { VirtualVNode } from '../shared/vnode/virtual-vnode';
 import { encodeVNodeDataKey, encodeVNodeDataString } from '../shared/utils/character-escaping';
-import { QSlot } from '../shared/utils/markers';
+import { OnRenderProp, QComponentHash, QSlot } from '../shared/utils/markers';
 
 describe('vnode', () => {
   let parent: ContainerElement;
@@ -438,6 +438,17 @@ describe('vnode', () => {
           <Fragment key=":key_" />
         </test>
       );
+    });
+    it('should decode an identity-only component hash on Virtual', () => {
+      const componentHash = '</script>|{component}~';
+      const encodedHash = encodeVNodeDataString(encodeVNodeDataKey(componentHash));
+      parent.innerHTML = ``;
+      document.qVNodeData.set(parent, `{<_${encodedHash}}`);
+
+      const virtual = vnode_getFirstChild(vParent)!;
+
+      expect(vnode_getProp(virtual, QComponentHash, null)).toBe(componentHash);
+      expect(vnode_getProp(virtual, OnRenderProp, null)).toBeNull();
     });
     it('should decode encoded custom attribute names on Virtual', () => {
       const attrName = '</script><script>globalThis.__qwik_xss=1</script>';

--- a/packages/qwik/src/core/shared/utils/markers.ts
+++ b/packages/qwik/src/core/shared/utils/markers.ts
@@ -2,6 +2,7 @@ import { QContainerValue } from '../types';
 
 /** State factory of the component. */
 export const OnRenderProp = 'q:renderFn';
+export const QComponentHash = 'q:componentHash';
 
 /** Target DOM element for external projection rendering. */
 export const QTargetElement = 'q:targetEl';

--- a/packages/qwik/src/core/shared/vnode-data-types.ts
+++ b/packages/qwik/src/core/shared/vnode-data-types.ts
@@ -57,6 +57,8 @@ export const VNodeDataChar = {
   SCOPED_STYLE_CHAR: /* */ ';',
   RENDER_FN: /* ********** */ 60, // `<` - `q:renderFn' - Component QRL render function (body)
   RENDER_FN_CHAR: /* ** */ '<',
+  RENDER_HASH_PREFIX: /* **/ 95, // `_` after `<` identifies a component hash.
+  RENDER_HASH_PREFIX_CHAR: '_',
   ID: /* ***************** */ 61, // `=` - `q:id` - ID of the element.
   ID_CHAR: /* ********* */ '=',
   PROPS: /* ************** */ 62, // `>` - `q:props' - Component Props

--- a/packages/qwik/src/server/ssr-container.spec.ts
+++ b/packages/qwik/src/server/ssr-container.spec.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createDocument } from '@qwik.dev/core/testing';
+import { _createQRL } from '@qwik.dev/core/internal';
 import { ssrCreateContainer } from './ssr-container';
 import {
   QDefaultSlot,
   QError,
+  OnRenderProp,
   QSlot,
   QStyle,
   VNodeDataChar,
@@ -242,6 +244,29 @@ describe('SSR Container', () => {
     expect(vnodeContent).toContain(
       `${VNodeDataChar.SEPARATOR_CHAR}${encodedValue}${VNodeDataChar.SEPARATOR_CHAR}`
     );
+  });
+
+  it('should encode the component hash when its render QRL is not a root', () => {
+    const { container, writer } = createTestContainer();
+    container.openContainer();
+    container.serializationCtx.$roots$.push({});
+    Reflect.set(container, '$noMoreRoots$', true);
+    const componentHash = '</script>|{component}~';
+
+    (container as any).vNodeDatas = [
+      [
+        VNodeDataFlag.SERIALIZE | VNodeDataFlag.VIRTUAL_NODE,
+        { [OnRenderProp]: _createQRL(null, `s_${componentHash}`, () => undefined) },
+        OPEN_FRAGMENT,
+        CLOSE_FRAGMENT,
+      ],
+    ];
+
+    (container as any).emitVNodeData();
+
+    const encodedHash = encodeVNodeDataString(encodeVNodeDataKey(componentHash));
+    expect(writer.toString()).toContain(`${VNodeDataChar.RENDER_FN_CHAR}_${encodedHash}`);
+    expect(writer.toString()).not.toContain(`${VNodeDataChar.RENDER_FN_CHAR}_${componentHash}`);
   });
 
   it('should encode custom attribute names in emitVNodeData', () => {

--- a/packages/qwik/src/server/ssr-container.ts
+++ b/packages/qwik/src/server/ssr-container.ts
@@ -101,6 +101,7 @@ import {
   type SymbolToChunkResolver,
   type ValueOrPromise,
   type EffectSubscription,
+  type QRLInternal,
 } from './qwik-types';
 
 import {
@@ -1258,8 +1259,12 @@ class SSRContainer extends _SharedContainer implements ISSRContainer {
         value = String(rawValue);
       } else if (typeof rawValue !== 'string') {
         rootId = this.addRoot(rawValue);
-        // We didn't add the vnode data, so we are only interested in the vnode position
         if (rootId === undefined) {
+          if (key === OnRenderProp) {
+            this.write(VNodeDataChar.RENDER_FN_CHAR);
+            this.write(VNodeDataChar.RENDER_HASH_PREFIX_CHAR);
+            this.write(encodeVNodeDataString(encodeVNodeDataKey((rawValue as QRLInternal).$hash$)));
+          }
           continue;
         }
         value = String(rootId);

--- a/packages/qwik/src/server/vnode-data.unit.tsx
+++ b/packages/qwik/src/server/vnode-data.unit.tsx
@@ -3,9 +3,15 @@ import { component$, componentQrl } from '../core/shared/component.public';
 import { inlinedQrl } from '../core/shared/qrl/qrl';
 import { useSignal } from '../core/use/use-signal';
 import { ssrRenderToDom } from '../testing/rendering.unit-util';
+import { trigger } from '../testing/element-fixture';
 import { encodeAsAlphanumeric } from './vnode-data';
-import { vnode_getProp, vnode_locate } from '../core/client/vnode-utils';
-import { ELEMENT_PROPS, OnRenderProp } from '../core/shared/utils/markers';
+import {
+  vnode_getProp,
+  vnode_getVNodeForChildNode,
+  vnode_locate,
+  vnode_setProp,
+} from '../core/client/vnode-utils';
+import { ELEMENT_PROPS, OnRenderProp, QComponentHash } from '../core/shared/utils/markers';
 import { type QRLInternal } from '../core/shared/qrl/qrl-class';
 import type { DomContainer } from '../core/client/dom-container';
 import { createContextId, useContext, useContextProvider } from '@qwik.dev/core';
@@ -41,6 +47,54 @@ describe('vnode data', () => {
   });
   describe('integration tests', () => {
     const cId = createContextId<number>('cId');
+
+    it('preserves a cold component when its resumed parent rerenders', async () => {
+      const Child = componentQrl(inlinedQrl(() => <input id="child" />, 's_child'));
+      const Parent = component$(() => {
+        const visible = useSignal(false);
+        return (
+          <>
+            <button onClick$={() => (visible.value = true)}>show</button>
+            <Child key="child" />
+            {visible.value && <span>visible</span>}
+          </>
+        );
+      });
+
+      const { container, document } = await ssrRenderToDom(<Parent />, { debug });
+      const input = document.querySelector('#child')!;
+      keepOnlyComponentIdentity(container, input);
+
+      await trigger(document.body, 'button', 'click');
+
+      expect(document.querySelector('#child')).toBe(input);
+      expect(document.querySelector('span')?.textContent).toBe('visible');
+    });
+
+    it('replaces a cold component when its type changes under the same key', async () => {
+      const First = componentQrl(inlinedQrl(() => <input id="first" />, 's_first'));
+      const Second = componentQrl(inlinedQrl(() => <input id="second" />, 's_second'));
+      const Parent = component$(() => {
+        const second = useSignal(false);
+        const Child = second.value ? Second : First;
+        return (
+          <>
+            <button onClick$={() => (second.value = true)}>change</button>
+            <Child key="child" />
+          </>
+        );
+      });
+
+      const { container, document } = await ssrRenderToDom(<Parent />, { debug });
+      const input = document.querySelector('#first')!;
+      keepOnlyComponentIdentity(container, input);
+
+      await trigger(document.body, 'button', 'click');
+
+      expect(document.querySelector('#first')).toBeFalsy();
+      expect(document.querySelector('#second')).not.toBe(input);
+    });
+
     it('components inside the div', async () => {
       const Component = component$<RefIdProp>(({ refId }) => {
         const data = useSignal(1);
@@ -253,4 +307,17 @@ function expectVNodeRefProp(container: DomContainer, vNodeId: string, refIdPropV
     refId: refIdPropValue,
   };
   expectVNodeProps(container, vNodeId, props);
+}
+
+function keepOnlyComponentIdentity(container: DomContainer, element: Element) {
+  const bodyVNode = vnode_getVNodeForChildNode(container.rootVNode, element.ownerDocument.body);
+  const elementVNode = vnode_getVNodeForChildNode(bodyVNode, element);
+  const componentVNode = elementVNode.parent!;
+  const componentQrl = vnode_getProp<QRLInternal>(
+    componentVNode,
+    OnRenderProp,
+    container.$getObjectById$
+  )!;
+  vnode_setProp(componentVNode, QComponentHash, componentQrl.$hash$);
+  vnode_setProp(componentVNode, OnRenderProp, null);
 }


### PR DESCRIPTION
Serialize a lightweight component hash when the full render QRL is omitted, allowing unchanged components to be reused after resume