### PR TITLE
fix: preserve nested QRLs captured by library components

### DIFF
--- a/.changeset/nested-qrl-captures.md
+++ b/.changeset/nested-qrl-captures.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/optimizer': patch
+---
+
+fix: preserve nested QRLs captured by library components

--- a/packages/optimizer/core/src/test.rs
+++ b/packages/optimizer/core/src/test.rs
@@ -7317,6 +7317,38 @@ export function qwikifyQrl(reactCmp$, opts) {
 }
 
 #[test]
+fn inlined_qrl_in_capture_is_extracted() {
+	let output = test_input!(TestInput {
+		code: r#"
+import { inlinedQrl } from '@qwik.dev/core';
+
+const context = {};
+export const handler = inlinedQrl(() => {}, "outer_abc", [
+	inlinedQrl(() => {}, "inner_def", [context]),
+]);
+"#
+		.to_string(),
+		entry_strategy: EntryStrategy::Segment,
+		mode: EmitMode::Prod,
+		is_server: Some(true),
+		snapshot: false,
+		..TestInput::default()
+	})
+	.unwrap();
+
+	let segments: Vec<_> = output
+		.modules
+		.iter()
+		.filter_map(|module| module.segment.as_ref())
+		.map(|segment| segment.name.as_ref())
+		.collect();
+	assert!(
+		segments.contains(&"s_def"),
+		"nested QRL captured by another QRL must be emitted as a segment, got {segments:?}"
+	);
+}
+
+#[test]
 fn inlined_qrl_preserves_destructured_captures() {
 	// Simulates a library .qwik.mjs file being processed by the app optimizer in SSR dev mode.
 	// The library has destructured useCustomSignal() return value, and inner inlinedQrl captures

--- a/packages/optimizer/core/src/transform.rs
+++ b/packages/optimizer/core/src/transform.rs
@@ -587,6 +587,7 @@ impl<'a> QwikTransform<'a> {
 
 		self.segment_stack.push(symbol_name.clone());
 		let folded = *first_arg.expr.fold_with(self);
+		let third_arg = third_arg.map(|arg| arg.fold_with(self));
 		self.segment_stack.pop();
 
 		// Inline const initializer if the value is a simple ident referencing a local const.


### PR DESCRIPTION
Fix nested inlinedQrl calls captured by another QRL not being extracted or included in the manifest. This prevented affected pages from resuming after a production full-page load.