### PR TITLE
fix(router): run non-blocking loaders without async local storage

### DIFF
--- a/.changeset/fuzzy-pandas-wait.md
+++ b/.changeset/fuzzy-pandas-wait.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/router': patch
+---
+
+fix: run non-blocking route loaders without async local storage

--- a/packages/qwik-router/src/runtime/src/qwik-router-component.tsx
+++ b/packages/qwik-router/src/runtime/src/qwik-router-component.tsx
@@ -226,7 +226,12 @@ export const useQwikRouter = (props?: QwikRouterProps) => {
   // Then set .value from middleware-computed loader values (inert, non-reactive data).
   const loaderState = {} as Record<string, ComputedSignal<unknown>>;
   const contentModulesForInit = env.loadedRoute.$mods$ as ContentModule[];
-  const loaders = ensureRouteLoaderSignals(contentModulesForInit, loaderState, routeLoaderCtx);
+  const loaders = ensureRouteLoaderSignals(
+    contentModulesForInit,
+    loaderState,
+    routeLoaderCtx,
+    env.ev
+  );
   for (const loader of loaders) {
     if (loader.__id in env.loaderValues) {
       const value = env.loaderValues[loader.__id];
@@ -613,7 +618,12 @@ export const useQwikRouter = (props?: QwikRouterProps) => {
       if (!isServer) {
         invalidateNavRouteLoaders(loaderState);
       }
-      const routeLoaders = ensureRouteLoaderSignals(contentModules, loaderState, routeLoaderCtx);
+      const routeLoaders = ensureRouteLoaderSignals(
+        contentModules,
+        loaderState,
+        routeLoaderCtx,
+        isServer ? env.ev : undefined
+      );
       if (shouldInvalidateActionLoaders) {
         // Actions force revalidation (fetch cache: 'reload') for their loaders
         if (actionLoaderHashes !== undefined) {

--- a/packages/qwik-router/src/runtime/src/route-loaders.spec.tsx
+++ b/packages/qwik-router/src/runtime/src/route-loaders.spec.tsx
@@ -27,6 +27,7 @@ import {
 } from '@qwik.dev/core/internal';
 import { createDocument } from '@qwik.dev/core/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RouteLoaderCtxContext, RouteStateContext } from './contexts';
 import {
   ensureRouteLoaderSignal,
   getModuleRouteLoaders,
@@ -285,6 +286,36 @@ describe('route loader store + computed signal tracking', () => {
 
     expect(signal.error).toBeUndefined();
     expect(signal.value).toBe('late-loader-value');
+  });
+
+  it('passes the RequestEvent to a loader created during render', async () => {
+    let resolve!: (value: string) => void;
+    const pendingValue = new Promise<string>((r) => (resolve = r));
+    const loader = routeLoaderQrl(
+      createQRL(null, 'render-loader', () => pendingValue)
+    ) as LoaderInternal;
+    const requestEv = {
+      sharedMap: new Map(),
+      cookie: {},
+      url: new URL('http://localhost/'),
+    } as unknown as RequestEvent;
+    const loaderPromise = loadRouteLoader(loader, requestEv);
+    const host = vnode_newVirtual();
+    container.setContext(host, RouteStateContext, {});
+    container.setContext(host, RouteLoaderCtxContext, { loaderPaths: {} });
+    container.$serverData$.qwikrouter = { ev: requestEv };
+    const ctx = newInvokeContext();
+    ctx.$container$ = container;
+    ctx.$hostElement$ = host;
+
+    const signal = invoke(ctx, loader);
+
+    resolve('render-loader-value');
+    await loaderPromise;
+    await signal.promise();
+
+    expect(signal.error).toBeUndefined();
+    expect(signal.value).toBe('render-loader-value');
   });
 
   it('should verify store is reactive', async () => {

--- a/packages/qwik-router/src/runtime/src/route-loaders.spec.tsx
+++ b/packages/qwik-router/src/runtime/src/route-loaders.spec.tsx
@@ -27,8 +27,14 @@ import {
 } from '@qwik.dev/core/internal';
 import { createDocument } from '@qwik.dev/core/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getModuleRouteLoaders, routeLoaderQrl, setLoaderSignalValue } from './route-loaders';
-import type { LoaderInternal, RouteModule } from './types';
+import {
+  ensureRouteLoaderSignal,
+  getModuleRouteLoaders,
+  loadRouteLoader,
+  routeLoaderQrl,
+  setLoaderSignalValue,
+} from './route-loaders';
+import type { LoaderInternal, RequestEvent, RouteModule } from './types';
 
 const taskFlag = 1 << 1; // TaskFlags.TASK
 
@@ -241,6 +247,44 @@ describe('route loader store + computed signal tracking', () => {
       await signal.promise();
       expect(signal.value).toBe('loaded:/page3');
     });
+  });
+
+  it('resolves a pending blockSSR:false loader without AsyncLocalStorage', async () => {
+    let resolve!: (value: string) => void;
+    const pendingValue = new Promise<string>((r) => (resolve = r));
+    const loader = Object.assign(() => {}, {
+      __brand: 'server_loader' as const,
+      __id: 'late-loader',
+      __qrl: createQRL(null, 'late-loader', () => pendingValue),
+      __validators: undefined,
+      __serializationStrategy: 'never' as const,
+      __cacheControl: undefined,
+      __eTag: undefined,
+      __cacheKey: undefined,
+      __search: undefined,
+      __blockSSR: false,
+    }) as unknown as LoaderInternal;
+    const requestEv = {
+      sharedMap: new Map(),
+      cookie: {},
+      url: new URL('http://localhost/'),
+    } as unknown as RequestEvent;
+
+    const loaderPromise = loadRouteLoader(loader, requestEv);
+    const ctx = newInvokeContext();
+    ctx.$container$ = container;
+    const signal = invoke(ctx, () => {
+      const signal = ensureRouteLoaderSignal(loader, {}, { loaderPaths: {} }, requestEv);
+      void signal.promise();
+      return signal;
+    });
+
+    resolve('late-loader-value');
+    await loaderPromise;
+    await signal.promise();
+
+    expect(signal.error).toBeUndefined();
+    expect(signal.value).toBe('late-loader-value');
   });
 
   it('should verify store is reactive', async () => {

--- a/packages/qwik-router/src/runtime/src/route-loaders.ts
+++ b/packages/qwik-router/src/runtime/src/route-loaders.ts
@@ -4,13 +4,13 @@ import {
   implicit$FirstArg,
   isDev,
   isServer,
+  useServerData,
   type ComputedSignal,
   type NoSerialize,
   type QRL,
 } from '@qwik.dev/core';
 import {
   _deserialize,
-  _getContextEvent,
   _injectAsyncSignalValue,
   _markSignalAsExternallyOwned,
   _resolveContextWithoutSequentialScope,
@@ -41,6 +41,7 @@ import type {
   LoaderConstructorQRL,
   LoaderInternal,
   LoaderOptions,
+  QwikRouterEnvData,
   RequestEvent,
   RequestEventLoader,
   RouteNavigate,
@@ -147,7 +148,7 @@ class ServerRouteLoaderCapture {
   ) {}
 
   load() {
-    const requestEv = this.requestEv ?? getRequestEvent();
+    const requestEv = this.requestEv;
     if (!requestEv) {
       throw new Error('Unable to determine the current RequestEvent.');
     }
@@ -292,7 +293,7 @@ const createRouteLoaderSignal = (
         loader.__qrl,
         loader.__validators,
         loader.__blockSSR,
-        requestEv
+        requestEv ?? useServerData<QwikRouterEnvData>('qwikrouter')?.ev
       )
     : id;
   const searchFilter = loader.__search;
@@ -500,7 +501,7 @@ export const getRequestEvent = (thisArg?: unknown): RequestEvent | undefined => 
   if (!isServer) {
     throw new Error('getRequestEvent() can only be used on the server.');
   }
-  return _asyncRequestStore?.getStore() || [thisArg, _getContextEvent()].find(isRequestEvent);
+  return _asyncRequestStore?.getStore() ?? (isRequestEvent(thisArg) ? thisArg : undefined);
 };
 
 const REQUEST_ROUTE_LOADER_VALUES = '@routeLoaderValues';
@@ -917,12 +918,7 @@ export const routeLoaderQrl = ((
   function loader() {
     const state = _resolveContextWithoutSequentialScope(RouteStateContext)!;
     const routeLoaderCtx = _resolveContextWithoutSequentialScope(RouteLoaderCtxContext)!;
-    const signal = ensureRouteLoaderSignal(
-      loader,
-      state,
-      routeLoaderCtx,
-      isServer ? getRequestEvent() : undefined
-    );
+    const signal = ensureRouteLoaderSignal(loader, state, routeLoaderCtx);
     void signal.promise();
     return signal;
   }

--- a/packages/qwik-router/src/runtime/src/route-loaders.ts
+++ b/packages/qwik-router/src/runtime/src/route-loaders.ts
@@ -142,11 +142,12 @@ class ServerRouteLoaderCapture {
     readonly hash: string,
     readonly qrl: QRL<(event: RequestEventLoader) => unknown>,
     readonly validators: DataValidator[] | undefined,
-    readonly blockSSR: boolean
+    readonly blockSSR: boolean,
+    readonly requestEv?: RequestEvent
   ) {}
 
   load() {
-    const requestEv = getRequestEvent();
+    const requestEv = this.requestEv ?? getRequestEvent();
     if (!requestEv) {
       throw new Error('Unable to determine the current RequestEvent.');
     }
@@ -279,13 +280,20 @@ export const fetchRouteLoaderData = async (
 const createRouteLoaderSignal = (
   loader: LoaderInternal,
   routeLoaderCtx: RouteLoaderCtx,
-  state: RouteLoaderState
+  state: RouteLoaderState,
+  requestEv?: RequestEvent
 ) => {
   const id = loader.__id;
   const stateValues = state as Record<string, unknown>;
   const resumeValueKey = getRouteLoaderValueStateKey(id);
   const capture = isServer
-    ? new ServerRouteLoaderCapture(id, loader.__qrl, loader.__validators, loader.__blockSSR)
+    ? new ServerRouteLoaderCapture(
+        id,
+        loader.__qrl,
+        loader.__validators,
+        loader.__blockSSR,
+        requestEv
+      )
     : id;
   const searchFilter = loader.__search;
   // Raw text of the last successful fetch, to skip deserialization and keep object
@@ -643,7 +651,8 @@ export const applyClientRouteLoaderPath = (loaderId: string, ctx: RouteLoaderCtx
 export const ensureRouteLoaderSignal = (
   loader: LoaderInternal,
   state: RouteLoaderState,
-  routeLoaderCtx: RouteLoaderCtx
+  routeLoaderCtx: RouteLoaderCtx,
+  requestEv?: RequestEvent
 ) => {
   if (!isServer && routeLoaderCtx.pagePathname) {
     applyClientRouteLoaderPath(loader.__id, routeLoaderCtx);
@@ -654,17 +663,18 @@ export const ensureRouteLoaderSignal = (
   if (isServer && loader.__serializationStrategy === 'never') {
     (state as Record<string, unknown>)[getRouteLoaderValueStateKey(loader.__id)] = _UNINITIALIZED;
   }
-  return (state[loader.__id] ||= createRouteLoaderSignal(loader, routeLoaderCtx, state));
+  return (state[loader.__id] ||= createRouteLoaderSignal(loader, routeLoaderCtx, state, requestEv));
 };
 
 export const ensureRouteLoaderSignals = (
   mods: readonly (RouteModule | undefined)[],
   state: RouteLoaderState,
-  routeLoaderCtx: RouteLoaderCtx
+  routeLoaderCtx: RouteLoaderCtx,
+  requestEv?: RequestEvent
 ) => {
   const loaders = getModuleRouteLoaders(mods);
   for (let i = 0; i < loaders.length; i++) {
-    ensureRouteLoaderSignal(loaders[i], state, routeLoaderCtx);
+    ensureRouteLoaderSignal(loaders[i], state, routeLoaderCtx, requestEv);
   }
   return loaders;
 };
@@ -907,7 +917,12 @@ export const routeLoaderQrl = ((
   function loader() {
     const state = _resolveContextWithoutSequentialScope(RouteStateContext)!;
     const routeLoaderCtx = _resolveContextWithoutSequentialScope(RouteLoaderCtxContext)!;
-    const signal = ensureRouteLoaderSignal(loader, state, routeLoaderCtx);
+    const signal = ensureRouteLoaderSignal(
+      loader,
+      state,
+      routeLoaderCtx,
+      isServer ? getRequestEvent() : undefined
+    );
     void signal.promise();
     return signal;
   }

--- a/packages/qwik/src/core/use/use-core.ts
+++ b/packages/qwik/src/core/use/use-core.ts
@@ -14,21 +14,9 @@ import { QError, qError } from '../shared/error/error';
 import type { Container, HostElement } from '../shared/types';
 import { RenderEvent, TaskEvent } from '../shared/utils/markers';
 import { seal } from '../shared/utils/qdev';
-import { isObject } from '../shared/utils/types';
 import { setLocale } from './use-locale';
 
-// Simplified version of `ServerRequestEvent` from `@qwik.dev/router` package.
-export interface SimplifiedServerRequestEvent<T = unknown> {
-  url: URL;
-  locale: string | undefined;
-  request: Request;
-}
-
-export type PossibleEvents =
-  | Event
-  | SimplifiedServerRequestEvent
-  | typeof TaskEvent
-  | typeof RenderEvent;
+export type PossibleEvents = Event | typeof TaskEvent | typeof RenderEvent;
 
 export interface RenderInvokeContext extends InvokeContext {
   // The below are just always-defined attributes of InvokeContext.
@@ -149,20 +137,16 @@ export function newRenderInvokeContext(
 }
 
 /** @internal */
-// TODO how about putting url and locale (and event/custom?) in to a "static" object
 export function newInvokeContext(
   locale?: string,
   hostElement?: HostElement,
   event?: Exclude<PossibleEvents, typeof RenderEvent>
 ): InvokeContext {
-  // ServerRequestEvent has .locale, but it's not always defined.
-  const $locale$ =
-    locale || (event && isObject(event) && 'locale' in event ? event.locale : undefined);
   const ctx: InvokeContext = {
     $hostElement$: hostElement,
     $event$: event,
     $effectSubscriber$: undefined,
-    $locale$,
+    $locale$: locale,
     $container$: undefined,
   };
   seal(ctx);


### PR DESCRIPTION
Fix non-blocking route loaders failing during SSR when AsyncLocalStorage is disabled by explicitly passing the RequestEvent. Also remove the router-specific request event type and fallback handling from Qwik Core.