### PR TITLE
fix(release): publish beta-tagged packages even when the latest pass fails

### DIFF
--- a/scripts/changeset-release.mjs
+++ b/scripts/changeset-release.mjs
@@ -40,11 +40,18 @@ const savedManifests = new Map(
 for (const [path, source] of savedManifests) {
   writeFileSync(path, JSON.stringify({ private: true, ...JSON.parse(source) }, null, 2));
 }
+// The two passes are independent; a failure in one must not block the other.
+let latestError;
 try {
   publish('latest');
+} catch (error) {
+  latestError = error;
 } finally {
   for (const [path, source] of savedManifests) {
     writeFileSync(path, source);
   }
 }
 publish('beta');
+if (latestError) {
+  throw latestError;
+}


### PR DESCRIPTION
# What is it?
- Bug | Infra

# Description
The last two releases (beta.41/42) never published `eslint-plugin-qwik` and `create-qwik`: the `@qwik.dev/devtools` publish fails with E404 (no npm trusted publisher configured for it yet), which aborted the release script before the `--tag beta` pass that publishes the v1-named packages. The two passes are independent, so now the beta pass runs even when the latest pass fails, and the script still exits with the original error.

This can't cause a core/router version split: both publish in the same `--tag latest` pass, and `changeset publish` already works package-by-package with no rollback (beta.41/42 published core/router while devtools failed). The only new case is `eslint-plugin-qwik`/`create-qwik` publishing while a latest-pass package failed — harmless, since changesets is idempotent and the next run catches up whatever is missing, and these two only depend on core/router as devDependencies.

Note: devtools still needs a trusted publisher on npmjs.com (GitHub Actions, repo `QwikDev/qwik`, workflow `ci.yml`) before it can publish from CI.