### PR TITLE
docs: remove duplicated words in guides

### DIFF
--- a/packages/docs/src/routes/docs/(qwikrouter)/guides/env-variables/index.mdx
+++ b/packages/docs/src/routes/docs/(qwikrouter)/guides/env-variables/index.mdx
@@ -57,7 +57,7 @@ Build-time variables are powered by [Vite](https://vitejs.dev/guide/env-and-mode
 
 Notice that build-time variables should be considered as **public**, since they will be hardcoded in the browser build, which can be easily read by anyone.
 
-Build-time variables are prefixed by default with `PUBLIC_` and can be accessed with with `import.meta.env.PUBLIC_*`.
+Build-time variables are prefixed by default with `PUBLIC_` and can be accessed with `import.meta.env.PUBLIC_*`.
 
 ### Defining Variables
 

--- a/packages/docs/src/routes/docs/integrations/authjs/index.mdx
+++ b/packages/docs/src/routes/docs/integrations/authjs/index.mdx
@@ -95,7 +95,7 @@ When migrating from `@builder.io/qwik-auth` to `@auth/qwik`, there are a couple 
     };
     ```
 
-2. The setup function and and methods exported by it have changed in `plugin@auth.ts`. Be sure to update the imports for the `useAuthSession`, `useAuthSignin`, and `useAuthSignout` methods anywhere you use them in your app.
+2. The setup function and methods exported by it have changed in `plugin@auth.ts`. Be sure to update the imports for the `useAuthSession`, `useAuthSignin`, and `useAuthSignout` methods anywhere you use them in your app.
 
     ```diff
     import Auth0Provider from "@auth/core/providers/auth0";


### PR DESCRIPTION
## Summary

Removes two accidental duplicated words in the documentation. Text-only corrections with no change to meaning or code.

| File | Before | After |
| --- | --- | --- |
| `docs/(qwikrouter)/guides/env-variables/index.mdx` | "accessed **with with** `import.meta.env`" | "accessed with `import.meta.env`" |
| `docs/integrations/authjs/index.mdx` | "setup function **and and** methods" | "setup function and methods" |

Each duplicate was manually verified to be a genuine error.
