### PR TITLE
feat(docs): add a build-time blog RSS feed

### DIFF
--- a/packages/docs/src/routes/(blog)/blog/(articles)/partytown-is-now-in-beta/index.mdx
+++ b/packages/docs/src/routes/(blog)/blog/(articles)/partytown-is-now-in-beta/index.mdx
@@ -4,7 +4,7 @@ authors:
   - 'Adam Bradley'
 tags: ['Qwik']
 date: 'December 14, 2021'
-canonical: 'https://www.builder.io/blog/introducing-qwik-starters'
+canonical: 'https://www.builder.io/blog/partytown-is-now-in-beta'
 ---
 
 {/* ---

--- a/packages/docs/src/routes/(blog)/blog/index.tsx
+++ b/packages/docs/src/routes/(blog)/blog/index.tsx
@@ -20,4 +20,12 @@ export default component$(() => {
 
 export const head: DocumentHead = {
   title: 'Qwik Blog',
+  links: [
+    {
+      rel: 'alternate',
+      type: 'application/rss+xml',
+      title: 'Qwik Blog RSS feed',
+      href: '/blog/rss.xml',
+    },
+  ],
 };

--- a/packages/docs/vite-blog-rss.ts
+++ b/packages/docs/vite-blog-rss.ts
@@ -224,11 +224,12 @@ export function readBlogArticles(articlesDir: string, siteUrl = BLOG_SITE_URL): 
 
 function renderArticle(article: BlogRssArticle): string {
   const guid = article.guid ?? article.url;
+  const isGuidPermalink = article.guid === undefined;
   const lines = [
     '    <item>',
     `      <title>${escapeXml(article.title)}</title>`,
     `      <link>${escapeXml(article.url)}</link>`,
-    `      <guid isPermaLink="true">${escapeXml(guid)}</guid>`,
+    `      <guid isPermaLink="${isGuidPermalink}">${escapeXml(guid)}</guid>`,
     `      <pubDate>${escapeXml(article.date.toUTCString())}</pubDate>`,
   ];
 

--- a/packages/docs/vite-blog-rss.ts
+++ b/packages/docs/vite-blog-rss.ts
@@ -1,0 +1,307 @@
+import matter from 'gray-matter';
+import { readdirSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import type { Plugin } from 'vite';
+
+export const BLOG_RSS_FILE = 'blog/rss.xml';
+export const BLOG_SITE_URL = 'https://qwik.dev';
+
+const BLOG_ARTICLES_PATH = join('(blog)', 'blog', '(articles)');
+
+function removeInvalidXmlCharacters(value: string): string {
+  let result = '';
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)!;
+    const isValid =
+      codePoint === 0x9 ||
+      codePoint === 0xa ||
+      codePoint === 0xd ||
+      (codePoint >= 0x20 && codePoint <= 0xd7ff) ||
+      (codePoint >= 0xe000 && codePoint <= 0xfffd) ||
+      (codePoint >= 0x10000 && codePoint <= 0x10ffff);
+    if (isValid) {
+      result += character;
+    }
+  }
+  return result;
+}
+
+export interface BlogRssArticle {
+  title: string;
+  authors: string[];
+  tags: string[];
+  date: Date;
+  url: string;
+  /** Optional stable route identity when the public link is canonicalized elsewhere. */
+  guid?: string;
+  description?: string;
+}
+
+/** Convert a route file path into the public blog pathname. */
+export function fileToBlogPath(relativeFile: string): string {
+  const clean = relativeFile
+    .split(sep)
+    .join('/')
+    .replace(/\([^/]+\)\//g, '')
+    .replace(/index\.mdx?$/, '')
+    .replace(/^\/+|\/+$/g, '');
+
+  return `/blog/${clean}/`;
+}
+
+/** Escape text for use in an XML element or attribute. */
+export function escapeXml(value: string): string {
+  return removeInvalidXmlCharacters(value).replace(/[<>&'"]/g, (character) => {
+    switch (character) {
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '&':
+        return '&amp;';
+      case '"':
+        return '&quot;';
+      case "'":
+        return '&apos;';
+      default:
+        return character;
+    }
+  });
+}
+
+function ensureTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value : `${value}/`;
+}
+
+function toAbsoluteUrl(pathname: string, siteUrl: string): string {
+  return new URL(pathname.replace(/^\/+/, ''), ensureTrailingSlash(siteUrl)).toString();
+}
+
+function asStringList(value: unknown): string[] {
+  const values = Array.isArray(value) ? value : [value];
+  return values
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+/** Parse a frontmatter date without allowing invalid dates into the feed. */
+export function parseBlogDate(value: unknown): Date | null {
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    const parsed = new Date(value.getTime());
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  const raw = String(value).trim();
+  if (!raw) {
+    return null;
+  }
+
+  // ISO calendar dates are already UTC in ECMAScript; do not reinterpret them locally.
+  const isoDate = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw);
+  if (isoDate) {
+    const year = Number(isoDate[1]);
+    const month = Number(isoDate[2]);
+    const day = Number(isoDate[3]);
+    const parsed = new Date(Date.UTC(year, month - 1, day));
+    if (
+      Number.isNaN(parsed.getTime()) ||
+      parsed.getUTCFullYear() !== year ||
+      parsed.getUTCMonth() !== month - 1 ||
+      parsed.getUTCDate() !== day
+    ) {
+      return null;
+    }
+    return parsed;
+  }
+
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  // Blog frontmatter currently stores calendar dates without a timezone. Convert those local
+  // parses to UTC so builds produce the same publication time on every developer machine and CI.
+  const hasTimezone = /(?:Z|[+-]\d{2}(?::?\d{2})?|\b(?:UTC|GMT)\b)\s*$/i.test(raw);
+  if (!hasTimezone) {
+    return new Date(
+      Date.UTC(
+        parsed.getFullYear(),
+        parsed.getMonth(),
+        parsed.getDate(),
+        parsed.getHours(),
+        parsed.getMinutes(),
+        parsed.getSeconds(),
+        parsed.getMilliseconds()
+      )
+    );
+  }
+
+  return parsed;
+}
+
+/** Build one feed item from an article's frontmatter and route pathname. */
+export function parseBlogArticle(
+  data: Record<string, unknown>,
+  pathname: string,
+  siteUrl = BLOG_SITE_URL
+): BlogRssArticle | null {
+  const title = typeof data.title === 'string' ? data.title.trim() : '';
+  const date = parseBlogDate(data.date);
+
+  if (!title || !date) {
+    return null;
+  }
+
+  const canonical = typeof data.canonical === 'string' ? data.canonical.trim() : '';
+  const routeUrl = toAbsoluteUrl(pathname, siteUrl);
+  let url = routeUrl;
+  if (canonical) {
+    try {
+      const candidate = new URL(canonical, url);
+      if (candidate.protocol === 'http:' || candidate.protocol === 'https:') {
+        url = candidate.toString();
+      }
+    } catch {
+      // Keep the generated route URL when frontmatter contains an invalid canonical URL.
+    }
+  }
+
+  const descriptionValue = data.description ?? data.summary;
+  const description = typeof descriptionValue === 'string' ? descriptionValue.trim() : '';
+
+  return {
+    title,
+    authors: asStringList(data.authors),
+    tags: asStringList(data.tags),
+    date,
+    url,
+    ...(url === routeUrl ? {} : { guid: routeUrl }),
+    ...(description ? { description } : {}),
+  };
+}
+
+function* walkIndexFiles(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkIndexFiles(fullPath);
+    } else if (/^index\.mdx?$/.test(entry.name)) {
+      yield fullPath;
+    }
+  }
+}
+
+function sortArticles(articles: BlogRssArticle[]): BlogRssArticle[] {
+  return [...articles].sort((left, right) => {
+    const dateOrder = right.date.getTime() - left.date.getTime();
+    if (dateOrder !== 0) {
+      return dateOrder;
+    }
+    return left.url < right.url ? -1 : left.url > right.url ? 1 : 0;
+  });
+}
+
+/** Read and sort all blog article frontmatter for the RSS feed. */
+export function readBlogArticles(articlesDir: string, siteUrl = BLOG_SITE_URL): BlogRssArticle[] {
+  const files = [...walkIndexFiles(articlesDir)].sort();
+  const articles: BlogRssArticle[] = [];
+
+  for (const file of files) {
+    const pathname = fileToBlogPath(relative(articlesDir, file));
+    const article = parseBlogArticle(matter.read(file).data, pathname, siteUrl);
+    if (article) {
+      articles.push(article);
+    }
+  }
+
+  return sortArticles(articles);
+}
+
+function renderArticle(article: BlogRssArticle): string {
+  const guid = article.guid ?? article.url;
+  const lines = [
+    '    <item>',
+    `      <title>${escapeXml(article.title)}</title>`,
+    `      <link>${escapeXml(article.url)}</link>`,
+    `      <guid isPermaLink="true">${escapeXml(guid)}</guid>`,
+    `      <pubDate>${escapeXml(article.date.toUTCString())}</pubDate>`,
+  ];
+
+  if (article.description) {
+    lines.push(`      <description>${escapeXml(article.description)}</description>`);
+  }
+  if (article.authors.length > 0) {
+    lines.push(`      <dc:creator>${escapeXml(article.authors.join(', '))}</dc:creator>`);
+  }
+  for (const tag of article.tags) {
+    lines.push(`      <category>${escapeXml(tag)}</category>`);
+  }
+
+  lines.push('    </item>');
+  return lines.join('\n');
+}
+
+/** Render a deterministic RSS 2.0 document from blog article metadata. */
+export function renderRssFeed(articles: BlogRssArticle[], siteUrl = BLOG_SITE_URL): string {
+  const sortedArticles = sortArticles(articles);
+  const blogUrl = toAbsoluteUrl('/blog/', siteUrl);
+  const feedUrl = toAbsoluteUrl(`/${BLOG_RSS_FILE}`, siteUrl);
+  const latestArticle = sortedArticles[0];
+  const lines = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">',
+    '  <channel>',
+    '    <title>Qwik Blog</title>',
+    `    <link>${escapeXml(blogUrl)}</link>`,
+    '    <description>Latest articles from the Qwik Blog.</description>',
+    '    <language>en</language>',
+    `    <atom:link href="${escapeXml(feedUrl)}" rel="self" type="application/rss+xml" />`,
+  ];
+
+  if (latestArticle) {
+    lines.push(`    <lastBuildDate>${escapeXml(latestArticle.date.toUTCString())}</lastBuildDate>`);
+  }
+
+  if (sortedArticles.length > 0) {
+    lines.push(sortedArticles.map(renderArticle).join('\n'));
+  }
+
+  lines.push('  </channel>', '</rss>', '');
+  return lines.join('\n');
+}
+
+/** Generate the blog RSS asset during the client-side docs build. */
+export function blogRssData(routesDir: string, siteUrl = BLOG_SITE_URL): Plugin {
+  const articlesDir = join(routesDir, BLOG_ARTICLES_PATH);
+
+  return {
+    name: 'blogRssData',
+    apply: 'build',
+
+    buildStart() {
+      for (const file of walkIndexFiles(articlesDir)) {
+        this.addWatchFile(file);
+      }
+    },
+
+    generateBundle() {
+      // The docs adapter builds client, SSR, and SSG environments separately. RSS is public
+      // static content and should be emitted only by the client environment.
+      if (this.environment.config.consumer !== 'client') {
+        return;
+      }
+
+      const articles = readBlogArticles(articlesDir, siteUrl);
+      this.emitFile({
+        type: 'asset',
+        fileName: BLOG_RSS_FILE,
+        source: renderRssFeed(articles, siteUrl),
+      });
+    },
+  };
+}

