### PR TITLE
fix(qwik-router): preserve route params on loader request event views

### DIFF
--- a/.changeset/silly-params-lost.md
+++ b/.changeset/silly-params-lost.md
@@ -2,12 +2,4 @@
 '@qwik.dev/router': patch
 ---
 
-fix: preserve route params on loader request event views scoped by `search`
-
-`routeLoader$` with `{ search: [] }` (or an explicit allowlist, or under
-`strictLoaders: true`) on a route with a dynamic segment (e.g.
-`[lang]/index.tsx`) previously received an empty `params` object whenever
-the request URL carried a query string — even though the same request
-without a query string resolved `params` correctly. Route params come from
-matching the pathname, not the query string, so they are now preserved on
-the loader's scoped request event view.
+fix: preserve route params on loaders using a `search` filter

--- a/.changeset/silly-params-lost.md
+++ b/.changeset/silly-params-lost.md
@@ -1,0 +1,13 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: preserve route params on loader request event views scoped by `search`
+
+`routeLoader$` with `{ search: [] }` (or an explicit allowlist, or under
+`strictLoaders: true`) on a route with a dynamic segment (e.g.
+`[lang]/index.tsx`) previously received an empty `params` object whenever
+the request URL carried a query string — even though the same request
+without a query string resolved `params` correctly. Route params come from
+matching the pathname, not the query string, so they are now preserved on
+the loader's scoped request event view.

