### PR TITLE
fix(docs): scope crossOriginIsolated to the REPL

### DIFF
--- a/packages/docs/public/_headers
+++ b/packages/docs/public/_headers
@@ -1,5 +1,20 @@
 /*
   Cache-Control: public, max-age=3600, s-maxage=3600;
+
+# Only the REPL needs crossOriginIsolated; site-wide it blocks third-party images.
+/playground*
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Embedder-Policy: require-corp
+
+/tutorial*
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Embedder-Policy: require-corp
+
+/examples*
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Embedder-Policy: require-corp
+
+/repl*
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Embedder-Policy: require-corp
 

--- a/packages/docs/src/routes/layout.tsx
+++ b/packages/docs/src/routes/layout.tsx
@@ -1,16 +1,14 @@
 import type { RequestHandler } from '@qwik.dev/router';
 import { component$, Slot } from '@qwik.dev/core';
-import { setReplCorsHeaders } from '~/utils/utils';
 
 export default component$(() => {
   return <Slot />;
 });
 
-export const onGet: RequestHandler = ({ cacheControl, headers }) => {
+export const onGet: RequestHandler = ({ cacheControl }) => {
   // cache for pages using this layout
   cacheControl({
     public: true,
     maxAge: 3600,
   });
-  setReplCorsHeaders(headers);
 };

--- a/packages/docs/vite.config.ts
+++ b/packages/docs/vite.config.ts
@@ -12,7 +12,7 @@ import type { ShikiTransformer } from '@shikijs/types';
 import tailwindcss from '@tailwindcss/vite';
 import path, { resolve } from 'node:path';
 // import { qwikDevtools } from '@qwik.dev/devtools';
-import { defineConfig, loadEnv, type Plugin, type UserConfig } from 'vite';
+import { defineConfig, loadEnv, type Connect, type Plugin, type UserConfig } from 'vite';
 import { compiledStringPlugin } from '../../scripts/compiled-string-plugin.js';
 import { docsUpdatedData } from './vite-docs-updated';
 import { examplesData, playgroundData, rawSource, tutorialData } from './vite.repl-apps';
@@ -57,6 +57,28 @@ const muteWarningsPlugin = (warningsToIgnore: string[][]): Plugin => {
         this.warn('Some of your muted warnings never appeared during the build process:');
         diff.forEach((m) => this.warn(`- ${m.join(': ')}`));
       }
+    },
+  };
+};
+
+/** Paths that host the REPL, which needs crossOriginIsolated for its SharedArrayBuffer. */
+const REPL_PATHS = ['/playground', '/tutorial', '/examples', '/repl'];
+
+const crossOriginIsolateRepl = (): Plugin => {
+  const isolateRepl: Connect.NextHandleFunction = (req, res, next) => {
+    if (REPL_PATHS.some((replPath) => req.url?.startsWith(replPath))) {
+      res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+      res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+    }
+    next();
+  };
+  return {
+    name: 'cross-origin-isolate-repl',
+    configureServer: (server) => {
+      server.middlewares.use(isolateRepl);
+    },
+    configurePreviewServer: (server) => {
+      server.middlewares.use(isolateRepl);
     },
   };
 };
@@ -153,8 +175,6 @@ export default defineConfig(({ mode }) => {
     preview: {
       headers: {
         'Cache-Control': 'public, max-age=600',
-        'Cross-Origin-Opener-Policy': 'same-origin',
-        'Cross-Origin-Embedder-Policy': 'require-corp',
       },
     },
     define: {
@@ -182,6 +202,7 @@ export default defineConfig(({ mode }) => {
     },
 
     plugins: [
+      crossOriginIsolateRepl(),
       qds({ icons: true, asChild: true }),
       // some imported react code has sourcemap issues
       muteWarningsPlugin([
@@ -248,11 +269,6 @@ export default defineConfig(({ mode }) => {
     clearScreen: false,
     server: {
       port: 3000,
-      // Needed for the REPL SharedArrayBuffer
-      headers: {
-        'Cross-Origin-Opener-Policy': 'same-origin',
-        'Cross-Origin-Embedder-Policy': 'require-corp',
-      },
     },
   } as UserConfig;
 });


### PR DESCRIPTION
# What is it?
- Bug

# Description
The contributor badges at the bottom of docs pages were all broken. `Cross-Origin-Embedder-Policy: require-corp` was set site-wide (root layout, `_headers`, and the vite dev/preview servers), and GitHub's `github.com/<user>.png` redirect carries no CORP header, so Chrome blocked every avatar with `ERR_BLOCKED_BY_RESPONSE.NotSameOriginAfterDefaultedToSameOriginByCoep`.

Only the REPL needs `crossOriginIsolated` (for `SharedArrayBuffer`), so this scopes the headers to `/playground`, `/tutorial`, `/examples` and `/repl` instead of `/*`. Verified locally that the badges load again and that those four paths are still isolated.

Note that `crossOrigin="anonymous"` (tried in #8863) does not help here — the `github.com` redirect has no `Access-Control-Allow-Origin` either, so the CORS-mode fetch fails at the redirect.