### PR TITLE
fix(core): resolve each migrate-v2 package's dependency version independently

### DIFF
--- a/.changeset/silly-lions-migrate.md
+++ b/.changeset/silly-lions-migrate.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: v2 migration no longer pins unpublished dist-tag versions for packages that don't share core's release cadence

--- a/packages/qwik/src/cli/migrate-v2/update-dependencies.ts
+++ b/packages/qwik/src/cli/migrate-v2/update-dependencies.ts
@@ -8,8 +8,6 @@ export async function updateDependencies() {
   // TODO(migrate-v2): rely on workspaceRoot instead?
   const packageJson = await readPackageJson(process.cwd());
 
-  const version = await getPackageTag();
-
   const dependencyNames = [
     'dependencies',
     'devDependencies',
@@ -19,6 +17,8 @@ export async function updateDependencies() {
 
   for (let i = 0; i < packageNames.length; i++) {
     const name = packageNames[i];
+    // each package is versioned independently, so its tags must be resolved on its own
+    const version = await getPackageTag(name);
     for (let j = 0; j < dependencyNames.length; j++) {
       const propName = dependencyNames[j];
       const prop = packageJson[propName];
@@ -36,13 +36,12 @@ export async function updateDependencies() {
 }
 
 /**
- * Resolve the list of available package tags for the "@qwik.dev/core" and get the best match of
+ * Resolve the list of available package tags for the given package name and get the best match of
  * ^2.0.0 based on the "versionTagPriority"
  */
-async function getPackageTag() {
+async function getPackageTag(packageName: string) {
   const { major } = await import('semver');
-  // we assume all migrated packages have the same set of tags
-  const tags: [tag: string, version: string][] = execSync('npm dist-tag @qwik.dev/core', {
+  const tags: [tag: string, version: string][] = execSync(`npm dist-tag ${packageName}`, {
     encoding: 'utf-8',
   })
     ?.split('\n')
@@ -71,7 +70,9 @@ async function getPackageTag() {
       return version;
     }
   }
-  log.warn('Failed to resolve the Qwik version tag, version "2.0.0" will be installed');
+  log.warn(
+    `Failed to resolve the version tag for "${packageName}", version "2.0.0" will be installed`
+  );
   return '2.0.0';
 }
 

--- a/packages/qwik/src/cli/migrate-v2/update-dependencies.unit.ts
+++ b/packages/qwik/src/cli/migrate-v2/update-dependencies.unit.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { readPackageJson, writePackageJson } from './../utils/utils';
+import { updateDependencies } from './update-dependencies';
+
+const distTagsByPackage: Record<string, string> = {};
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn((command: string) => {
+    const packageName = command.replace('npm dist-tag ', '');
+    return distTagsByPackage[packageName] ?? '';
+  }),
+}));
+
+vi.mock('./../utils/utils', () => ({
+  readPackageJson: vi.fn(),
+  writePackageJson: vi.fn(),
+  getPackageManager: vi.fn(() => 'npm'),
+}));
+
+vi.mock('../utils/install-deps', () => ({
+  installDeps: vi.fn(() => ({ install: Promise.resolve(true) })),
+}));
+
+vi.mock('@clack/prompts', () => ({
+  log: { warn: vi.fn(), success: vi.fn() },
+  spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+}));
+
+describe('updateDependencies', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const keys = Object.keys(distTagsByPackage);
+    for (let i = 0; i < keys.length; i++) {
+      delete distTagsByPackage[keys[i]];
+    }
+  });
+
+  test('resolves each package version independently instead of reusing @qwik.dev/core version', async () => {
+    // @qwik.dev/core and @qwik.dev/router were published for beta.42, but
+    // eslint-plugin-qwik was not, so it stayed on its own beta.40
+    distTagsByPackage['@qwik.dev/core'] = 'latest: 1.14.0\nbeta: 2.0.0-beta.42\n';
+    distTagsByPackage['@qwik.dev/router'] = 'latest: 1.14.0\nbeta: 2.0.0-beta.42\n';
+    distTagsByPackage['@qwik.dev/react'] = 'latest: 1.14.0\nbeta: 2.0.0-beta.42\n';
+    distTagsByPackage['eslint-plugin-qwik'] = 'latest: 1.14.0\nbeta: 2.0.0-beta.40\n';
+
+    const packageJson: any = {
+      devDependencies: {
+        '@qwik.dev/core': '^1.14.0',
+        '@qwik.dev/router': '^1.14.0',
+        '@qwik.dev/react': '^1.14.0',
+        'eslint-plugin-qwik': '^1.14.0',
+      },
+    };
+    vi.mocked(readPackageJson).mockResolvedValue(packageJson);
+
+    await updateDependencies();
+
+    expect(packageJson.devDependencies['@qwik.dev/core']).toBe('2.0.0-beta.42');
+    expect(packageJson.devDependencies['@qwik.dev/router']).toBe('2.0.0-beta.42');
+    expect(packageJson.devDependencies['eslint-plugin-qwik']).toBe('2.0.0-beta.40');
+    expect(vi.mocked(writePackageJson)).toHaveBeenCalledWith(expect.any(String), packageJson);
+  });
+
+  test('falls back to "2.0.0" only for the package missing a v2 tag', async () => {
+    distTagsByPackage['@qwik.dev/core'] = 'latest: 1.14.0\nbeta: 2.0.0-beta.42\n';
+    distTagsByPackage['@qwik.dev/router'] = 'latest: 1.14.0\nbeta: 2.0.0-beta.42\n';
+    distTagsByPackage['@qwik.dev/react'] = 'latest: 1.14.0\nbeta: 2.0.0-beta.42\n';
+    // eslint-plugin-qwik has no v2 dist-tag published at all yet
+    distTagsByPackage['eslint-plugin-qwik'] = 'latest: 1.14.0\n';
+
+    const packageJson: any = {
+      devDependencies: {
+        '@qwik.dev/core': '^1.14.0',
+        'eslint-plugin-qwik': '^1.14.0',
+      },
+    };
+    vi.mocked(readPackageJson).mockResolvedValue(packageJson);
+
+    await updateDependencies();
+
+    expect(packageJson.devDependencies['@qwik.dev/core']).toBe('2.0.0-beta.42');
+    expect(packageJson.devDependencies['eslint-plugin-qwik']).toBe('2.0.0');
+  });
+});

--- a/packages/qwik/src/cli/migrate-v2/update-dependencies.unit.ts
+++ b/packages/qwik/src/cli/migrate-v2/update-dependencies.unit.ts
@@ -61,6 +61,36 @@ describe('updateDependencies', () => {
     expect(vi.mocked(writePackageJson)).toHaveBeenCalledWith(expect.any(String), packageJson);
   });
 
+  test('resolves eslint-plugin-qwik to its own beta when its "latest" tag is still v1', async () => {
+    // real npm dist-tag output: core's "latest" is already v2, but
+    // eslint-plugin-qwik's "latest" still points at a v1 release
+    distTagsByPackage['@qwik.dev/core'] =
+      'alpha: 2.0.0-alpha.10\nbeta: 2.0.0-beta.40\nlatest: 2.0.0-beta.42\n';
+    distTagsByPackage['@qwik.dev/router'] =
+      'alpha: 2.0.0-alpha.10\nbeta: 2.0.0-beta.40\nlatest: 2.0.0-beta.42\n';
+    distTagsByPackage['@qwik.dev/react'] =
+      'alpha: 2.0.0-alpha.10\nbeta: 2.0.0-beta.40\nlatest: 2.0.0-beta.42\n';
+    distTagsByPackage['eslint-plugin-qwik'] =
+      'alpha: 2.0.0-alpha.10\nbeta: 2.0.0-beta.40\ndev: 1.7.0-dev20240711122353\nlatest: 1.20.0\nnext: 0.9.0\n';
+
+    const packageJson: any = {
+      devDependencies: {
+        '@qwik.dev/core': '^1.14.0',
+        '@qwik.dev/router': '^1.14.0',
+        '@qwik.dev/react': '^1.14.0',
+        'eslint-plugin-qwik': '^1.14.0',
+      },
+    };
+    vi.mocked(readPackageJson).mockResolvedValue(packageJson);
+
+    await updateDependencies();
+
+    expect(packageJson.devDependencies['@qwik.dev/core']).toBe('2.0.0-beta.42');
+    expect(packageJson.devDependencies['@qwik.dev/router']).toBe('2.0.0-beta.42');
+    expect(packageJson.devDependencies['@qwik.dev/react']).toBe('2.0.0-beta.42');
+    expect(packageJson.devDependencies['eslint-plugin-qwik']).toBe('2.0.0-beta.40');
+  });
+
   test('falls back to "2.0.0" only for the package missing a v2 tag', async () => {
     distTagsByPackage['@qwik.dev/core'] = 'latest: 1.14.0\nbeta: 2.0.0-beta.42\n';
     distTagsByPackage['@qwik.dev/router'] = 'latest: 1.14.0\nbeta: 2.0.0-beta.42\n';


### PR DESCRIPTION
# What is it?

- Bug

# Description

The v2 migration CLI (`packages/qwik/src/cli/migrate-v2`) resolved `@qwik.dev/core`'s npm dist-tag once and reused that same resolved version string for every migrated package (`@qwik.dev/core`, `@qwik.dev/router`, `@qwik.dev/react`, `eslint-plugin-qwik`). `eslint-plugin-qwik` isn't released in lockstep with core/router, so this could pin it to a version (e.g. a beta) that was never actually published for it, breaking `pnpm install` after migration.

Each package now resolves its own dist-tags independently via `getPackageTag(packageName)`, falling back to `2.0.0` only for the specific package missing a v2 tag, instead of assuming every package shares core's tags.

# Checklist

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [ ] I made corresponding changes to the Qwik docs
- [x] I added new tests to cover the fix / functionality