### PR TITLE
fix: fail the SSG route when an <ErrorBoundary> catches

### DIFF
--- a/.changeset/ssg-error-boundary-fails-route.md
+++ b/.changeset/ssg-error-boundary-fails-route.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: fail the SSG route when an `<ErrorBoundary>` catches instead of baking the fallback at 200

--- a/packages/qwik-router/src/middleware/request-handler/request-event-core.ts
+++ b/packages/qwik-router/src/middleware/request-handler/request-event-core.ts
@@ -43,6 +43,7 @@ export const RequestEvSharedNonce = '@nonce';
 export const RequestEvIsRewrite = '@rewrite';
 export const RequestEvShareServerTiming = '@serverTiming';
 export const RequestEvETagCacheKey = '@eTagCacheKey';
+export const RequestEvErrorBoundaryCaught = '@errorBoundaryCaught';
 export const RequestEvHttpStatusMessage = '@httpStatusMessage';
 
 export function createRequestEvent(

--- a/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers-core.ts
+++ b/packages/qwik-router/src/middleware/request-handler/resolve-request-handlers-core.ts
@@ -26,6 +26,7 @@ import { ensureSlash } from '../../utils/pathname';
 import { performETagMatch, hash, normalizeETag, setETagHeader } from './etag-hash';
 import {
   getRequestMode,
+  RequestEvErrorBoundaryCaught,
   RequestEvETagCacheKey,
   RequestEvHttpStatusMessage,
   RequestEvShareServerTiming,
@@ -816,6 +817,9 @@ The request origin "${inputOrigin}" does not match the server origin "${origin}"
           await stream.write((result as any as RenderToStringResult).html);
         }
         boundaryErrored ||= (result as RenderToStreamResult).errorBoundaryCaught === true;
+        if (boundaryErrored) {
+          requestEv.sharedMap.set(RequestEvErrorBoundaryCaught, true);
+        }
       } finally {
         try {
           await stream.ready;

--- a/packages/qwik-router/src/ssg/worker-thread.ts
+++ b/packages/qwik-router/src/ssg/worker-thread.ts
@@ -4,6 +4,7 @@ import {
   renderQwikMiddleware,
   resolveRequestHandlers,
 } from '../middleware/request-handler/resolve-request-handlers-core';
+import { RequestEvErrorBoundaryCaught } from '../middleware/request-handler/request-event-core';
 import { trimInternalPathname } from '../middleware/request-handler/request-path';
 import type { ServerRequestEvent } from '../middleware/request-handler/types';
 import { runQwikRouter } from '../middleware/request-handler/user-response';
@@ -117,7 +118,7 @@ export async function workerThread(sys: System) {
   });
 }
 
