### PR TITLE
fix(router): preserve bodyless Cloudflare responses

### DIFF
--- a/.changeset/qwik-bodyless-304-8934.md
+++ b/.changeset/qwik-bodyless-304-8934.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: preserve bodyless Cloudflare responses

--- a/packages/qwik-router/src/middleware/cloudflare-pages/index.ts
+++ b/packages/qwik-router/src/middleware/cloudflare-pages/index.ts
@@ -65,11 +65,16 @@ export function createQwikRouter(opts: QwikRouterCloudflarePagesOptions) {
           },
         },
         getWritableStream: (status, headers, cookies, resolve) => {
-          const { readable, writable } = new TransformStream<Uint8Array>();
-          const response = new Response(readable, {
+          const responseInit = {
             status,
             headers: mergeHeadersCookies(headers, cookies),
-          });
+          };
+          if (status === 204 || status === 205 || status === 304) {
+            resolve(new Response(null, responseInit));
+            return new WritableStream<Uint8Array>();
+          }
+          const { readable, writable } = new TransformStream<Uint8Array>();
+          const response = new Response(readable, responseInit);
           resolve(response);
           return writable;
         },

--- a/packages/qwik-router/src/middleware/cloudflare-pages/index.unit.ts
+++ b/packages/qwik-router/src/middleware/cloudflare-pages/index.unit.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockRequestHandler } = vi.hoisted(() => ({
+  mockRequestHandler: vi.fn(),
+}));
+
+vi.mock('@qwik.dev/core/build', () => ({
+  isDev: false,
+  isServer: true,
+}));
+
+vi.mock('@qwik.dev/core/server', () => ({
+  setServerPlatform: vi.fn(),
+}));
+
+vi.mock('@qwik.dev/router/middleware/request-handler', () => ({
+  _TextEncoderStream_polyfill: TextEncoderStream,
+  getErrorHtml: vi.fn(),
+  isStaticPath: vi.fn(() => false),
+  mergeHeadersCookies: vi.fn((headers) => headers),
+  requestHandler: mockRequestHandler,
+}));
+
+import { createQwikRouter } from './index';
+
+describe('createQwikRouter()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns a null body for 304 responses', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockRequestHandler.mockImplementation(async (serverRequestEv) => {
+      let resolve!: (response: Response) => void;
+      const response = new Promise<Response>((r) => (resolve = r));
+      const stream = serverRequestEv.getWritableStream(
+        304,
+        new Headers({ ETag: '"resource"' }),
+        { headers: () => [] },
+        resolve
+      );
+      await stream.getWriter().close();
+      return { completion: Promise.resolve(), response };
+    });
+
+    const handler = createQwikRouter({ render: vi.fn() } as any);
+    const response = await handler(
+      new Request('http://localhost/resource'),
+      { ASSETS: { fetch: vi.fn() } },
+      { waitUntil: vi.fn() }
+    );
+
+    expect(response.status, 'BODYLESS_304_STATUS').toBe(304);
+    expect(response.body).toBeNull();
+    expect(response.headers.get('ETag')).toBe('"resource"');
+  });
+});


### PR DESCRIPTION
# What is it?

- Bug

# Description

A bodyless response passed to `RequestEvent.send()` still acquires a writable stream. The Cloudflare Pages adapter currently backs that stream with a `TransformStream`, so constructing the final response throws when the status is `204`, `205`, or `304` and the request is returned as a 500.

This change resolves body-forbidden statuses with a null-body `Response` while preserving merged headers and cookies. Other statuses retain the existing streaming response path.

A focused adapter test exercises a `304 Not Modified` response and verifies that its status, null body, and `ETag` header survive the Qwik response-completion path.

Fixes #8934.

# Checklist

- [x] My code follows the developer guidelines of this project
- [x] I performed a self-review of my own code
- [x] I added a patch changeset
- [x] I added a focused regression test