### PR TITLE
fix(router): duplicate route loader requests

### DIFF
--- a/.changeset/calm-tasks-cleanup.md
+++ b/.changeset/calm-tasks-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: release task subscriptions when components are removed

--- a/.changeset/fresh-routes-fetch.md
+++ b/.changeset/fresh-routes-fetch.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: avoid duplicate loader fetches during SPA navigation

--- a/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/routes/issue8966/a/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/routes/issue8966/a/index.tsx
@@ -1,0 +1,22 @@
+import { component$, useStore, useTask$ } from '@qwik.dev/core';
+import { Link, routeLoader$ } from '@qwik.dev/router';
+
+export const useData = routeLoader$(() => 'a');
+
+export default component$(() => {
+  const data = useData();
+  const local = useStore({ value: data.value });
+
+  useTask$(({ track }) => {
+    local.value = track(() => data.value);
+  });
+
+  return (
+    <>
+      <p>{local.value}</p>
+      <Link id="issue8966-b" href="/qwikrouter-test.prod/issue8966/b/">
+        B
+      </Link>
+    </>
+  );
+});

--- a/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/routes/issue8966/a/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/routes/issue8966/a/index.tsx
@@ -1,11 +1,12 @@
 import { component$, useStore, useTask$ } from '@qwik.dev/core';
