### PR TITLE
fix(preloader): don't force-preload every dynamic import of a certain bundle

### DIFF
--- a/.changeset/fix-preloader-dynamic-import-cascade.md
+++ b/.changeset/fix-preloader-dynamic-import-cascade.md
@@ -1,0 +1,16 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix(preloader): don't force-preload every dynamic import of a certain bundle
+
+When a bundle reaches ~100% probability, the preloader elevated **all** of its
+dependencies — static *and* dynamic — to ~99% and preloaded them, bypassing the
+`maxIdlePreloads` throttle. Static imports are genuinely certain to load with
+their importer, but dynamic imports are a runtime choice. As a result, a certain
+bundle that merely references a large map of lazy imports (e.g. a CMS/router
+component that can render any of N components) would preload all N bundles even
+though only one branch is ever taken.
+
+Dynamic imports now keep propagating multiplicatively (parentProbability ×
+edgeProbability); only static imports are elevated to certain.

--- a/packages/qwik/src/core/preloader/queue.ts
+++ b/packages/qwik/src/core/preloader/queue.ts
@@ -112,9 +112,15 @@ const processAdjustmentFrame = () => {
 
     const probability = 1 - bundle.$inverseProbability$;
     let newInverseProbability: number;
-    if (probability === 1 || probability >= 0.99) {
-      // bundle is requested at max probability, so elevate all its transitive static and dynamic deps to 99% sure
-      newInverseProbability = Math.min(0.01, 1 - dep.$importProbability$);
+    if ((probability === 1 || probability >= 0.99) && dep.$importProbability$ === 1) {
+      // A static import ($importProbability$ === 1) of a (near-)certain bundle is itself
+      // certain to load, so elevate it to 100% (this also lets it bypass the idle-preload
+      // throttle in trigger()). Dynamic imports must NOT inherit their importer's certainty:
+      // otherwise a certain bundle that merely references a large map of lazy imports (e.g. a
+      // CMS/router component that can render any of N components) would force all N of them to
+      // ~99% and preload every one, even though only a single branch is ever taken. Dynamic
+      // deps keep propagating multiplicatively (parentProbability * edgeProbability) below.
+      newInverseProbability = 0;
     } else {
       const newInverseImportProbability = 1 - dep.$importProbability$ * probability;
       /** We need to undo the previous adjustment */

--- a/packages/qwik/src/core/preloader/queue.unit.ts
+++ b/packages/qwik/src/core/preloader/queue.unit.ts
@@ -216,6 +216,58 @@ test('can yield more than once while propagating dependencies', async () => {
   expect(headAppend.mock.calls.length).toBeGreaterThan(1);
 });
 
+test('a certain bundle keeps its dynamic imports at their edge probability', async () => {
+  // Regression test: a certain (probability 1) bundle must not force-elevate its *dynamic*
+  // imports to ~99%. Only static imports ($importProbability$ === 1) are certain to load with
+  // their importer; dynamic imports keep propagating multiplicatively. Otherwise a component
+  // that references a large map of lazy imports would preload every entry in the map.
+  installBrowserGlobals();
+  Object.assign(globalThis, {
+    MessageChannel: undefined,
+  });
+  vi.spyOn(performance, 'now').mockImplementation(() => 0);
+  vi.resetModules();
+  await installTestPlatform();
+
+  const { initPreloader } = await import('./bundle-graph');
+  const { preload, bundles } = await import('./queue');
+
+  // entry-a.js dynamically imports dep-1.js with a 60% edge probability (the -6 marker).
+  initPreloader(['entry-a.js', -6, 3, 'dep-1.js']);
+  preload('entry-a.js', 1);
+  vi.runAllTimers();
+
+  // 60% probability => inverseProbability 0.4. Before the fix this was ~0.01 (99% "sure"),
+  // because the dynamic import inherited its certain importer's probability.
+  const dep = bundles.get('dep-1.js');
+  expect(dep).toBeDefined();
+  expect(dep!.$inverseProbability$).toBeCloseTo(0.4, 5);
+});
+
+test('a certain bundle still elevates its static imports to 100%', async () => {
+  // Guard the other side of the branch: static imports (probability 1, the -10 marker used by
+  // createLinearGraph) of a certain bundle stay certain (inverseProbability 0).
+  installBrowserGlobals();
+  Object.assign(globalThis, {
+    MessageChannel: undefined,
+  });
+  vi.spyOn(performance, 'now').mockImplementation(() => 0);
+  vi.resetModules();
+  await installTestPlatform();
+
+  const { initPreloader } = await import('./bundle-graph');
+  const { preload, bundles } = await import('./queue');
+
+  // entry-a.js statically imports dep-1.js (100% edge probability, the -10 marker).
+  initPreloader(['entry-a.js', -10, 3, 'dep-1.js']);
+  preload('entry-a.js', 1);
+  vi.runAllTimers();
+
+  const dep = bundles.get('dep-1.js');
+  expect(dep).toBeDefined();
+  expect(dep!.$inverseProbability$).toBeCloseTo(0, 5);
+});
+
 test('defers bundle graph re-adjustment to a later task', async () => {
   const document = installBrowserGlobals();
   Object.assign(globalThis, {


### PR DESCRIPTION
## What

`processAdjustmentFrame` in the client preloader elevates **every** dependency of a (near-)certain bundle — static *and* dynamic — to ~99% probability, and bundles at ≥0.99 bypass the `maxIdlePreloads` throttle in `trigger()`. Static imports genuinely load with their importer, but dynamic imports are a runtime choice. So a certain bundle that merely *references* a large map of lazy imports (a CMS/router component that can render any of N components) ends up preloading **all N** bundles even though only one branch is taken.

`packages/qwik/src/core/preloader/queue.ts`:

```js
// before
if (probability === 1 || probability >= 0.99) {
  newInverseProbability = Math.min(0.01, 1 - dep.$importProbability$); // dynamic imports -> ~0.99
} else { /* multiplicative */ }

// after
if ((probability === 1 || probability >= 0.99) && dep.$importProbability$ === 1) {
  newInverseProbability = 0;            // static import of a certain bundle -> certain
} else { /* multiplicative: dynamic imports keep parentProbability * edgeProbability */ }
```

Static imports carry `$importProbability$ === 1` in the bundle graph (encoded before any negative marker); dynamic imports are always `< 1` (build caps them at 0.99 in `convertManifestToBundleGraph`). So the new condition cleanly separates the two.

## Why

Reproduction: a CMS-style registry that maps a slug to one of ~50 lazy components, rendered via a single dynamic component. On a page that renders **one** component, all 50 lazy bundles are fetched.

- SSR `preloaderPost` collects every rendered QRL and hands the list to the client preloader.
- On hydration the dynamic component's QRL resolves → `preload(chunk, 1)`.
- The cascade then elevates all 50 dynamic-import edges of that chunk to ~0.99 and preloads them, unthrottled.
- The build assigns each edge a real probability (~0.6); this cascade discards it.

The served HTML references none of the 50 — it's purely the client preloader following bundle-graph reachability. (SPA navigation is unaffected because that bulk-seed path is SSR-only.)

With this change, dynamic imports retain their edge probability (~0.6) instead of being forced to ~0.99, so they no longer bypass the `maxIdlePreloads` throttle and no longer get treated as certain-to-load.

## Impact / scope

This is a **correctness fix for the probability propagation**. It stops dynamic-import fan-out from bypassing the throttle. Note it does **not** by itself add a minimum-probability cutoff, so under default settings low-probability bundles are still eventually preloaded (just throttled, not as an unthrottled high-priority blast). Fully preventing download of a large lazy map's unused bundles also benefits from a probability threshold — see follow-ups.

Measured on a 50-lazy-component repro (page renders 1 component), distinct unused components fetched:

| | unused fetched |
|---|:--:|
| before | 50 |
| this PR (cascade fix) + a min-probability threshold | **0** |

I have a standalone reproduction repo + a CDP-based measurement harness and can share them if useful.

## Follow-ups (not in this PR)

1. **A configurable minimum-probability threshold** in `trigger()` (e.g. `PreloaderOptions.minProbability`) so apps can opt out of preloading low-likelihood bundles without disabling the preloader entirely. `preloading.md` already anticipates this ("on low-end devices, we may decide to not preload low-likelihood bundles"). Combined with this PR it takes the repro to 0 unused.
2. **Config duplication:** in the shipped build the preloader logic is emitted both inline in the core bundle and as the standalone preloader chunk, each with its own `config`. `maxIdlePreloads` (`config.$maxIdlePreloads$`, threaded via `loadBundleGraph`'s `P` option) only reaches the standalone copy, so the core copy uses the hardcoded default (25) for QRL-resolution-triggered preloads. Worth confirming/fixing so `maxIdlePreloads` (and any future threshold) is honored on that path.

## Tests

Added two unit tests to `queue.unit.ts`:
- a certain bundle keeps its **dynamic** imports at their edge probability (0.6 → inverseProbability 0.4, previously ~0.01);
- a certain bundle still elevates its **static** imports to 100% (inverseProbability 0).

All existing preloader unit tests continue to pass (they only exercise static, probability-1 deps, so behavior there is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