-async function workerRender(
+export async function workerRender(
   sys: System,
   opts: SsgHandlerOptions,
   staticRoute: SsgRoute,
@@ -305,10 +306,23 @@ async function workerRender(
       .then((rsp) => {
         if (rsp != null) {
           return rsp.completion.then((r) => {
+            const failRouteOnCaughtBoundary = (completion: unknown) => {
+              if (
+                completion === undefined &&
+                rsp.requestEv.sharedMap.get(RequestEvErrorBoundaryCaught)
+              ) {
+                result.ok = false;
+                result.filePath = null;
+                return new Error(
+                  `An <ErrorBoundary> caught an error while rendering ${staticRoute.pathname}`
+                );
+              }
+              return completion;
+            };
             if (routeWriter) {
-              return closePromise.then(() => r);
+              return closePromise.then(() => failRouteOnCaughtBoundary(r));
             }
-            return r;
+            return failRouteOnCaughtBoundary(r);
           });
         }
       })

--- a/packages/qwik-router/src/ssg/worker-thread.unit.ts
+++ b/packages/qwik-router/src/ssg/worker-thread.unit.ts
@@ -1,0 +1,118 @@
+import { _serialize } from '@qwik.dev/core/internal';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  renderQwikMiddleware,
+  resolveRequestHandlers,
+} from '../middleware/request-handler/resolve-request-handlers-core';
+import { trimInternalPathname } from '../middleware/request-handler/request-path';
+import { runQwikRouter } from '../middleware/request-handler/user-response';
+import { loadRoute } from '../runtime/src/routing';
+import type { SsgHandlerOptions, SsgWorkerRenderResult, System } from './types';
+import { workerRender } from './worker-thread';
+
+const deps: Parameters<typeof workerRender>[5] = {
+  loadRoute,
+  renderQwikMiddleware,
+  resolveRequestHandlers,
+  trimInternalPathname,
+  runQwikRouter,
+  serialize: _serialize,
+};
+
+function createSystem() {
+  const written = new Map<string, string[]>();
+  const sys: System = {
+    createMainProcess: null,
+    createLogger: async () => ({ info: () => {}, error: () => {}, debug: () => {} }),
+    getOptions: () => ({}) as any,
+    ensureDir: async () => {},
+    access: async () => false,
+    createWriteStream: (filePath) => {
+      const chunks: string[] = [];
+      written.set(filePath, chunks);
+      return {
+        write: (chunk: string | Buffer) => {
+          chunks.push(chunk.toString());
+        },
+        end: (callback?: () => void) => callback?.(),
+        on: () => {},
+      };
+    },
+    createTimer: () => () => 0,
+    getRouteFilePath: (pathname) =>
+      `/out${pathname === '/' ? '' : pathname}/index.html`.replace('//', '/'),
+    getLoaderFilePath: (pathname, loaderId) => `/out${pathname}q-data-${loaderId}.json`,
+    getEnv: () => undefined,
+    platform: {},
+  };
+  return { sys, written };
+}
+
+const createRender = ({ earlyCatch = false, lateCatch = false } = {}) =>
+  vi.fn(async (renderOpts: any) => {
+    renderOpts.onBeforeFirstFlush?.({ errorBoundaryCaught: earlyCatch });
+    await renderOpts.stream.write('<!DOCTYPE html><html q:container="paused">fallback</html>');
+    return {
+      flushes: 1,
+      size: 10,
+      isStatic: false,
+      timing: {},
+      errorBoundaryCaught: earlyCatch || lateCatch,
+    };
+  });
+
+function renderRoute(sys: System, render: any) {
+  const opts: SsgHandlerOptions = {
+    outDir: '/out',
+    origin: 'https://example.com',
+    render,
+    qwikRouterConfig: {
+      routes: { _I: async () => ({ default: () => null }) },
+      serverPlugins: undefined,
+      cacheModules: false,
+      basePathname: '/',
+      fallthrough: false,
+    } as any,
+  };
+  return new Promise<SsgWorkerRenderResult>((resolve, reject) => {
+    workerRender(sys, opts, { pathname: '/', params: undefined }, new Set(), resolve, deps).catch(
+      reject
+    );
+  });
+}
+
+describe('SSG worker error boundary handling', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('a healthy render writes the page and stays ok', async () => {
+    const { sys, written } = createSystem();
+    const result = await renderRoute(sys, createRender());
+
+    expect(result.ok).toBe(true);
+    expect(result.error).toBeNull();
+    expect(result.filePath).toBe('/out/index.html');
+    expect(written.get('/out/index.html')?.join('')).toContain('q:container');
+  });
+
+  it('a boundary caught before the first flush fails the route', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { sys } = createSystem();
+    const result = await renderRoute(sys, createRender({ earlyCatch: true }));
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.message).toContain('ErrorBoundary');
+    expect(result.filePath).toBeNull();
+  });
+
+  it('a boundary caught after the first flush fails the route', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { sys } = createSystem();
+    const result = await renderRoute(sys, createRender({ lateCatch: true }));
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.message).toContain('ErrorBoundary');
+    expect(result.filePath).toBeNull();
+  });
+});


### PR DESCRIPTION
# What is it?
- Bug

# Description
Fixes #8977. SSG baked a caught `<ErrorBoundary>` fallback into static HTML at 200 and reported success. The render middleware now records the catch on the request, and the SSG worker fails the route: the build exits 1 and the path stays out of `staticPaths`, so a deployed app would still SSR it.