-import { Link, routeLoader$ } from '@qwik.dev/router';
+import { Link, routeLoader$, useNavigate } from '@qwik.dev/router';
 
 export const useData = routeLoader$(() => 'a');
 
 export default component$(() => {
   const data = useData();
   const local = useStore({ value: data.value });
+  const navigate = useNavigate();
 
   useTask$(({ track }) => {
     local.value = track(() => data.value);
@@ -17,6 +18,9 @@ export default component$(() => {
       <Link id="issue8966-b" href="/qwikrouter-test.prod/issue8966/b/">
         B
       </Link>
+      <button id="issue8966-goto-b" onClick$={() => navigate('/qwikrouter-test.prod/issue8966/b/')}>
+        B with goto
+      </button>
     </>
   );
 });

--- a/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/routes/issue8966/b/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/routes/issue8966/b/index.tsx
@@ -1,5 +1,7 @@
 import { component$ } from '@qwik.dev/core';
-import { Link } from '@qwik.dev/router';
+import { Link, routeLoader$ } from '@qwik.dev/router';
+
+export const useData = routeLoader$(() => 'b');
 
 export default component$(() => (
   <Link id="issue8966-c" href="/qwikrouter-test.prod/issue8966/c/">

--- a/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/routes/issue8966/b/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/routes/issue8966/b/index.tsx
@@ -1,0 +1,8 @@
+import { component$ } from '@qwik.dev/core';
+import { Link } from '@qwik.dev/router';
+
+export default component$(() => (
+  <Link id="issue8966-c" href="/qwikrouter-test.prod/issue8966/c/">
+    C
+  </Link>
+));

--- a/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/routes/issue8966/c/index.tsx
+++ b/e2e/qwik-e2e/apps/qwikrouter-test.prod/src/routes/issue8966/c/index.tsx
@@ -1,0 +1,3 @@
+import { component$ } from '@qwik.dev/core';
+
+export default component$(() => <p id="issue8966-c-page">C</p>);

--- a/e2e/qwik-e2e/tests/qwikrouter/loaders.e2e.ts
+++ b/e2e/qwik-e2e/tests/qwikrouter/loaders.e2e.ts
@@ -110,6 +110,48 @@ test.describe('loaders', () => {
       expect(await page.evaluate(() => (window as any).__prodLoaderMarker)).toBe(true);
     });
 
+    test('fetches a destination loader once on first SPA navigation', async ({ page }) => {
+      const loaderRequests: string[] = [];
+      page.on('request', (request) => {
+        const pathname = new URL(request.url()).pathname;
+        if (pathname.includes('/issue8966/b/q-loader-')) {
+          loaderRequests.push(pathname);
+        }
+      });
+
+      await page.goto('/qwikrouter-test.prod/issue8966/a/');
+      await page.locator('#issue8966-b').click();
+      await page.waitForURL('**/issue8966/b/');
+      await page.waitForLoadState('networkidle');
+
+      expect(loaderRequests).toHaveLength(1);
+    });
+
+    test('fetches goto loader data only from the loader signal', async ({ page }) => {
+      await page.goto('/qwikrouter-test.prod/issue8966/a/');
+      await page.evaluate(() => {
+        const originalFetch = window.fetch;
+        (window as any).__issue8966LoaderFetchSignals = [];
+        window.fetch = (...args) => {
+          const [input, init] = args;
+          const url =
+            typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+          if (url.includes('/issue8966/b/q-loader-')) {
+            (window as any).__issue8966LoaderFetchSignals.push(!!init?.signal);
+          }
+          return originalFetch(...args);
+        };
+      });
+
+      await page.locator('#issue8966-goto-b').click();
+      await page.waitForURL('**/issue8966/b/');
+      await page.waitForLoadState('networkidle');
+
+      expect(await page.evaluate(() => (window as any).__issue8966LoaderFetchSignals)).toEqual([
+        true,
+      ]);
+    });
+
     test('releases route loader tasks across SPA navigations', async ({ page }) => {
       const loaderRequests: string[] = [];
       page.on('request', (request) => {

--- a/e2e/qwik-e2e/tests/qwikrouter/loaders.e2e.ts
+++ b/e2e/qwik-e2e/tests/qwikrouter/loaders.e2e.ts
@@ -110,6 +110,28 @@ test.describe('loaders', () => {
       expect(await page.evaluate(() => (window as any).__prodLoaderMarker)).toBe(true);
     });
 
+    test('releases route loader tasks across SPA navigations', async ({ page }) => {
+      const loaderRequests: string[] = [];
+      page.on('request', (request) => {
+        const pathname = new URL(request.url()).pathname;
+        if (pathname.includes('/issue8966/a/q-loader-')) {
+          loaderRequests.push(pathname);
+        }
+      });
+
+      await page.goto('/qwikrouter-test.prod/issue8966/a/');
+      await page.locator('#issue8966-b').click();
+      await page.waitForURL('**/issue8966/b/');
+      await page.waitForLoadState('networkidle');
+      loaderRequests.length = 0;
+
+      await page.locator('#issue8966-c').click();
+      await page.waitForURL('**/issue8966/c/');
+      await expect(page.locator('#issue8966-c-page')).toHaveText('C');
+      await page.waitForLoadState('networkidle');
+      expect(loaderRequests).toHaveLength(0);
+    });
+
     test('loads a wrapped route loader session after a production action redirect', async ({
       page,
     }) => {

--- a/packages/qwik-router/src/runtime/src/qwik-router-component.tsx
+++ b/packages/qwik-router/src/runtime/src/qwik-router-component.tsx
@@ -486,8 +486,8 @@ export const useQwikRouter = (props?: QwikRouterProps) => {
     };
 
     if (isBrowser) {
-      // Prefetch: start loading route bundles and optionally loader data
-      prefetchRoute(dest, true, 0.8, manifestHash);
+      // Prefetch bundles; loader signals fetch navigation data below.
+      prefetchRoute(dest, false, 0.8, manifestHash, true);
     }
 
     navResolver.p = new Promise<void>((resolve) => {
@@ -610,10 +610,10 @@ export const useQwikRouter = (props?: QwikRouterProps) => {
         routeLoaderCtx.goto = noSerialize(goto);
       }
       updateRouteLoaderPaths(routeLoaderCtx, loadedRoute.$loaderPaths$, trackUrl);
-      const routeLoaders = ensureRouteLoaderSignals(contentModules, loaderState, routeLoaderCtx);
       if (!isServer) {
         invalidateNavRouteLoaders(loaderState);
       }
+      const routeLoaders = ensureRouteLoaderSignals(contentModules, loaderState, routeLoaderCtx);
       if (shouldInvalidateActionLoaders) {
         // Actions force revalidation (fetch cache: 'reload') for their loaders
         if (actionLoaderHashes !== undefined) {

--- a/packages/qwik/src/core/client/vnode-diff.ts
+++ b/packages/qwik/src/core/client/vnode-diff.ts
@@ -1963,12 +1963,15 @@ export function cleanup(
             const obj = seq[i];
             if (isObject(obj)) {
               const objIsTask = isTask(obj);
-              if (objIsTask && obj.$flags$ & TaskFlags.VISIBLE_TASK) {
-                obj.$flags$ |= TaskFlags.NEEDS_CLEANUP;
-                markVNodeDirty(container, vCursor, ChoreBits.CLEANUP, cursorRoot);
+              if (objIsTask) {
+                clearAllEffects(container, obj);
+                if (obj.$flags$ & TaskFlags.VISIBLE_TASK) {
+                  obj.$flags$ |= TaskFlags.NEEDS_CLEANUP;
+                  markVNodeDirty(container, vCursor, ChoreBits.CLEANUP, cursorRoot);
 
-                // don't call cleanupDestroyable yet, do it by the scheduler
-                continue;
+                  // don't call cleanupDestroyable yet, do it by the scheduler
+                  continue;
+                }
               }
               // Stores and plain signals are only producers; their subscriptions are removed
               // when cleaning the consumers that read them. They don't own reactive backrefs.

--- a/packages/qwik/src/core/client/vnode-diff.unit.tsx
+++ b/packages/qwik/src/core/client/vnode-diff.unit.tsx
@@ -7,6 +7,7 @@ import {
   component$,
   useSignal,
   useStore,
+  useTask$,
   type JSXChildren,
   type JSXOutput,
 } from '@qwik.dev/core';
@@ -2019,6 +2020,32 @@ describe('vNode-diff', () => {
       _flushJournal(journal2);
       await container.$renderPromise$;
       expect(store!.$effects$?.size).toBe(0);
+    });
+
+    it('should clear task effects when removing a component', async () => {
+      const { vParent, container } = vnode_fromJSX(<Fragment />);
+      const signal = createSignal('initial') as SignalImpl;
+
+      const Child = component$(() => {
+        useTask$(({ track }) => track(signal));
+        return <span />;
+      });
+
+      const child = _jsxSorted(Child, null, null, null, 3, null) as unknown as JSXChildren;
+      const journal: VNodeJournal = [];
+      vnode_setProp(vParent, NODE_DIFF_DATA_KEY, child);
+      markVNodeDirty(container, vParent, ChoreBits.NODE_DIFF);
+      _flushJournal(journal);
+      await container.$renderPromise$;
+
+      expect(signal.$effects$?.size).toBeGreaterThan(0);
+
+      const cleanupJournal: VNodeJournal = [];
+      await vnode_diff(container, cleanupJournal, <Fragment />, vParent, vParent, null);
+      _flushJournal(cleanupJournal);
+      await container.$renderPromise$;
+
+      expect(signal.$effects$?.size).toBe(0);
     });
   });
 });


### PR DESCRIPTION
Fix duplicate route loader requests by invalidating existing signals before creating destination signals and limiting goto() prefetching to route bundles