### PR TITLE
fix(router): prerendered pages 404 on redirect and HEAD requests

### DIFF
--- a/.changeset/lucky-pans-repeat.md
+++ b/.changeset/lucky-pans-repeat.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: prerendered pages without a trailing slash now redirect instead of returning 404

--- a/.changeset/tidy-moons-shave.md
+++ b/.changeset/tidy-moons-shave.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: HEAD requests for prerendered pages returned 404 instead of the page headers

--- a/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers-core.ts
+++ b/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers-core.ts
@@ -38,6 +38,7 @@ import { loaderHandler } from './handlers/loader-handler';
 import { jsonRequestWrapper } from './handlers/json-request-wrapper';
 import { actionHandler } from './handlers/action-handler';
 import { IsQLoader, QLoaderId } from './request-path';
+import { isStaticPath } from './static-paths';
 import type { ErrorCodes, RequestEvent, RequestEventBase, RequestHandler } from './types';
 import { QACTION_KEY, QFN_KEY } from '../../runtime/src/constants';
 import { resolveRouteConfig } from '../../runtime/src/head';
@@ -122,9 +123,7 @@ function createResolveRequestHandlers() {
       requestHandlers.push(loaderHandler(routeLoaders, route.$loaderPaths$));
       // Per-action handler: returns JSON and exits if IsQAction + Accept: json
       requestHandlers.push(actionHandler(routeActions));
-      if (!route.$notFound$) {
-        requestHandlers.push(fixTrailingSlash);
-      }
+      requestHandlers.push(route.$notFound$ ? fixStaticTrailingSlash : fixTrailingSlash);
     }
 
     if (isPageRoute) {
@@ -645,6 +644,21 @@ function createResolveRequestHandlers() {
     }
   }
 
