### PR TITLE
fix(router): remove the broken ./service-worker export

### DIFF
--- a/.changeset/fix-router-service-worker-export.md
+++ b/.changeset/fix-router-service-worker-export.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: drop the `./service-worker` export — it pointed at a file the package doesn't ship, and `setupServiceWorker` is a no-op in v2 anyway

--- a/packages/qwik-router/package.json
+++ b/packages/qwik-router/package.json
@@ -147,10 +147,6 @@
       "types": "./lib/vite/index.d.ts",
       "import": "./lib/vite/index.mjs"
     },
-    "./service-worker": {
-      "types": "./service-worker.d.ts",
-      "import": "./lib/service-worker.mjs"
-    },
     "./package.json": "./package.json"
   },
   "files": [


### PR DESCRIPTION
Closes #8961.

`@qwik.dev/router`'s `./service-worker` export points at `./lib/service-worker.mjs`, which isn't in the published tarball — the package ships `lib/service-worker/index.mjs` instead. `tsc` doesn't catch this (the `types` condition resolves independently of `import`), so it only fails at bundle/runtime:

- Node ESM: `ERR_MODULE_NOT_FOUND`
- Vite/Rolldown: `failed to resolve import "@qwik.dev/router/service-worker"`

Repro: https://github.com/ixcans/qwik-router-service-worker-repro

Rather than repointing `import` at the correct path, this removes the export entirely. `setupServiceWorker` is a documented no-op in v2 (preloading is embedded now) — repointing the path would make the import resolve into a function that silently does nothing, which seemed more likely to mislead than a clear "no such export" at resolve time. Happy to switch to the repoint-the-path version instead if you'd rather keep the export surface unchanged for now — this was flagged as an open choice in the issue.