### PR TITLE
fix(router): add wasm to static file MIME types

### DIFF
--- a/.changeset/wasm-mime-type.md
+++ b/.changeset/wasm-mime-type.md
@@ -2,4 +2,4 @@
 '@qwik.dev/router': patch
 ---
 
-fix: serve `.wasm` static files with the `application/wasm` content type. Browsers require it for `WebAssembly.instantiateStreaming`; without it the streaming compile is rejected and runtimes fall back to downloading the binary a second time.
+fix: serve wasm files with the correct content type

--- a/.changeset/wasm-mime-type.md
+++ b/.changeset/wasm-mime-type.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: serve `.wasm` static files with the `application/wasm` content type. Browsers require it for `WebAssembly.instantiateStreaming`; without it the streaming compile is rejected and runtimes fall back to downloading the binary a second time.

--- a/packages/qwik-router/src/middleware/request-handler/mime-types.ts
+++ b/packages/qwik-router/src/middleware/request-handler/mime-types.ts
@@ -40,6 +40,7 @@ export const MIME_TYPES: { [ext: string]: string } = {
   tiff: 'image/tiff',
   ts: 'video/mp2t',
   txt: 'text/plain',
+  wasm: 'application/wasm',
   wbmp: 'image/vnd.wap.wbmp',
   webm: 'video/webm',
   webp: 'image/webp',


### PR DESCRIPTION
## What

Adds `wasm: 'application/wasm'` to the static file MIME table used by the node/express middleware `staticFile` handler.

## Why

`.wasm` assets served by the router's static handler currently go out with no `Content-Type` header at all, because the table has no entry for the extension. Browsers require exactly `application/wasm` for `WebAssembly.instantiateStreaming` / `compileStreaming` (W3C wasm Web API, IANA-registered type), so the streaming compile is rejected:

```
Failed to execute 'compile' on 'WebAssembly': Incorrect response MIME type. Expected 'application/wasm'.
```

Emscripten-based runtimes (Rive, ffmpeg.wasm, etc.) then log `wasm streaming compile failed` / `falling back to ArrayBuffer instantiation` and download the whole binary a second time. We hit this in production with a 2 MB Rive runtime being fetched twice on every page load; the workaround is to set the header manually before calling `staticFile`.

## Notes

- Changeset included (`@qwik.dev/router`, patch).
- The same table exists in `packages/qwik-city` on the `v1` branch — happy to open a backport PR there too if wanted.
