### PR TITLE
docs: finish Qwik City to Qwik Router rename in docs and starters

### DIFF
--- a/packages/docs/src/routes/docs/(qwikrouter)/advanced/speculative-module-fetching/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikrouter)/advanced/speculative-module-fetching/index.mdx
@@ -64,7 +64,7 @@ The Qwik build process generates a `q-manifest.json` file. The `q-manifest.json`
 
 This is then further used to generate the `build/q-bundle-graph-xyz.json` file, which is a compact representation of the module graph, including probabilities of which bundlers are more likely to be requested next given a certain bundle has loaded, and is loaded by Qwik to preload QRL segment loading.
 
-Qwik-City also injects all routes with their dependencies into this bundlegraph file.
+Qwik Router also injects all routes with their dependencies into this bundlegraph file.
 
 When a container resumes, it will fetch the bundlegraph file (probably from the cache) and use it to prefetch modules needed for event handlers and routes.
 

--- a/packages/docs/src/routes/docs/(qwikrouter)/api/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikrouter)/api/index.mdx
@@ -443,7 +443,7 @@ test('should render the button and navigate', async () => {
 <Note>If you are using `routeLoader$`s in a Qwik Component that you want to test, you can provide a `loaders` prop to mock the data returned by the loaders</Note>
 
 ```ts title="src/loaders/product.loader.ts"
-import { routeLoader$ } from '@builder.io/qwik-city';
+import { routeLoader$ } from '@qwik.dev/router';
 
 export const useProductData = routeLoader$(async () => {
   const res = await fetch('https://.../product');

--- a/packages/docs/src/routes/docs/(qwikrouter)/guides/mdx/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikrouter)/guides/mdx/index.mdx
@@ -212,7 +212,7 @@ Menus are contextual data declared with `menu.md` files. See [menus file definit
 
 # Dynamic Page Navigation with MDX
 
-When working with documentation or content-heavy pages in Qwik City, you often need to generate a table of contents or sidebar navigation based on the page's content. Qwik City provides a built-in solution for this through the `useContent()` hook, which can automatically extract headings from your MDX files.
+When working with documentation or content-heavy pages in Qwik Router, you often need to generate a table of contents or sidebar navigation based on the page's content. Qwik Router provides a built-in solution for this through the `useContent()` hook, which can automatically extract headings from your MDX files.
 
 ## Using `useContent()` for Page Navigation
 

--- a/packages/docs/src/routes/docs/(qwikrouter)/layout/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikrouter)/layout/index.mdx
@@ -117,7 +117,7 @@ When you run the app, Qwik will render the `About` nested inside the `RootLayout
 
 ## Named Slots in Layouts
 
-A layout can define multiple named [`<Slot />`](/docs/components/slots/) areas (for example a sidebar, a breadcrumb bar, or a secondary action bar). Because the Qwik City router passes each page as a single component to its parent layout, using named slots requires a special technique: the page's `default export` must be an **inline component** (a plain function) instead of a `component$`.
+A layout can define multiple named [`<Slot />`](/docs/components/slots/) areas (for example a sidebar, a breadcrumb bar, or a secondary action bar). Because the Qwik Router passes each page as a single component to its parent layout, using named slots requires a special technique: the page's `default export` must be an **inline component** (a plain function) instead of a `component$`.
 
 ### Why inline components?
 

--- a/packages/docs/src/routes/docs/deployments/index.mdx
+++ b/packages/docs/src/routes/docs/deployments/index.mdx
@@ -142,7 +142,7 @@ However, if the origin of your application is not static because you're hosting 
 
 ```ts
 // Provide ORIGIN=https://example.com in your environment
-createQwikCity({
+createQwikRouter({
   origin: process.env.ORIGIN,
 });
 ```
@@ -150,7 +150,7 @@ createQwikCity({
 2) Compute origin using forwarded headers (common when behind proxies). Use the headers your proxy provides, e.g. `X-Forwarded-Proto` and `X-Forwarded-Host`:
 
 ```ts
-createQwikCity({
+createQwikRouter({
   getOrigin(req) {
     const proto = req.headers['x-forwarded-proto'] as string | undefined;
     const host = req.headers['x-forwarded-host'] as string | undefined || (req.headers.host as string | undefined);
@@ -164,7 +164,7 @@ createQwikCity({
 
 ```ts
 // starters/adapters/cloud-run entry (illustrative)
-createQwikCity({
+createQwikRouter({
   getOrigin(req) {
     // Cloud Run sets X-Forwarded-Proto and Host headers
     const proto = req.headers['x-forwarded-proto'] as string | undefined;

--- a/packages/docs/src/routes/docs/integrations/authjs/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/authjs/index.mdx
@@ -111,7 +111,7 @@ When migrating from `@builder.io/qwik-auth` to `@auth/qwik`, there are a couple 
 ```diff 
    export default defineConfig(({ command, mode }): UserConfig => {
   return {
-    plugins: [qwikCity(), qwikVite(), tsconfigPaths({ root: '.' })],
+    plugins: [qwikRouter(), qwikVite(), tsconfigPaths({ root: '.' })],
     // This tells Vite which dependencies to pre-build in dev mode.
     optimizeDeps: {
       include: ["@auth/qwik"],

--- a/starters/adapters/cloudflare-workers/adapters/cloudflare-workers/vite.config.ts
+++ b/starters/adapters/cloudflare-workers/adapters/cloudflare-workers/vite.config.ts
@@ -1,5 +1,5 @@
-import { cloudflarePagesAdapter as cloudflareWorkersAdapter } from "@builder.io/qwik-city/adapters/cloudflare-pages/vite";
-import { extendConfig } from "@builder.io/qwik-city/vite";
+import { cloudflarePagesAdapter as cloudflareWorkersAdapter } from "@qwik.dev/router/adapters/cloudflare-pages/vite";
+import { extendConfig } from "@qwik.dev/router/vite";
 import baseConfig from "../../vite.config";
 
 export default extendConfig(baseConfig, () => {
@@ -7,7 +7,7 @@ export default extendConfig(baseConfig, () => {
     build: {
       ssr: true,
       rolldownOptions: {
-        input: ["src/entry.cloudflare-pages.tsx", "@qwik-city-plan"],
+        input: ["src/entry.cloudflare-pages.tsx"],
       },
     },
     plugins: [cloudflareWorkersAdapter()],

--- a/starters/adapters/cloudflare-workers/src/entry.cloudflare-pages.tsx
+++ b/starters/adapters/cloudflare-workers/src/entry.cloudflare-pages.tsx
@@ -8,16 +8,15 @@
  *
  */
 import {
-  createQwikCity,
+  createQwikRouter,
   type PlatformCloudflarePages as PlatformCloudflareWorkers,
-} from "@builder.io/qwik-city/middleware/cloudflare-pages";
-import qwikCityPlan from "@qwik-city-plan";
+} from "@qwik.dev/router/middleware/cloudflare-pages";
 import render from "./entry.ssr";
 
 declare global {
-  type QwikCityPlatform = PlatformCloudflareWorkers;
+  type QwikRouterPlatform = PlatformCloudflareWorkers;
 }
 
-const fetch = createQwikCity({ render, qwikCityPlan });
+const fetch = createQwikRouter({ render });
 
 export { fetch };

--- a/starters/features/compiled-i18n/src/components/locale-selector/locale-selector.tsx
+++ b/starters/features/compiled-i18n/src/components/locale-selector/locale-selector.tsx
@@ -1,4 +1,4 @@
-import { component$, getLocale } from "@builder.io/qwik";
+import { component$, getLocale } from "@qwik.dev/core";
 import { _, locales } from "compiled-i18n";
 
 export const LocaleSelector = component$(() => {

--- a/starters/features/compiled-i18n/src/routes/plugin@compiled-i18n.ts
+++ b/starters/features/compiled-i18n/src/routes/plugin@compiled-i18n.ts
@@ -1,6 +1,6 @@
 // ... other imports
 import { guessLocale } from "compiled-i18n";
-import type { RequestHandler } from "@builder.io/qwik-city";
+import type { RequestHandler } from "@qwik.dev/router";
 
 /**
  * Handle incoming requests to determine and set the appropriate locale.

--- a/starters/features/cypress/src/actions/example.action.ts
+++ b/starters/features/cypress/src/actions/example.action.ts
@@ -1,4 +1,4 @@
-import { routeAction$ } from "@builder.io/qwik-city";
+import { routeAction$ } from "@qwik.dev/router";
 
 export const useExampleAction = routeAction$(() => {
   return "This is example action data.";

--- a/starters/features/cypress/src/components/example/example.cy.tsx
+++ b/starters/features/cypress/src/components/example/example.cy.tsx
@@ -1,5 +1,5 @@
-import { $, component$ } from "@builder.io/qwik";
-import { QwikCityMockProvider } from "@builder.io/qwik-city";
+import { $, component$ } from "@qwik.dev/core";
+import { QwikRouterMockProvider } from "@qwik.dev/router";
 
 import { ExampleTest } from "./example";
 import { useExampleLoader } from "../../loaders/example.loader";
@@ -25,9 +25,9 @@ const Template = component$((props: { flag: boolean }) => {
   ];
 
   return (
-    <QwikCityMockProvider loaders={loadersMock} actions={actionsMock}>
+    <QwikRouterMockProvider loaders={loadersMock} actions={actionsMock}>
       <ExampleTest flag={props.flag} />
-    </QwikCityMockProvider>
+    </QwikRouterMockProvider>
   );
 });
 

--- a/starters/features/cypress/src/loaders/example.loader.ts
+++ b/starters/features/cypress/src/loaders/example.loader.ts
@@ -1,4 +1,4 @@
-import { routeLoader$ } from "@builder.io/qwik-city";
+import { routeLoader$ } from "@qwik.dev/router";
 
 export const useExampleLoader = routeLoader$(() => {
   return "This is example loader data.";


### PR DESCRIPTION
# What is it?
- Docs / tests / types / typos

# Description
Swept the repo for leftover Qwik City naming that should be Qwik Router. Follow-up to #8955, which covered the Cloudflare Workers page only.

Docs: six pages under `docs/` still said Qwik City in prose or used `@builder.io/qwik-city` / `qwikCity()` / `createQwikCity()` in examples.

Starters: the `cloudflare-workers` adapter and the `cypress` and `compiled-i18n` features were still on v1 imports, so `qwik add cloudflare-workers` (and the other two) scaffolded projects that don't build on v2. The cloudflare-pages adapter beside them was already migrated — these were just missed.

Left alone on purpose: blog posts (historical), the upgrade guide and both deprecated-features pages (they show the old names deliberately), the deprecated `createQwikCity` / `QwikCityMockProvider` aliases in `packages/qwik-router`, generated `api.json` / `.api.md`, and third-party URLs that contain `qwikcity`.