--- a/packages/docs/vite-blog-rss.unit.ts
+++ b/packages/docs/vite-blog-rss.unit.ts
@@ -1,0 +1,179 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, test } from 'vitest';
+import {
+  blogRssData,
+  escapeXml,
+  fileToBlogPath,
+  parseBlogArticle,
+  readBlogArticles,
+  renderRssFeed,
+} from './vite-blog-rss';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function createTemporaryArticlesDir() {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'qwik-blog-rss-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function writeArticle(directory: string, relativePath: string, frontmatter: string) {
+  const file = path.join(directory, relativePath);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `---\n${frontmatter}\n---\n\nArticle body\n`);
+}
+
+describe('blog RSS generation', () => {
+  test('converts pathless route groups into public blog paths', () => {
+    expect(fileToBlogPath(path.join('nested', '(articles)', 'post', 'index.mdx'))).toBe(
+      '/blog/nested/post/'
+    );
+  });
+
+  test('escapes XML text and attributes', () => {
+    expect(escapeXml(`A & B < C > D "quoted" 'single'`)).toBe(
+      'A &amp; B &lt; C &gt; D &quot;quoted&quot; &apos;single&apos;'
+    );
+    expect(escapeXml('Qwik 🎉')).toBe('Qwik 🎉');
+  });
+
+  test('uses canonical URLs and falls back to the generated route', () => {
+    const canonical = parseBlogArticle(
+      { title: 'Canonical', date: '2026-01-02', canonical: 'https://example.com/post' },
+      '/blog/post/',
+      'https://qwik.dev'
+    );
+    expect(canonical?.url).toBe('https://example.com/post');
+    expect(canonical?.guid).toBe('https://qwik.dev/blog/post/');
+    expect(
+      parseBlogArticle(
+        { title: 'Fallback', date: '2026-01-02', canonical: 'javascript:bad' },
+        '/blog/fallback/'
+      )?.url
+    ).toBe('https://qwik.dev/blog/fallback/');
+  });
+
+  test('skips articles without a valid title or date', () => {
+    expect(parseBlogArticle({ title: 'Missing date' }, '/blog/missing/')).toBeNull();
+    expect(
+      parseBlogArticle({ title: 'Invalid date', date: 'not-a-date' }, '/blog/invalid/')
+    ).toBeNull();
+    expect(parseBlogArticle({ date: '2026-01-02' }, '/blog/missing-title/')).toBeNull();
+  });
+
+  test('normalizes timezone-free calendar dates to UTC', () => {
+    expect(
+      parseBlogArticle(
+        { title: 'Calendar date', date: 'August 26, 2025' },
+        '/blog/date/'
+      )?.date.toISOString()
+    ).toBe('2025-08-26T00:00:00.000Z');
+    expect(
+      parseBlogArticle(
+        { title: 'Explicit timezone', date: '2025-08-26T12:00:00+02:00' },
+        '/blog/date/'
+      )?.date.toISOString()
+    ).toBe('2025-08-26T10:00:00.000Z');
+    expect(
+      parseBlogArticle(
+        { title: 'ISO calendar date', date: '2025-08-26' },
+        '/blog/date/'
+      )?.date.toISOString()
+    ).toBe('2025-08-26T00:00:00.000Z');
+  });
+
+  test('reads, sorts, and normalizes article metadata', () => {
+    const directory = createTemporaryArticlesDir();
+    writeArticle(
+      directory,
+      path.join('(group)', 'older', 'index.mdx'),
+      "title: Older\nauthors: [A]\ntags: [old]\ndate: 'January 1, 2024'"
+    );
+    writeArticle(
+      directory,
+      path.join('newer', 'index.mdx'),
+      "title: Newer\nauthors:\n  - A\n  - B\ndate: 'January 1, 2025'\ndescription: A summary"
+    );
+    writeArticle(directory, path.join('invalid', 'index.mdx'), "title: Invalid\ndate: 'unknown'");
+
+    const articles = readBlogArticles(directory, 'https://qwik.dev');
+    expect(articles.map((article) => article.title)).toEqual(['Newer', 'Older']);
+    expect(articles[0]).toMatchObject({
+      authors: ['A', 'B'],
+      description: 'A summary',
+      url: 'https://qwik.dev/blog/newer/',
+    });
+  });
+
+  test('renders deterministic RSS fields and an empty feed', () => {
+    const feed = renderRssFeed(
+      [
+        {
+          title: 'Older & wiser',
+          authors: ['A <B>'],
+          tags: ['News'],
+          date: new Date('2024-01-01T00:00:00Z'),
+          url: 'https://qwik.dev/blog/older/',
+        },
+        {
+          title: 'Newest',
+          authors: [],
+          tags: [],
+          date: new Date('2025-01-01T00:00:00Z'),
+          url: 'https://qwik.dev/blog/newest/',
+        },
+      ],
+      'https://qwik.dev'
+    );
+
+    expect(feed.indexOf('<title>Newest</title>')).toBeLessThan(
+      feed.indexOf('<title>Older &amp; wiser</title>')
+    );
+    expect(feed).toContain('<dc:creator>A &lt;B&gt;</dc:creator>');
+    expect(feed).toContain('<category>News</category>');
+    expect(feed).toContain('type="application/rss+xml"');
+    expect(renderRssFeed([], 'https://qwik.dev')).not.toContain('<lastBuildDate>');
+  });
+
+  test('emits the feed only for the client environment', () => {
+    const routesDirectory = createTemporaryArticlesDir();
+    const articlesDirectory = path.join(routesDirectory, '(blog)', 'blog', '(articles)');
+    writeArticle(
+      articlesDirectory,
+      path.join('post', 'index.mdx'),
+      "title: Post\ndate: '2026-01-01'"
+    );
+    const plugin = blogRssData(routesDirectory, 'https://qwik.dev');
+    if (typeof plugin.generateBundle !== 'function') {
+      throw new Error('Expected a generateBundle hook');
+    }
+
+    const emitted: Array<{ fileName: string; source: string }> = [];
+    const context = {
+      environment: { config: { consumer: 'client' } },
+      emitFile(asset: { fileName: string; source: string }) {
+        emitted.push(asset);
+        return 'rss';
+      },
+    };
+    plugin.generateBundle.call(context as any, {} as any, {} as any, false);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].fileName).toBe('blog/rss.xml');
+
+    const serverContext = {
+      environment: { config: { consumer: 'server' } },
+      emitFile() {
+        throw new Error('RSS should not be emitted by server builds');
+      },
+    };
+    plugin.generateBundle.call(serverContext as any, {} as any, {} as any, false);
+  });
+});

