### PR TITLE
fix(core): widen the vitest peer range to allow Vitest 4

### DIFF
--- a/.changeset/widen-vitest-peer-range.md
+++ b/.changeset/widen-vitest-peer-range.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: widen the `vitest` peer range to `>=2 <5` so Vitest 4 no longer warns

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -162,7 +162,7 @@
   "peerDependencies": {
     "prettier": "*",
     "vite": ">=8 <9",
-    "vitest": ">=2 <4"
+    "vitest": ">=2 <5"
   },
   "peerDependenciesMeta": {
     "vitest": {


### PR DESCRIPTION
Closes #8958.

`@qwik.dev/core` declares `"vitest": ">=2 <4"`, which excludes Vitest 4 and emits a peer warning for anyone on the current release.

The bound looks stale rather than intentional:

- `packages/qwik/package.json` already dev-depends on `vitest@4.1.10`, so Qwik's own suite runs on Vitest 4 today.
- Vitest 4 declares `"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"`, so it covers the Vite 8 that Qwik 2 requires.

I verified it against an app on `@qwik.dev/core@2.0.0-beta.40` with `vitest@4.1.11` + `vite@8.2.2`: the suite passes, including a spec that uses `createDOM()` from `@qwik.dev/core/testing`.

This widens the range to `>=2 <5`. Happy to use an open-ended `>=2` instead if you'd prefer not to have to bump this again.
