### PR TITLE
fix(router): refresh wrapped loaders after SPA navigation

### DIFF
--- a/.changeset/wrapped-loaders-refresh.md
+++ b/.changeset/wrapped-loaders-refresh.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: refresh wrapped route loader data after SPA navigation

--- a/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/routes/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/routes/index.tsx
@@ -1,7 +1,10 @@
 import { component$ } from '@qwik.dev/core';
-import { Link } from '@qwik.dev/router';
+import { Form, Link } from '@qwik.dev/router';
+import { useDynamicSignIn } from './plugin@dynamic-session';
 
 export default component$(() => {
+  const signIn = useDynamicSignIn();
+
   return (
     <div>
       <h1>Welcome to Qwik Router!</h1>
@@ -13,6 +16,11 @@ export default component$(() => {
           Loaders
         </Link>
       </p>
+      <Form action={signIn}>
+        <button id="prod-session-sign-in" type="submit">
+          Sign in
+        </button>
+      </Form>
     </div>
   );
 });

--- a/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/routes/loaders/child/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/routes/loaders/child/index.tsx
@@ -1,10 +1,17 @@
 import { $, component$ } from '@qwik.dev/core';
 import { routeLoaderQrl } from '@qwik.dev/router';
+import { useDynamicSession } from '../../plugin@dynamic-session';
 
 export const useQrlLoader = routeLoaderQrl($(() => 'qrl loader'));
 
 export default component$(() => {
   const qrlLoader = useQrlLoader();
+  const session = useDynamicSession();
 
-  return <div id="prod-qrl-loader">{qrlLoader.value}</div>;
+  return (
+    <>
+      <div id="prod-qrl-loader">{qrlLoader.value}</div>
+      <div id="prod-session-user">{session.value ?? 'No user'}</div>
+    </>
+  );
 });

--- a/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/routes/plugin@dynamic-session.ts
+++ b/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/routes/plugin@dynamic-session.ts
@@ -1,16 +1,15 @@
 import { globalAction$, type RequestHandler } from '@qwik.dev/router';
-import { createDynamicSession } from './dynamic-session/session.qwik.js';
+import { createDynamicSession } from '../session.qwik.js';
 
-const SESSION_COOKIE = 'qwik-dynamic-session';
-const SESSION_KEY = 'qwik-dynamic-session';
+const SESSION_COOKIE = 'qwik-prod-session';
 
 export const onRequest: RequestHandler = ({ cookie, sharedMap }) => {
-  sharedMap.set(SESSION_KEY, cookie.get(SESSION_COOKIE)?.value ?? null);
+  sharedMap.set(SESSION_COOKIE, cookie.get(SESSION_COOKIE)?.value ?? null);
 };
 
 export const { useDynamicSession } = createDynamicSession();
 
 export const useDynamicSignIn = globalAction$((_data, { cookie, redirect }) => {
   cookie.set(SESSION_COOKIE, 'admin', { path: '/' });
-  throw redirect(302, '/qwikrouter-test/dynamic-session/dashboard/');
+  throw redirect(303, '/qwikrouter-test.prod/loaders/child/');
 });

--- a/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/session.qwik.js
+++ b/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/session.qwik.js
@@ -1,0 +1,5 @@
+import { routeLoader$ } from '@qwik.dev/router';
+
+export const createDynamicSession = () => ({
+  useDynamicSession: routeLoader$(({ sharedMap }) => sharedMap.get('qwik-prod-session')),
+});

--- a/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/dynamic-session/session.qwik.js
+++ b/e2e/qwik-e2e/apps/qwikrouter-test/src/routes/dynamic-session/session.qwik.js
@@ -1,0 +1,5 @@
+import { routeLoader$ } from '@qwik.dev/router';
+
+export const createDynamicSession = () => ({
+  useDynamicSession: routeLoader$(({ sharedMap }) => sharedMap.get('qwik-dynamic-session')),
+});

--- a/e2e/qwik-e2e/tests/qwikrouter/loaders.e2e.ts
+++ b/e2e/qwik-e2e/tests/qwikrouter/loaders.e2e.ts
@@ -92,13 +92,13 @@ test.describe('loaders', () => {
       await expect(loaderId).toHaveText('id: two');
     });
 
-    test('loads a routeLoaderQrl session after an action redirect', async ({ page }) => {
+    test('loads a wrapped route loader session after an action redirect', async ({ page }) => {
       await page.goto('/qwikrouter-test/dynamic-session/login/');
       await page.evaluate(() => ((window as any).__dynamicSessionMarker = true));
       await page.getByRole('button', { name: 'Sign in' }).click();
 
-      await expect(page.locator('#dynamic-session-user')).toHaveText('admin');
       expect(await page.evaluate(() => (window as any).__dynamicSessionMarker)).toBe(true);
+      await expect(page.locator('#dynamic-session-user')).toHaveText('admin');
     });
 
     test('loads routeLoaderQrl after production SPA navigation', async ({ page }) => {
@@ -108,6 +108,17 @@ test.describe('loaders', () => {
 
       await expect(page.locator('#prod-qrl-loader')).toHaveText('qrl loader');
       expect(await page.evaluate(() => (window as any).__prodLoaderMarker)).toBe(true);
+    });
+
+    test('loads a wrapped route loader session after a production action redirect', async ({
+      page,
+    }) => {
+      await page.goto('/qwikrouter-test.prod/');
+      await page.evaluate(() => ((window as any).__prodSessionMarker = true));
+      await page.locator('#prod-session-sign-in').click();
+
+      expect(await page.evaluate(() => (window as any).__prodSessionMarker)).toBe(true);
+      await expect(page.locator('#prod-session-user')).toHaveText('admin');
     });
   });
 

--- a/packages/qwik-router/src/buildtime/vite/plugin.ts
+++ b/packages/qwik-router/src/buildtime/vite/plugin.ts
@@ -3,7 +3,7 @@ import type { QwikVitePlugin } from '@qwik.dev/core/optimizer';
 import fs from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { basename, extname, join, resolve } from 'node:path';
-import { findExports } from 'mlly';
+import { findExports, findStaticImports, parseStaticImport } from 'mlly';
 import type {
   ConfigEnv,
   EnvironmentOptions,
@@ -114,7 +114,7 @@ export function addRouteLoaderHash(
   filePath: string,
   hash: string
 ) {
-  const normalizedPath = normalizePath(filePath);
+  const normalizedPath = normalizePath(filePath.split(/[?#]/, 1)[0]);
   const existing = loadersByFile.get(normalizedPath);
   if (!existing) {
     loadersByFile.set(normalizedPath, [hash]);
@@ -128,7 +128,7 @@ export function addRouteLoaderHash(
 }
 
 export function clearRouteLoaderHashes(loadersByFile: Map<string, string[]>, filePath: string) {
-  return loadersByFile.delete(normalizePath(filePath));
+  return loadersByFile.delete(normalizePath(filePath.split(/[?#]/, 1)[0]));
 }
 
 export function isRouterSourceFilePath(filePath: string) {
@@ -187,7 +187,7 @@ export async function findRouteLoaderSourceFiles(
     owners.add(plugin.filePath);
   }
   await Promise.all(
-    [...owners].map((owner) => collectReExportSources(owner, owner, resolveSource, sources))
+    [...owners].map((owner) => collectRouteLoaderSources(owner, owner, resolveSource, sources))
   );
   return sources;
 }
@@ -203,7 +203,7 @@ function collectRouteLoaderOwners(node: RoutingContext['routeTrie'], owners: Set
   }
 }
 
-async function collectReExportSources(
+async function collectRouteLoaderSources(
   owner: string,
   filePath: string,
   resolveSource: SourceResolver,
@@ -220,29 +220,51 @@ async function collectReExportSources(
   } catch {
     return;
   }
-  await Promise.all(
-    exportEntries.map(async (exp) => {
-      if (!exp.specifier) {
-        return;
+
+  const importedFactories = new Map<string, string>();
+  for (const entry of findStaticImports(code)) {
+    const parsed = parseStaticImport(entry);
+    if (parsed.defaultImport) {
+      importedFactories.set(parsed.defaultImport, entry.specifier);
+    }
+    if (parsed.namedImports) {
+      for (const localName of Object.values(parsed.namedImports)) {
+        importedFactories.set(localName, entry.specifier);
       }
-      const resolved = await resolveSource(exp.specifier, filePath);
-      if (!resolved || resolved.charCodeAt(0) === 0) {
-        return;
+    }
+  }
+
+  const specifiers = new Set<string>();
+  for (const exp of exportEntries) {
+    if (exp.specifier) {
+      specifiers.add(exp.specifier);
+    } else if (/^export\s+(?:const|let|var)\s*{/.test(exp.code)) {
+      const factoryName = code.slice(exp.end).match(/^\s*([\w$]+)(?:\s*<[^;()]*>)?\s*\(/)?.[1];
+      const specifier = factoryName && importedFactories.get(factoryName);
+      if (specifier) {
+        specifiers.add(specifier);
       }
-      const resolvedPath = normalizePath(resolved.split(/[?#]/, 1)[0]);
-      let ownerSources = sources.get(owner);
-      if (!ownerSources) {
-        sources.set(owner, (ownerSources = []));
-      }
-      if (!ownerSources.includes(resolvedPath)) {
-        ownerSources.push(resolvedPath);
-      }
-      if (!seen.has(resolvedPath)) {
-        seen.add(resolvedPath);
-        await collectReExportSources(owner, resolvedPath, resolveSource, sources, seen);
-      }
-    })
-  );
+    }
+  }
+
+  for (const specifier of specifiers) {
+    const resolved = await resolveSource(specifier, filePath);
+    if (!resolved || resolved.charCodeAt(0) === 0) {
+      continue;
+    }
+    const resolvedPath = normalizePath(resolved.split(/[?#]/, 1)[0]);
+    let ownerSources = sources.get(owner);
+    if (!ownerSources) {
+      sources.set(owner, (ownerSources = []));
+    }
+    if (!ownerSources.includes(resolvedPath)) {
+      ownerSources.push(resolvedPath);
+    }
+    if (!seen.has(resolvedPath)) {
+      seen.add(resolvedPath);
+      await collectRouteLoaderSources(owner, resolvedPath, resolveSource, sources, seen);
+    }
+  }
 }
 
 export function invalidateRouterConfigModules(server: ViteDevServer) {

--- a/packages/qwik-router/src/buildtime/vite/plugin.unit.ts
+++ b/packages/qwik-router/src/buildtime/vite/plugin.unit.ts
@@ -35,8 +35,8 @@ describe('qwikRouter plugin', () => {
     });
   });
 
-  describe('route loader re-exports', () => {
-    it('discovers re-exported source files through the resolver', async () => {
+  describe('route loader source discovery', () => {
+    it('discovers re-exported and factory source files through the resolver', async () => {
       const dir = await mkdtemp(join(tmpdir(), 'qwik-router-'));
       try {
         const routeDir = join(dir, 'src/routes/[id]');
@@ -47,9 +47,16 @@ describe('qwikRouter plugin', () => {
         const layout = join(routeDir, 'layout.tsx');
         const barrel = join(loadersDir, 'barrel.ts');
         const data = join(loadersDir, 'data.ts');
+        const plugin = join(dir, 'src/routes/plugin@auth.ts');
+        const auth = join(loadersDir, 'auth.ts');
         await writeFile(layout, `export { useDadJoke } from '~/loaders/barrel';`);
         await writeFile(barrel, `export { useDadJoke } from './data';`);
         await writeFile(data, `export const useDadJoke = 1;`);
+        await writeFile(
+          plugin,
+          `import { QwikAuth$ } from '~/loaders/auth'; export const { useSession } = QwikAuth$<Session>();`
+        );
+        await writeFile(auth, `export const QwikAuth$ = () => ({ useSession: true });`);
 
         const ctx = {
           routeTrie: {
@@ -66,7 +73,7 @@ describe('qwikRouter plugin', () => {
             ],
             children: new Map(),
           },
-          serverPlugins: [],
+          serverPlugins: [{ filePath: plugin }],
         } as any;
 
         const sources = await findRouteLoaderSourceFiles(ctx, async (specifier, importer) => {
@@ -82,6 +89,7 @@ describe('qwikRouter plugin', () => {
           barrel.replaceAll(/\\/g, '/'),
           data.replaceAll(/\\/g, '/'),
         ]);
+        expect(sources.get(plugin)).toEqual([auth.replaceAll(/\\/g, '/')]);
       } finally {
         await rm(dir, { recursive: true, force: true });
       }
@@ -134,6 +142,16 @@ describe('qwikRouter plugin', () => {
   });
 
   describe('routeLoader$ dev cache', () => {
+    it('matches optimized dependency ids with Vite query parameters', () => {
+      const loadersByFile = new Map<string, string[]>();
+      const filePath = '/app/node_modules/@auth/qwik/index.qwik.js';
+
+      addRouteLoaderHash(loadersByFile, `${filePath}?v=123`, 'session');
+
+      expect(loadersByFile.get(filePath)).toEqual(['session']);
+      expect(clearRouteLoaderHashes(loadersByFile, `${filePath}?v=456`)).toBe(true);
+    });
+
     it('dedupes hashes and can replace stale file entries', () => {
       const loadersByFile = new Map<string, string[]>();
 

--- a/packages/qwik-router/src/runtime/src/route-loaders.ts
+++ b/packages/qwik-router/src/runtime/src/route-loaders.ts
@@ -130,9 +130,8 @@ export type RouteLoaderCtx = {
   goto?: NoSerialize<RouteNavigate>;
   /** Client manifest hash for q-loader fetch URLs. */
   manifestHash?: string;
+  routeLoaderCandidates?: Record<string, string>;
 };
-
-type DevRouteLoaderCtx = RouteLoaderCtx & { devRouteLoaderPaths?: Record<string, true> };
 
 export type RouteLoaderState = Record<string, ComputedSignal<unknown>>;
 
@@ -561,15 +560,7 @@ export function getRouteLoaderCtx(requestEv: RequestEventBase): RouteLoaderCtx {
   return ctx;
 }
 
-/**
- * Update the loader paths store on client-side navigation.
- *
- * Only adds/updates entries for loaders present on the new route. Entries for loaders that are NOT
- * on the new route are left untouched — their ComputedSignals keep their prior values, and no
- * track() fires to invalidate them. If the user navigates back to a route where the loader IS
- * present, the path updates and the signal re-fetches. This is the "stale is fine by default"
- * contract: readers see old data until new data arrives.
- */
+/** Update route loader matching state on navigation. */
 export const updateRouteLoaderPaths = (
   ctx: RouteLoaderCtx,
   loaderPaths: Record<string, string> | undefined,
@@ -578,16 +569,10 @@ export const updateRouteLoaderPaths = (
   if (!isServer) {
     ctx.pagePathname = pageUrl.pathname;
     ctx.pageSearch = pageUrl.search;
-    if (isDev) {
-      (ctx as DevRouteLoaderCtx).devRouteLoaderPaths = {};
-    }
-  }
-  if (loaderPaths) {
+    ctx.routeLoaderCandidates = loaderPaths;
+  } else if (loaderPaths) {
     for (const key in loaderPaths) {
       ctx.loaderPaths[key] = loaderPaths[key];
-      if (!isServer && isDev) {
-        (ctx as DevRouteLoaderCtx).devRouteLoaderPaths![key] = true;
-      }
     }
   }
 };
@@ -646,11 +631,23 @@ export const invalidateNavRouteLoaders = (state: RouteLoaderState) => {
   }
 };
 
+export const applyClientRouteLoaderPath = (loaderId: string, ctx: RouteLoaderCtx) => {
+  const currentPath = ctx.routeLoaderCandidates?.[loaderId];
+  if (currentPath) {
+    ctx.loaderPaths[loaderId] = currentPath;
+  } else if (isDev && ctx.pagePathname) {
+    ctx.loaderPaths[loaderId] = ctx.pagePathname;
+  }
+};
+
 export const ensureRouteLoaderSignal = (
   loader: LoaderInternal,
   state: RouteLoaderState,
   routeLoaderCtx: RouteLoaderCtx
 ) => {
+  if (!isServer && routeLoaderCtx.pagePathname) {
+    applyClientRouteLoaderPath(loader.__id, routeLoaderCtx);
+  }
   if (loader.__cacheControl === 'immutable') {
     immutableLoaderIds.add(loader.__id);
   }
@@ -667,16 +664,7 @@ export const ensureRouteLoaderSignals = (
 ) => {
   const loaders = getModuleRouteLoaders(mods);
   for (let i = 0; i < loaders.length; i++) {
-    const loader = loaders[i];
-    // Dev-only safety net for the first SPA nav: the route module isn't transformed yet, so the
-    // client trie has no _R loader hash and the loader would resolve to undefined.
-    if (isDev && !isServer) {
-      const devCtx = routeLoaderCtx as DevRouteLoaderCtx;
-      if (devCtx.pagePathname && !devCtx.devRouteLoaderPaths?.[loader.__id]) {
-        devCtx.loaderPaths[loader.__id] = devCtx.pagePathname;
-      }
-    }
-    ensureRouteLoaderSignal(loader, state, routeLoaderCtx);
+    ensureRouteLoaderSignal(loaders[i], state, routeLoaderCtx);
   }
   return loaders;
 };
@@ -918,11 +906,8 @@ export const routeLoaderQrl = ((
 
   function loader() {
     const state = _resolveContextWithoutSequentialScope(RouteStateContext)!;
-    let signal = state[loader.__id];
-    if (!signal) {
-      const routeLoaderCtx = _resolveContextWithoutSequentialScope(RouteLoaderCtxContext)!;
-      signal = ensureRouteLoaderSignal(loader, state, routeLoaderCtx);
-    }
+    const routeLoaderCtx = _resolveContextWithoutSequentialScope(RouteLoaderCtxContext)!;
+    const signal = ensureRouteLoaderSignal(loader, state, routeLoaderCtx);
     void signal.promise();
     return signal;
   }

--- a/packages/qwik-router/src/runtime/src/route-loaders.unit.ts
+++ b/packages/qwik-router/src/runtime/src/route-loaders.unit.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { _UNINITIALIZED, type SerializationStrategy } from '@qwik.dev/core/internal';
 import {
+  applyClientRouteLoaderPath,
   ensureRouteLoaderSignal,
   getRouteLoaderResponse,
   invalidateNavRouteLoaders,
@@ -13,6 +14,23 @@ import { ServerError } from '../../middleware/request-handler/server-error';
 import type { LoaderInternal } from './types';
 
 describe('route loader execution', () => {
+  it('assigns candidate paths only when their loader is used', () => {
+    const routeLoaderCtx = {
+      loaderPaths: { 'unused-loader': '/previous/' },
+      routeLoaderCandidates: {
+        'session-loader': '/dashboard/',
+        'unused-loader': '/dashboard/',
+      },
+    };
+
+    applyClientRouteLoaderPath('session-loader', routeLoaderCtx);
+
+    expect(routeLoaderCtx.loaderPaths).toEqual({
+      'session-loader': '/dashboard/',
+      'unused-loader': '/previous/',
+    });
+  });
+
   it('stores an uninitialized resume marker for never loaders', () => {
     const state = {} as RouteLoaderState;
     const routeLoaderCtx = { loaderPaths: {} };


### PR DESCRIPTION
Fix wrapped route loaders returning stale data after SPA navigation, including action redirects. Route loader sources are now discovered through imported factories in both development and production builds, with regression coverage for both modes.