--- a/packages/docs/vite-blog-rss.unit.ts
+++ b/packages/docs/vite-blog-rss.unit.ts
@@ -122,6 +122,7 @@ describe('blog RSS generation', () => {
           tags: ['News'],
           date: new Date('2024-01-01T00:00:00Z'),
           url: 'https://qwik.dev/blog/older/',
+          guid: 'qwik-blog:older',
         },
         {
           title: 'Newest',
@@ -139,6 +140,8 @@ describe('blog RSS generation', () => {
     );
     expect(feed).toContain('<dc:creator>A &lt;B&gt;</dc:creator>');
     expect(feed).toContain('<category>News</category>');
+    expect(feed).toContain('<guid isPermaLink="false">qwik-blog:older</guid>');
+    expect(feed).toContain('<guid isPermaLink="true">https://qwik.dev/blog/newest/</guid>');
     expect(feed).toContain('type="application/rss+xml"');
     expect(renderRssFeed([], 'https://qwik.dev')).not.toContain('<lastBuildDate>');
   });

--- a/packages/docs/vite.config.ts
+++ b/packages/docs/vite.config.ts
@@ -14,6 +14,7 @@ import path, { resolve } from 'node:path';
 // import { qwikDevtools } from '@qwik.dev/devtools';
 import { defineConfig, loadEnv, type Connect, type Plugin, type UserConfig } from 'vite';
 import { compiledStringPlugin } from '../../scripts/compiled-string-plugin.js';
+import { blogRssData } from './vite-blog-rss';
 import { docsUpdatedData } from './vite-docs-updated';
 import { examplesData, playgroundData, rawSource, tutorialData } from './vite.repl-apps';
 import { sourceResolver } from './vite.source-resolver';
@@ -246,6 +247,7 @@ export default defineConfig(({ mode }) => {
       }),
       examplesData(routesDir),
       playgroundData(routesDir),
+      blogRssData(routesDir),
       docsUpdatedData(routesDir),
       tutorialData(routesDir),
       sourceResolver(docsDir),


### PR DESCRIPTION
## What is it?

- [x] Docs / tests / types

## Description

Fixes #8209.

The Qwik blog stores its publication metadata in MDX frontmatter, but visitors currently have no RSS endpoint to subscribe to. This change turns that existing metadata into a deterministic RSS 2.0 feed during the client bundle, as requested in the issue discussion.

### What changed

- Scan blog article frontmatter at build time and include title, publication date, authors, tags, and canonical URL.
- Emit `dist/blog/rss.xml` from the client build only, so SSR/SSG builds do not produce duplicate assets.
- Normalize timezone-free frontmatter dates to UTC, sort items newest-first, and escape XML content for stable valid output.
- Add the RSS alternate link to the blog page head.
- Add focused tests for route mapping, metadata parsing, date handling, XML escaping, deterministic rendering, and client-only emission.

### User impact

Readers can subscribe to `https://qwik.dev/blog/rss.xml` in an RSS reader. Existing blog pages and suppression/content behavior are unchanged.

### Verification

- `pnpm exec vitest run packages/docs/vite-blog-rss.unit.ts` (8 passed)
- `pnpm -C packages/docs run build` (passed; 253 SSG pages, 158 Pagefind pages, 30 RSS items)
- `xmllint --noout dist/blog/rss.xml` (passed)
- RSS output SHA-256 is identical under UTC, `America/Los_Angeles`, and `Asia/Shanghai`: `b28e62703b192f28f93708daddc8d35e4b8756831e74b06872bddb3fc8a978a1`
- `git diff --check` and staged formatting checks passed

A repository-wide TypeScript check still reports pre-existing React demo/type declaration errors; this change does not add errors in the RSS files.

This PR was written with assistance from OpenAI Codex and is submitted for maintainer review.

No changeset is included because this only changes the documentation site's generated asset and does not alter a published package.