### PR TITLE
docs: mark blog hero images as priority for qwik-image

### DIFF
--- a/packages/docs/src/routes/(blog)/blog/components/featured-article.tsx
+++ b/packages/docs/src/routes/(blog)/blog/components/featured-article.tsx
@@ -13,6 +13,7 @@ export const FeaturedArticle = component$(() => {
           <Image
             layout="fullWidth"
             objectFit="fill"
+            priority
             class="transform group-hover:scale-105 transition-transform duration-500"
             src={blogArticles[0].image}
             alt={blogArticles[0].title}

--- a/packages/docs/src/routes/(blog)/blog/components/mdx/article-hero.tsx
+++ b/packages/docs/src/routes/(blog)/blog/components/mdx/article-hero.tsx
@@ -62,7 +62,7 @@ export const ArticleHero = component$<Props>(({ image, authorLinks }) => {
         </div>
       </div>
       <div class="relative max-w-[1280px] pb-4">
-        <Image alt={title} src={image} layout="fullWidth" />
+        <Image alt={title} src={image} layout="fullWidth" priority />
       </div>
     </>
   );

--- a/packages/docs/src/routes/docs/integrations/image-optimization/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/image-optimization/index.mdx
@@ -337,6 +337,8 @@ bun install qwik-image
 
 <Note>This is a pluggable component so devs could connect different image loaders to it (like builder.io or other CDNs)</Note>
 
+<Note>Images load lazily by default. Add the `priority` prop to an above-the-fold image so it loads eagerly with a high fetch priority.</Note>
+
 <CodeSandbox src="/src/routes/demo/integration/img/qwik-image/index.tsx" style={{ height: '40em' }}>
 ```tsx
 import { $, component$ } from '@qwik.dev/core';


### PR DESCRIPTION
# What is it?
- Docs / tests / types / typos

# Description
qwik-image 2.0.4 lazy-loads by default, so the blog featured article and the article hero went lazy too. Both are the LCP image, so they now pass `priority` to stay eager with a high fetch priority.

Also adds a note to the image-optimization docs about the new default.

Supersedes #8704.