### PR TITLE
fix: preserve rest properties for plain objects

### DIFF
--- a/.changeset/silent-otters-rescue.md
+++ b/.changeset/silent-otters-rescue.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: preserve rest properties for plain objects

--- a/packages/qwik/src/core/qwik.core.api.md
+++ b/packages/qwik/src/core/qwik.core.api.md
@@ -1100,7 +1100,7 @@ export type ResourceReturn<T> = {
 };
 
 // @internal (undocumented)
-export const _restProps: (props: PropsProxy | Record<PropertyKey, unknown>, omit?: string[], target?: Props) => Props;
+export const _restProps: (props: unknown, omit?: string[], target?: Props) => Props;
 
 // @internal (undocumented)
 export const _reT: (input: TaskCtx) => void;

--- a/packages/qwik/src/core/qwik.core.api.md
+++ b/packages/qwik/src/core/qwik.core.api.md
@@ -1100,7 +1100,7 @@ export type ResourceReturn<T> = {
 };
 
 // @internal (undocumented)
-export const _restProps: (props: PropsProxy, omit?: string[], target?: Props) => Props;
+export const _restProps: (props: PropsProxy | Record<PropertyKey, unknown>, omit?: string[], target?: Props) => Props;
 
 // @internal (undocumented)
 export const _reT: (input: TaskCtx) => void;

--- a/packages/qwik/src/core/shared/utils/prop.ts
+++ b/packages/qwik/src/core/shared/utils/prop.ts
@@ -3,20 +3,50 @@ import { EffectProperty } from '../../reactive-primitives/types';
 import { trackSignalAndAssignHost } from '../../use/use-core';
 import { JSXNodeImpl } from '../jsx/jsx-node';
 import { type Props } from '../jsx/jsx-runtime';
-import { createPropsProxy, directGetPropsProxyProp, type PropsProxy } from '../jsx/props-proxy';
+import {
+  createPropsProxy,
+  directGetPropsProxyProp,
+  isPropsProxy,
+  type PropsProxy,
+} from '../jsx/props-proxy';
 import type { JSXNodeInternal } from '../jsx/types/jsx-node';
 import type { Container, HostElement } from '../types';
 import { _CONST_PROPS, _VAR_PROPS } from './constants';
 import { NON_SERIALIZABLE_MARKER_PREFIX, QDefaultSlot } from './markers';
 
 const _hasOwnProperty = Object.prototype.hasOwnProperty;
+const _propertyIsEnumerable = Object.prototype.propertyIsEnumerable;
 
 export function isSlotProp(prop: string): boolean {
   return !prop.startsWith('q:') && !prop.startsWith(NON_SERIALIZABLE_MARKER_PREFIX);
 }
 
 /** @internal */
