### PR TITLE
fix(browser-extension): escape qwikloader selector with CSS.escape

### DIFF
--- a/packages/browser-extension/public/qwikloader.js
+++ b/packages/browser-extension/public/qwikloader.js
@@ -114,7 +114,7 @@ const l = (e, t) => Array.from(e.querySelectorAll(t)),
   A = (e, t) => {
     const n = g(t.type),
       o = e + ':' + n,
-      r = q('[q-' + e + '\\:' + n + ']');
+      r = q('[q-' + CSS.escape(o) + ']');
     for (let e = 0; e < r.length; e++) {
       const s = r[e];
       w(s, t, o, n);


### PR DESCRIPTION
Closes #8936

packages/browser-extension/public/qwikloader.js is a hand-copied
vendored build that predates #8920 (it is not regenerated by
scripts/gen-injected-scripts.mjs, which only emits devtools-hook.js
and vnode-bridge.js). Its broadcast helper still constructs:

    q('[q-' + e + '\\:' + n + ']')

escaping only the separator, so a namespaced document/window event
(qwik:foo) leaves a raw colon in the selector and querySelectorAll
throws on every dispatch.

This applies the same fix merged in #8920 upstream, reusing the
already-computed scoped name (o):

    q('[q-' + CSS.escape(o) + ']')

For scope d and event qwik:foo this changes the selector from
[q-d\\:qwik:foo] to [q-d\\:qwik\\:foo], matching #8920's regression
expectation. Syntax verified with node --check.

Longer term, regenerating this file from the current qwikloader.ts
build would prevent future drift; happy to attempt that in a
follow-up if maintainers prefer.