+  /**
+   * Prerendered pages are pruned from the production server route plan, so a request missing the
+   * canonical trailing slash lands here as not found. Redirect it when the canonical path was
+   * prerendered, and leave a genuine 404 alone.
+   */
+  function fixStaticTrailingSlash(ev: RequestEvent) {
+    const canonicalUrl = new URL(ev.originalUrl);
+    canonicalUrl.pathname = globalThis.__NO_TRAILING_SLASH__
+      ? canonicalUrl.pathname.replace(/\/$/, '')
+      : ensureSlash(canonicalUrl.pathname);
+    if (isStaticPath(ev.request.method, canonicalUrl)) {
+      fixTrailingSlash(ev);
+    }
+  }
+
   function verifySerializable(data: any, qrl: QRL) {
     try {
       _verifySerializable(data, undefined);
@@ -833,6 +847,7 @@ The request origin "${inputOrigin}" does not match the server origin "${origin}"
     actionsMiddleware,
     checkBrand,
     checkCSRF,
+    fixStaticTrailingSlash,
     fixTrailingSlash,
     getPathname,
     isLastModulePageRoute,
@@ -850,6 +865,7 @@ export const {
   actionsMiddleware,
   checkBrand,
   checkCSRF,
+  fixStaticTrailingSlash,
   fixTrailingSlash,
   getPathname,
   isLastModulePageRoute,

--- a/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers.unit.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import {
   getPathname,
+  fixStaticTrailingSlash,
   fixTrailingSlash,
   resolveRequestHandlers,
   streamServerFunctionResult,
@@ -16,8 +17,17 @@ import { ServerError } from '@qwik.dev/router/middleware/request-handler';
 import { IsQLoader, QLoaderId } from './request-path';
 import { getRouteLoaderValues } from '../../runtime/src/route-loaders';
 
-function createMockServerRequestEvent(url = 'http://localhost:3000/test'): ServerRequestEvent {
-  const mockRequest = new Request(url);
+const { prerenderedPaths } = vi.hoisted(() => ({ prerenderedPaths: new Set<string>() }));
+vi.mock('./static-paths', () => ({
+  isStaticPath: (method: string, url: URL) =>
+    method === 'GET' && prerenderedPaths.has(url.pathname),
+}));
+
+function createMockServerRequestEvent(
+  url = 'http://localhost:3000/test',
+  method = 'GET'
+): ServerRequestEvent {
+  const mockRequest = new Request(url, { method });
 
   return {
     mode: 'server',
@@ -45,9 +55,13 @@ function createMockServerRequestEvent(url = 'http://localhost:3000/test'): Serve
 
 const justHiModule = { default: () => 'hi' };
 const mockRoute: LoadedRoute = { $routeName$: '/', $params$: {}, $mods$: [justHiModule] };
-function createMockRequestEvent(url = 'http://localhost:3000/test', trailingSlash = true) {
+function createMockRequestEvent(
+  url = 'http://localhost:3000/test',
+  trailingSlash = true,
+  method = 'GET'
+) {
   globalThis.__NO_TRAILING_SLASH__ = !trailingSlash;
-  const serverRequestEv = createMockServerRequestEvent(url);
+  const serverRequestEv = createMockServerRequestEvent(url, method);
   return createRequestEvent(serverRequestEv, mockRoute, [], '/', vi.fn());
 }
 
@@ -399,6 +413,87 @@ describe('resolve-request-handler', () => {
 
         fixTrailingSlash(requestEv);
       });
+    });
+  });
+
+  describe('fixStaticTrailingSlash', () => {
+    beforeEach(() => {
+      prerenderedPaths.clear();
+    });
+
+    it('should redirect to the trailing slash path when it is prerendered', () => {
+      prerenderedPaths.add('/docs/getting-started/');
+      const requestEv = createMockRequestEvent('http://localhost:3000/docs/getting-started', true);
+
+      expect(() => fixStaticTrailingSlash(requestEv)).toThrow(RedirectMessage);
+      expect(requestEv.headers.get('Location')).toBe('/docs/getting-started/');
+    });
+
+    it('should preserve the query string in the redirect', () => {
+      prerenderedPaths.add('/docs/getting-started/');
+      const requestEv = createMockRequestEvent(
+        'http://localhost:3000/docs/getting-started?foo=bar',
+        true
+      );
+
+      expect(() => fixStaticTrailingSlash(requestEv)).toThrow(RedirectMessage);
+      expect(requestEv.headers.get('Location')).toBe('/docs/getting-started/?foo=bar');
+    });
+
+    it('should not redirect when the trailing slash path is not prerendered', () => {
+      const requestEv = createMockRequestEvent('http://localhost:3000/does-not-exist', true);
+
+      fixStaticTrailingSlash(requestEv);
+      expect(requestEv.headers.get('Location')).toBeNull();
+    });
+
+    it('should remove the trailing slash when trailingSlash is false and the path is prerendered', () => {
+      prerenderedPaths.add('/docs/getting-started');
+      const requestEv = createMockRequestEvent(
+        'http://localhost:3000/docs/getting-started/',
+        false
+      );
+
+      expect(() => fixStaticTrailingSlash(requestEv)).toThrow(RedirectMessage);
+      expect(requestEv.headers.get('Location')).toBe('/docs/getting-started');
+    });
+
+    it('should not redirect a non-GET request', () => {
+      prerenderedPaths.add('/docs/getting-started/');
+      const requestEv = createMockRequestEvent(
+        'http://localhost:3000/docs/getting-started',
+        true,
+        'POST'
+      );
+
+      fixStaticTrailingSlash(requestEv);
+      expect(requestEv.headers.get('Location')).toBeNull();
+    });
+
+    it('should not redirect a protocol-relative pathname', () => {
+      prerenderedPaths.add('//evil.com/');
+      const requestEv = createMockRequestEvent('http://localhost:3000//evil.com', true);
+
+      fixStaticTrailingSlash(requestEv);
+      expect(requestEv.headers.get('Location')).toBeNull();
+    });
+  });
+
+  describe('trailing slash handler selection', () => {
+    it('should use fixTrailingSlash for a matched page route', () => {
+      const handlers = resolveRequestHandlers(undefined, mockRoute, 'GET', false, vi.fn());
+
+      expect(handlers).toContain(fixTrailingSlash);
+      expect(handlers).not.toContain(fixStaticTrailingSlash);
+    });
+
+    it('should use fixStaticTrailingSlash for a not-found page route', () => {
+      const notFoundRoute: LoadedRoute = { ...mockRoute, $notFound$: true };
+
+      const handlers = resolveRequestHandlers(undefined, notFoundRoute, 'GET', false, vi.fn());
+
+      expect(handlers).toContain(fixStaticTrailingSlash);
+      expect(handlers).not.toContain(fixTrailingSlash);
     });
   });
 

--- a/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers.unit.ts
@@ -20,7 +20,7 @@ import { getRouteLoaderValues } from '../../runtime/src/route-loaders';
 const { prerenderedPaths } = vi.hoisted(() => ({ prerenderedPaths: new Set<string>() }));
 vi.mock('./static-paths', () => ({
   isStaticPath: (method: string, url: URL) =>
-    method === 'GET' && prerenderedPaths.has(url.pathname),
+    (method === 'GET' || method === 'HEAD') && prerenderedPaths.has(url.pathname),
 }));
 
 function createMockServerRequestEvent(
@@ -456,6 +456,18 @@ describe('resolve-request-handler', () => {
 
       expect(() => fixStaticTrailingSlash(requestEv)).toThrow(RedirectMessage);
       expect(requestEv.headers.get('Location')).toBe('/docs/getting-started');
+    });
+
+    it('should redirect a HEAD request', () => {
+      prerenderedPaths.add('/docs/getting-started/');
+      const requestEv = createMockRequestEvent(
+        'http://localhost:3000/docs/getting-started',
+        true,
+        'HEAD'
+      );
+
+      expect(() => fixStaticTrailingSlash(requestEv)).toThrow(RedirectMessage);
+      expect(requestEv.headers.get('Location')).toBe('/docs/getting-started/');
     });
 
     it('should not redirect a non-GET request', () => {

--- a/packages/qwik-router/src/middleware/request-handler/static-paths.ts
+++ b/packages/qwik-router/src/middleware/request-handler/static-paths.ts
@@ -8,8 +8,8 @@ const staticPaths = new Set(['__QWIK_ROUTER_STATIC_PATHS_ARRAY__']);
  * @internal
  */
 export function isStaticPath(method: string, url: URL) {
-  const verb = method.toUpperCase();
-  if (verb !== 'GET' && verb !== 'HEAD') {
+  method = method.toUpperCase();
+  if (method !== 'GET' && method !== 'HEAD') {
     return false;
   }
   const p = url.pathname;

--- a/packages/qwik-router/src/middleware/request-handler/static-paths.ts
+++ b/packages/qwik-router/src/middleware/request-handler/static-paths.ts
@@ -8,7 +8,8 @@ const staticPaths = new Set(['__QWIK_ROUTER_STATIC_PATHS_ARRAY__']);
  * @internal
  */
 export function isStaticPath(method: string, url: URL) {
-  if (method.toUpperCase() !== 'GET') {
+  const verb = method.toUpperCase();
+  if (verb !== 'GET' && verb !== 'HEAD') {
     return false;
   }
   const p = url.pathname;

--- a/packages/qwik-router/src/middleware/request-handler/static-paths.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/static-paths.unit.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { isStaticPath } from './static-paths';
+
+const url = (pathname: string) => new URL(pathname, 'http://localhost:3000');
+
+describe('isStaticPath', () => {
+  it('should serve build assets for GET', () => {
+    expect(isStaticPath('GET', url('/build/q-abc.js'))).toBe(true);
+    expect(isStaticPath('GET', url('/assets/logo.svg'))).toBe(true);
+  });
+
+  it('should serve build assets for HEAD', () => {
+    expect(isStaticPath('HEAD', url('/build/q-abc.js'))).toBe(true);
+    expect(isStaticPath('HEAD', url('/assets/logo.svg'))).toBe(true);
+  });
+
+  it('should accept a lowercase method', () => {
+    expect(isStaticPath('head', url('/build/q-abc.js'))).toBe(true);
+  });
+
+  it('should reject methods that can change state', () => {
+    for (const method of ['POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']) {
+      expect(isStaticPath(method, url('/build/q-abc.js'))).toBe(false);
+    }
+  });
+
+  it('should reject a path that was not prerendered', () => {
+    expect(isStaticPath('GET', url('/docs/getting-started/'))).toBe(false);
+    expect(isStaticPath('HEAD', url('/docs/getting-started/'))).toBe(false);
+  });
+});


### PR DESCRIPTION
# What is it?
- Bug

# Description
Two bugs with the same cause: prerendered pages are pruned from the production server route plan, so any request that misses the exact static path key falls through to SSR and hits a route that is no longer there.

- `/docs/getting-started` (no trailing slash) rendered a 404 instead of redirecting to `/docs/getting-started/`.
- `HEAD` returned 404 for every prerendered page, including the home page, because `isStaticPath` rejected all non-GET methods.

Neither fix covers the other: a `HEAD` request without the trailing slash needs both. You can see both on any docs preview deployment.