-export const _restProps = (props: PropsProxy, omit: string[] = [], target: Props = {}) => {
+export const _restProps = (
+  props: PropsProxy | Record<PropertyKey, unknown>,
+  omit: string[] = [],
+  target: Props = {}
+) => {
+  // The optimizer can apply this transform to plain, non-component objects.
+  // Fall back to native object-rest copying so it cannot silently lose data.
+  if (!isPropsProxy(props)) {
+    const source = props as Record<PropertyKey, unknown>;
+    for (const key of Reflect.ownKeys(source)) {
+      if (
+        _propertyIsEnumerable.call(source, key) &&
+        (typeof key === 'symbol' || !omit.includes(key))
+      ) {
+        Object.defineProperty(target, key, {
+          value: source[key],
+          enumerable: true,
+          configurable: true,
+          writable: true,
+        });
+      }
+    }
+    return target;
+  }
+
   let constPropsTarget: Props | null = null;
   const constProps = props[_CONST_PROPS];
   if (constProps) {

--- a/packages/qwik/src/core/shared/utils/prop.ts
+++ b/packages/qwik/src/core/shared/utils/prop.ts
@@ -3,16 +3,12 @@ import { EffectProperty } from '../../reactive-primitives/types';
 import { trackSignalAndAssignHost } from '../../use/use-core';
 import { JSXNodeImpl } from '../jsx/jsx-node';
 import { type Props } from '../jsx/jsx-runtime';
-import {
-  createPropsProxy,
-  directGetPropsProxyProp,
-  isPropsProxy,
-  type PropsProxy,
-} from '../jsx/props-proxy';
+import { createPropsProxy, directGetPropsProxyProp, isPropsProxy } from '../jsx/props-proxy';
 import type { JSXNodeInternal } from '../jsx/types/jsx-node';
 import type { Container, HostElement } from '../types';
 import { _CONST_PROPS, _VAR_PROPS } from './constants';
 import { NON_SERIALIZABLE_MARKER_PREFIX, QDefaultSlot } from './markers';
+import { isObject } from './types';
 
 const _hasOwnProperty = Object.prototype.hasOwnProperty;
 const _propertyIsEnumerable = Object.prototype.propertyIsEnumerable;
@@ -22,16 +18,21 @@ export function isSlotProp(prop: string): boolean {
 }
 
 /** @internal */
-export const _restProps = (
-  props: PropsProxy | Record<PropertyKey, unknown>,
-  omit: string[] = [],
-  target: Props = {}
-) => {
-  // The optimizer can apply this transform to plain, non-component objects.
-  // Fall back to native object-rest copying so it cannot silently lose data.
-  if (!isPropsProxy(props)) {
-    const source = props as Record<PropertyKey, unknown>;
-    for (const key of Reflect.ownKeys(source)) {
+export const _restProps = (props: unknown, omit: string[] = [], target: Props = {}) => {
+  // The optimizer can apply this transform to plain, non-component objects and
+  // even primitives (e.g. destructuring a string). Guard `isPropsProxy`, whose
+  // `in` check throws on primitives, then fall back to native object-rest
+  // copying so the transform cannot silently lose data.
+  if (!isObject(props) || !isPropsProxy(props)) {
+    // Match native rest-destructuring: `({ ...rest }) => …` throws on nullish.
+    if (props == null) {
+      throw new TypeError(`Cannot destructure '${props}' as it is ${props}.`);
+    }
+    // Box primitives so they get native ToObject rest semantics (e.g. 'ab' -> {0:'a',1:'b'}).
+    const source = Object(props) as Record<PropertyKey, unknown>;
+    const keys = Reflect.ownKeys(source);
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
       if (
         _propertyIsEnumerable.call(source, key) &&
         (typeof key === 'symbol' || !omit.includes(key))

--- a/packages/qwik/src/core/shared/utils/prop.unit.ts
+++ b/packages/qwik/src/core/shared/utils/prop.unit.ts
@@ -52,6 +52,16 @@ describe('_restProps', () => {
       assert.equal(rest.visible, 1);
       assert.isFalse(Object.hasOwn(rest, 'hidden'));
     });
+
+    it('supports primitive object-rest sources', () => {
+      const rest = _restProps('ab');
+      assert.deepEqual({ ...rest }, { 0: 'a', 1: 'b' });
+    });
+
+    it('throws on nullish sources like native rest-destructuring', () => {
+      assert.throws(() => _restProps(null), TypeError);
+      assert.throws(() => _restProps(undefined), TypeError);
+    });
   });
 
   describe('props proxy path', () => {

--- a/packages/qwik/src/core/shared/utils/prop.unit.ts
+++ b/packages/qwik/src/core/shared/utils/prop.unit.ts
@@ -1,0 +1,73 @@
+import { assert, describe, it } from 'vitest';
+import { JSXNodeImpl } from '../jsx/jsx-node';
+import { createPropsProxy } from '../jsx/props-proxy';
+import { _CONST_PROPS, _VAR_PROPS } from './constants';
+import { _restProps } from './prop';
+
+describe('_restProps', () => {
+  describe('plain object fallback', () => {
+    it('copies own enumerable string keys and excludes omitted keys', () => {
+      const rest = _restProps({ drop: 1, keep: 2, also: 3 }, ['drop']);
+      assert.deepEqual({ ...rest }, { keep: 2, also: 3 });
+    });
+
+    it('preserves rest data for a non-component arrow (regression for silent loss)', () => {
+      const requestInit = _restProps({ url: '/api/orders', method: 'POST', body: 'payload' }, [
+        'url',
+      ]) as Record<string, unknown>;
+      assert.equal(requestInit.method, 'POST');
+      assert.equal(requestInit.body, 'payload');
+      assert.isUndefined(requestInit.url);
+    });
+
+    it('handles own __proto__ as a data property without mutating the prototype', () => {
+      const input = JSON.parse('{"drop":1,"__proto__":{"isAdmin":true},"keep":2}');
+      const rest = _restProps(input, ['drop']) as Record<string, unknown> & { isAdmin?: boolean };
+
+      assert.isTrue(Object.hasOwn(rest, '__proto__'));
+      assert.strictEqual(Object.getPrototypeOf(rest), Object.prototype);
+      assert.isUndefined(rest.isAdmin);
+      assert.equal(rest.keep, 2);
+    });
+
+    it('preserves enumerable symbol keys and ignores omit for symbols', () => {
+      const symbolKey = Symbol('key');
+      const rest = _restProps({ drop: 1, [symbolKey]: 2 }, ['drop']);
+      assert.equal(Reflect.get(rest, symbolKey), 2);
+    });
+
+    it('does not copy inherited properties', () => {
+      const proto = { inherited: 'nope' };
+      const input = Object.create(proto);
+      input.own = 'yes';
+      const rest = _restProps(input, []) as Record<string, unknown>;
+      assert.equal(rest.own, 'yes');
+      assert.isFalse(Object.hasOwn(rest, 'inherited'));
+    });
+
+    it('does not copy non-enumerable own properties', () => {
+      const input: Record<string, unknown> = { visible: 1 };
+      Object.defineProperty(input, 'hidden', { value: 2, enumerable: false });
+      const rest = _restProps(input, []) as Record<string, unknown>;
+      assert.equal(rest.visible, 1);
+      assert.isFalse(Object.hasOwn(rest, 'hidden'));
+    });
+  });
+
+  describe('props proxy path', () => {
+    it('returns a props proxy that preserves var and const props minus omitted keys', () => {
+      const proxy = createPropsProxy(
+        new JSXNodeImpl(null, { a: 1, drop: 2 }, { b: 3 }, null, 0, null)
+      );
+      const rest = _restProps(proxy, ['drop']) as any;
+
+      // still a props proxy
+      assert.isTrue(_VAR_PROPS in rest);
+      assert.deepEqual(rest[_VAR_PROPS], { a: 1 });
+      assert.deepEqual(rest[_CONST_PROPS], { b: 3 });
+      assert.equal(rest.a, 1);
+      assert.equal(rest.b, 3);
+      assert.isUndefined(rest.drop);
+    });
+  });
+});


### PR DESCRIPTION
# What is it?

- Bug

# Description

The optimizer applies its props-destructuring transform based on the local shape of an arrow function, not on proof that the argument is a Qwik `PropsProxy`. When that transform is applied to an ordinary object, the runtime `_restProps` helper — which assumed its input was always a `PropsProxy` — silently returned an empty result.

This caused silent data loss for plain, non-component arrow functions and callbacks, even ones with no Qwik API, `$` boundary, or JSX. For example, a framework-independent helper like:

```ts
export const request = ({ url, ...requestInit }: FetchRequest) => fetch(url, requestInit);
```
could have `requestInit` rewritten to an empty object, turning a `POST` into a `GET` and dropping headers and body — a correctness regression for code migrating from v1 to v2.

This PR fixes the runtime path only: `_restProps` now detects a non-proxy input via the canonical `isPropsProxy()` check and falls back to native object-rest semantics:

- copies own enumerable string **and** symbol properties
- excludes omitted keys (symbol keys are never omitted, since the optimizer does not transform computed destructuring keys)
- uses `Object.defineProperty` so an own `__proto__` key becomes a data property instead of mutating the target's prototype

The existing props-proxy path is unchanged, so component props behavior is unaffected.

The broader optimizer component-detection heuristic is a separate concern and is intentionally left to a follow-up design issue; this PR guarantees that optimizer false positives can never cause silent data loss.

Closes #8894

# Checklist

- [x] My code follows the developer guidelines of this project
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [x] I added new tests to cover the fix / functionality