--- a/packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.unit.ts
@@ -208,8 +208,6 @@ describe('loaderHandler', () => {
     expect(loaderEv.url.search).toBe('?q=shoes');
     expect(loaderEv.request.url).toBe('http://localhost/products/?q=shoes');
     expect(loaderEv.originalUrl.href).toBe('http://localhost/products/?q=shoes');
-    // Route params come from the pathname match, not the query string, and
-    // must be preserved on the filtered view — see #8964.
     expect(loaderEv.params).toEqual({ id: '123' });
     expect(loaderEv.query.get('q')).toBe('shoes');
     expect(loaderEv.query.has('ignored')).toBe(false);

--- a/packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/handlers/loader-handler.unit.ts
@@ -15,6 +15,7 @@ describe('loaderHandler', () => {
       headers,
       request: new Request(`http://localhost/products/${getLoaderName('loader-id', 'manifest')}`),
       url: new URL('http://localhost/products/?q=shoes&page=2&ignored=true'),
+      params: { id: '123' },
       headersSent: false,
       exited: false,
       cacheControl: vi.fn(),
@@ -207,7 +208,9 @@ describe('loaderHandler', () => {
     expect(loaderEv.url.search).toBe('?q=shoes');
     expect(loaderEv.request.url).toBe('http://localhost/products/?q=shoes');
     expect(loaderEv.originalUrl.href).toBe('http://localhost/products/?q=shoes');
-    expect(loaderEv.params).toEqual({});
+    // Route params come from the pathname match, not the query string, and
+    // must be preserved on the filtered view — see #8964.
+    expect(loaderEv.params).toEqual({ id: '123' });
     expect(loaderEv.query.get('q')).toBe('shoes');
     expect(loaderEv.query.has('ignored')).toBe(false);
     expect(requestEv.send).toHaveBeenCalledWith(200, expect.any(String));

--- a/packages/qwik-router/src/middleware/request-handler/handlers/loader-request-event.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/handlers/loader-request-event.unit.ts
@@ -19,8 +19,6 @@ describe('createLoaderRequestEventFactory', () => {
     expect(pageEv.query.has('q')).toBe(false);
     expect(pageEv.request.url).toBe('http://localhost/products/?page=2');
     expect(pageEv.originalUrl.href).toBe('http://localhost/products/?page=2');
-    // Route params (matched from the pathname) are unrelated to the loader's search
-    // filter and must be preserved on the scoped view — see #8964.
     expect(pageEv.params).toEqual({ id: '123' });
 
     expect(queryEv.url.search).toBe('?q=shoes');
@@ -35,11 +33,7 @@ describe('createLoaderRequestEventFactory', () => {
   });
 
   it('preserves route params on a `search: []` loader for a dynamic route, with or without a query string (#8964)', () => {
-    // Regression test: a routeLoader$ with `{ search: [] }` on a route with a
-    // dynamic segment (e.g. `[lang]/index.tsx`) used to receive an empty
-    // `params` object as soon as the request URL carried any query string,
-    // because the scoped view unconditionally set `params: {}` instead of
-    // copying it from the root request event.
+    // Regression: params were dropped when search filtering was active.
     const requestEv = createRequestEv('http://localhost/fr/?foo=bar', { lang: 'fr' });
     const getLoaderRequestEvent = createLoaderRequestEventFactory(requestEv);
     const strictLoader = createLoader('strict-loader', []);

--- a/packages/qwik-router/src/middleware/request-handler/handlers/loader-request-event.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/handlers/loader-request-event.unit.ts
@@ -19,17 +19,36 @@ describe('createLoaderRequestEventFactory', () => {
     expect(pageEv.query.has('q')).toBe(false);
     expect(pageEv.request.url).toBe('http://localhost/products/?page=2');
     expect(pageEv.originalUrl.href).toBe('http://localhost/products/?page=2');
-    expect(pageEv.params).toEqual({});
+    // Route params (matched from the pathname) are unrelated to the loader's search
+    // filter and must be preserved on the scoped view — see #8964.
+    expect(pageEv.params).toEqual({ id: '123' });
 
     expect(queryEv.url.search).toBe('?q=shoes');
     expect(queryEv.query.get('q')).toBe('shoes');
     expect(queryEv.query.has('page')).toBe(false);
     expect(queryEv.request.url).toBe('http://localhost/products/?q=shoes');
     expect(queryEv.originalUrl.href).toBe('http://localhost/products/?q=shoes');
-    expect(queryEv.params).toEqual({});
+    expect(queryEv.params).toEqual({ id: '123' });
 
     pageEv.sharedMap.set('shared', 'value');
     expect(requestEv.sharedMap.get('shared')).toBe('value');
+  });
+
+  it('preserves route params on a `search: []` loader for a dynamic route, with or without a query string (#8964)', () => {
+    // Regression test: a routeLoader$ with `{ search: [] }` on a route with a
+    // dynamic segment (e.g. `[lang]/index.tsx`) used to receive an empty
+    // `params` object as soon as the request URL carried any query string,
+    // because the scoped view unconditionally set `params: {}` instead of
+    // copying it from the root request event.
+    const requestEv = createRequestEv('http://localhost/fr/?foo=bar', { lang: 'fr' });
+    const getLoaderRequestEvent = createLoaderRequestEventFactory(requestEv);
+    const strictLoader = createLoader('strict-loader', []);
+
+    const loaderEv = getLoaderRequestEvent(strictLoader);
+
+    expect(loaderEv).not.toBe(requestEv);
+    expect(loaderEv.url.search).toBe('');
+    expect(loaderEv.params).toEqual({ lang: 'fr' });
   });
 
   it('creates a request event without search when the filtered search is empty', () => {
@@ -110,7 +129,7 @@ describe('createLoaderRequestEventFactory', () => {
       expect(detailsEv.url.href).toBe('http://localhost/products/123/?page=2');
       expect(productsEv.request.url).toBe('http://localhost/products/?page=2');
       expect(productsEv.originalUrl.href).toBe('http://localhost/products/?page=2');
-      expect(productsEv.params).toEqual({});
+      expect(productsEv.params).toEqual({ id: '123' });
     } finally {
       globalThis.__STRICT_LOADERS__ = previousStrictLoaders;
     }
@@ -134,7 +153,8 @@ describe('createLoaderRequestEventFactory', () => {
 });
 
 function createRequestEv(
-  href = 'http://localhost/products/?q=shoes&page=2&ignored=true'
+  href = 'http://localhost/products/?q=shoes&page=2&ignored=true',
+  params: Record<string, string> = { id: '123' }
 ): RequestEventInternal {
   const url = new URL(href);
   const requestEv = {
@@ -142,6 +162,7 @@ function createRequestEv(
     headers: new Headers(),
     request: new Request(url),
     url,
+    params,
     sharedMap: new Map<string, unknown>(),
   } as any;
   requestEv.resolveValue = (loader: LoaderInternal) => loadRouteLoader(loader, requestEv);

--- a/packages/qwik-router/src/runtime/src/route-loaders.ts
+++ b/packages/qwik-router/src/runtime/src/route-loaders.ts
@@ -788,7 +788,7 @@ export const getLoaderRequestEvent = (
         enumerable: true,
       },
       params: {
-        value: {},
+        value: rootRequestEv.params,
         enumerable: true,
       },
       pathname: {


### PR DESCRIPTION
## What is it?

Bug fix

## Description

Fixes #8964.

`getLoaderRequestEvent` (in `route-loaders.ts`) creates a scoped view of the
request event per loader when the loader's `search` filter changes the
effective URL — this is how `{ search: [...] }` (and `strictLoaders`'
implicit `search: []`) lets a loader see only the URL it declared it
depends on.

That scoped view was built with `params: { value: {}, ... }`
unconditionally. Route params come from matching the *pathname*, not the
query string, so filtering search params should never touch them — but the
view discarded them anyway, always handing the loader an empty `params`
object once the URL was scoped.

In practice: any `routeLoader$` with `{ search: [] }` (or an allowlist,
or under `strictLoaders: true`) on a route with a dynamic segment (e.g.
`[lang]/index.tsx`) silently received `params: {}` whenever the request
URL carried a query string of any kind — the exact same request without a
query string resolved `params` correctly. Since it's silent (no error,
no different status unless application code happens to validate the
param), it's easy to only notice once something downstream rejects the
empty value.

Fix: use `rootRequestEv.params` instead of a fresh `{}` when creating the
scoped view.

I also noticed the existing unit tests for this function build their mock
`RequestEvent` without ever setting `params` at all, so `rootRequestEv.params`
was `undefined` for the tests currently asserting `toEqual({})` — they were
passing regardless of what the scoped view did with params, and wouldn't
have caught this regression. I gave the mock a realistic `params: { id:
'123' }` and updated those assertions plus added one test that reproduces
the exact bug from #8964 (dynamic route + `search: []` + a query string).

## Reproduction

Minimal repro (before the fix): https://github.com/tidiview/qwik-router-query-404-repro

I verified the fix against both that minimal repro and the real
production app where we first hit this, applying the one-line change
directly to the built `@qwik.dev/router` output before/after — confirmed
route params are preserved with a query string present, and confirmed no
regression on requests without a query string.

I wasn't able to run the full monorepo test suite locally (a build
dependency — `@babel/generator@8.0.0-rc.5` — requires Node `>=24.11.0`,
and I'm on `24.7.0` here), so I'd appreciate CI double-checking the wider
suite.
