### PR TITLE
docs: use Qwik Router names in Cloudflare Workers adapter page

### DIFF
--- a/packages/docs/src/routes/docs/deployments/cloudflare-workers/index.mdx
+++ b/packages/docs/src/routes/docs/deployments/cloudflare-workers/index.mdx
@@ -6,7 +6,7 @@ import PackageManagerTabs from '~/components/package-manager-tabs/index.tsx';
 
 # Cloudflare Workers Adapter
 
-Qwik City Cloudflare Workers adapter allows you to connect Qwik City to [Cloudflare Workers](https://workers.cloudflare.com/).
+Qwik Router Cloudflare Workers adapter allows you to connect Qwik Router to [Cloudflare Workers](https://workers.cloudflare.com/).
 
 ## Installation
 
@@ -79,8 +79,8 @@ To enable local development with access to your Worker's bindings (KV, R2, D1, e
 
 ```ts title="vite.config.ts"
 import { defineConfig, type UserConfig } from "vite";
-import { qwikVite } from "@builder.io/qwik/optimizer";
-import { qwikCity } from "@builder.io/qwik-city/vite";
+import { qwikVite } from "@qwik.dev/core/optimizer";
+import { qwikRouter } from "@qwik.dev/router/vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 let platform = {};
@@ -93,7 +93,7 @@ if (process.env.NODE_ENV === 'development') {
 export default defineConfig(({ command, mode }): UserConfig => {
   return {
     plugins: [
-      qwikCity({
+      qwikRouter({
         platform
       }), 
 // the rest of your code
@@ -290,13 +290,12 @@ When the `cloudflare-workers` adapter is added, a new entry file will be created
 
 ```tsx title="src/entry.cloudflare-pages.tsx"
 import {
-  createQwikCity,
+  createQwikRouter,
   type PlatformCloudflarePages as PlatformCloudflareWorkers,
-} from '@builder.io/qwik-city/middleware/cloudflare-pages';
-import qwikCityPlan from '@qwik-city-plan';
+} from '@qwik.dev/router/middleware/cloudflare-pages';
 import render from './entry.ssr';
 
-const fetch = createQwikCity({ render, qwikCityPlan });
+const fetch = createQwikRouter({ render });
 
 export { fetch };
 ```
@@ -409,8 +408,8 @@ export const onRequest = async ({ platform }) => {
 For better type safety, import the `RequestHandler` and `PlatformCloudflareWorkers` types:
 
 ```tsx
-import { type RequestHandler } from '@builder.io/qwik-city';
-import { type PlatformCloudflarePages as PlatformCloudflareWorkers } from '@builder.io/qwik-city/middleware/cloudflare-pages';
+import { type RequestHandler } from '@qwik.dev/router';
+import { type PlatformCloudflarePages as PlatformCloudflareWorkers } from '@qwik.dev/router/middleware/cloudflare-pages';
 
 export const onGet: RequestHandler<PlatformCloudflareWorkers> = async ({ platform }) => {
   // TypeScript will provide autocompletion for platform.env


### PR DESCRIPTION
# What is it?
- Docs / tests / types / typos

# Description
The Cloudflare Workers deployment page still said Qwik City and used `@builder.io/*` imports. Swapped them for the v2 names, matching the Cloudflare Pages page.

Picks up where #8435 left off — that one missed the `qwikVite` optimizer import and the two `RequestHandler` / platform type imports near the bottom.

Note: the `cloudflare-workers` starter (`starters/adapters/cloudflare-workers/src/entry.cloudflare-pages.tsx`) is still on v1 imports, so `qwik add cloudflare-workers` scaffolds code that doesn't match these docs. Left it out of this PR since it's a code fix, not docs.