### PR TITLE
fix: prevent render loops and stalls after async failures

### DIFF
--- a/.changeset/quiet-components-settle.md
+++ b/.changeset/quiet-components-settle.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: prevent infinite retries after component chunk imports fail

--- a/.changeset/steady-streamed-computations.md
+++ b/.changeset/steady-streamed-computations.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: await asynchronous computations on streamed server nodes

--- a/.changeset/tidy-task-rejections.md
+++ b/.changeset/tidy-task-rejections.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+fix: prevent stalled renders when suspended tasks encounter rejected promises

--- a/packages/qwik/src/core/shared/cursor/chore-execution.ts
+++ b/packages/qwik/src/core/shared/cursor/chore-execution.ts
@@ -241,7 +241,10 @@ export function executeComponentChore(
      * it. We just return the promise and we'll be called again, possibly with updated props, which
      * is why we don't clear the dirty bit yet.
      */
-    return componentQRL.resolve();
+    return componentQRL.resolve().catch((error) => {
+      vNode.dirty &= ~ChoreBits.COMPONENT;
+      throw error;
+    });
   }
   vNode.dirty &= ~ChoreBits.COMPONENT;
   if (!componentQRL) {

--- a/packages/qwik/src/core/shared/cursor/chore-execution.unit.ts
+++ b/packages/qwik/src/core/shared/cursor/chore-execution.unit.ts
@@ -571,6 +571,24 @@ describe('executeComponentChore', () => {
     await result;
   });
 
+  it('should clear only COMPONENT dirty bit when the component import rejects', async () => {
+    const error = new TypeError('Failed to fetch dynamically imported module');
+    const componentQRL = {
+      resolved: undefined,
+      resolve: vi.fn().mockRejectedValue(error),
+    };
+    container.setHostProp(vNode, OnRenderProp, componentQRL);
+    vNode.dirty |= ChoreBits.CHILDREN;
+
+    const result = executeComponentChore(vNode, container, journal, cursor);
+
+    expect(vNode.dirty & ChoreBits.COMPONENT).toBeTruthy();
+    await expect(result).rejects.toBe(error);
+    expect(vNode.dirty).toBe(ChoreBits.CHILDREN);
+    expect(executeComponent).not.toHaveBeenCalled();
+    expect(vnode_diff).not.toHaveBeenCalled();
+  });
+
   it('should not mark component execution clean until it has actually started', async () => {
     let resolveQrl!: () => void;
     const componentQRL = {
@@ -598,11 +616,22 @@ describe('executeComponentChore', () => {
     resolveQrl();
     await 1;
     expect(executeComponent).toHaveBeenCalledTimes(0);
+    expect(vNode.dirty & ChoreBits.COMPONENT).toBeTruthy();
+    const updatedProps = { id: 'updated' } as Props;
+    container.setHostProp(vNode, ELEMENT_PROPS, updatedProps);
     const freshResult = executeComponentChore(vNode, container, journal, cursor);
     await freshResult;
     await staleResult;
 
     expect(executeComponent).toHaveBeenCalledTimes(1);
+    expect(executeComponent).toHaveBeenCalledWith(
+      container,
+      vNode,
+      vNode,
+      componentQRL,
+      updatedProps
+    );
+    expect(vNode.dirty & ChoreBits.COMPONENT).toBe(0);
     expect(vnode_diff).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/qwik/src/core/shared/cursor/ssr-chore-execution.ts
+++ b/packages/qwik/src/core/shared/cursor/ssr-chore-execution.ts
@@ -26,11 +26,12 @@ export function _executeSsrChores(
   ssrNode: ISsrNode
 ): ValueOrPromise<void> {
   if (!(ssrNode.flags & SsrNodeFlags.Updatable)) {
+    let result: ValueOrPromise<void> = undefined;
     if (ssrNode.dirty & ChoreBits.NODE_PROPS) {
       executeNodePropChore(container, ssrNode);
     }
     if (ssrNode.dirty & ChoreBits.COMPUTE) {
-      executeCompute(ssrNode, container);
+      result = executeCompute(ssrNode, container);
     }
     if (
       isDev &&
@@ -54,7 +55,7 @@ export function _executeSsrChores(
       logWarn(warningMessage);
     }
     ssrNode.dirty &= ~ChoreBits.DIRTY_MASK;
-    return;
+    return result;
   }
 
   let promise: ValueOrPromise<void> | null = null;

--- a/packages/qwik/src/core/shared/cursor/ssr-chore-execution.unit.ts
+++ b/packages/qwik/src/core/shared/cursor/ssr-chore-execution.unit.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WrappedSignalImpl } from '../../reactive-primitives/impl/wrapped-signal-impl';
+import type { ISsrNode, SSRContainer } from '../../ssr/ssr-types';
+import { getPlatform, setPlatform } from '../platform/platform';
+import { ChoreBits } from '../vnode/enums/chore-bits.enum';
+import { markVNodeDirty } from '../vnode/vnode-dirty';
+import { HOST_SIGNAL } from './cursor-props';
+
+describe('streamed SSR compute chores', () => {
+  let previousPlatform: ReturnType<typeof getPlatform>;
+
+  beforeEach(() => {
+    previousPlatform = getPlatform();
+    setPlatform({ ...previousPlatform, isServer: true });
+  });
+
+  afterEach(() => {
+    setPlatform(previousPlatform);
+  });
+
+  it.each(['resolve', 'reject'])('tracks a suspended computation that will %s', async (outcome) => {
+    let resolve!: () => void;
+    let reject!: (error: Error) => void;
+    const pending = new Promise<void>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    const compute = vi
+      .fn()
+      .mockReturnValue(42)
+      .mockImplementationOnce(() => {
+        throw pending;
+      });
+    const node = { flags: 0, dirty: ChoreBits.NONE } as unknown as ISsrNode;
+    const container = {
+      $renderPromise$: null,
+      getHostProp: vi.fn(),
+    } as unknown as SSRContainer;
+    const signal = new WrappedSignalImpl(container, compute, [], null);
+    vi.mocked(container.getHostProp).mockImplementation((_host, prop) =>
+      prop === HOST_SIGNAL ? signal : null
+    );
+
+    try {
+      const result = markVNodeDirty(container, node, ChoreBits.COMPUTE);
+      expect(result).toBeInstanceOf(Promise);
+      expect(container.$renderPromise$).toBe(result);
+      expect(node.dirty).toBe(ChoreBits.NONE);
+      expect(compute).toHaveBeenCalledTimes(1);
+
+      if (outcome === 'reject') {
+        const error = new Error('computation failed');
+        const assertion = expect(container.$renderPromise$).rejects.toBe(error);
+        reject(error);
+        await assertion;
+        expect(compute).toHaveBeenCalledTimes(1);
+      } else {
+        resolve();
+        await container.$renderPromise$;
+        expect(compute).toHaveBeenCalledTimes(2);
+        expect(signal.$untrackedValue$).toBe(42);
+      }
+    } finally {
+      resolve();
+    }
+  });
+});

--- a/packages/qwik/src/core/tests/use-task.spec.tsx
+++ b/packages/qwik/src/core/tests/use-task.spec.tsx
@@ -119,6 +119,41 @@ describe.each([
       expect(e).toBe(error);
     }
   });
+  it('finishes rendering after a nonblocking task throws a rejected promise', async () => {
+    const error = new Error('dependency failed');
+    const Counter = component$(() => {
+      const count = useSignal(0);
+      useTask$(
+        ({ track }) => {
+          if (track(count) === 1) {
+            throw Promise.reject(error);
+          }
+        },
+        { deferUpdates: false }
+      );
+      return <button onClick$={() => count.value++}>{count.value}</button>;
+    });
+
+    const { container } = await render(
+      <ErrorProvider>
+        <Counter />
+      </ErrorProvider>
+    );
+    const button = container.element.querySelector('button')!;
+    const handleError = vi.spyOn(container, 'handleError');
+
+    await trigger(container.element, button, 'click');
+    expect(handleError).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ message: 'dependency failed' }),
+      expect.anything(),
+      'hook'
+    );
+    expect(container.$renderPromise$).toBeNull();
+    await trigger(container.element, button, 'click');
+    expect(button.textContent).toBe('2');
+    handleError.mockRestore();
+  });
+
   it('should not run next task until previous async task is finished', async () => {
     const log: string[] = [];
     const Counter = component$(() => {

--- a/packages/qwik/src/core/use/use-task.ts
+++ b/packages/qwik/src/core/use/use-task.ts
@@ -209,7 +209,7 @@ export const runTask = (
               task.$taskPromise$ = null;
             }
             return runTask(task, container, host);
-          });
+          }, handleError);
         } else {
           handleError(err);
         }

--- a/packages/qwik/src/core/use/use-task.unit.ts
+++ b/packages/qwik/src/core/use/use-task.unit.ts
@@ -67,6 +67,27 @@ const createTask = (fn: (...args: any[]) => any) => {
 };
 
 describe('runTask', () => {
+  it('reports a rejected thrown promise once and allows a later rerun', async () => {
+    const error = new Error('dependency failed');
+    const container = createMockContainer();
+    const taskFn = vi.fn().mockImplementationOnce(() => {
+      throw Promise.reject(error);
+    });
+    const { host, task } = createTask(taskFn);
+
+    await expect(runTask(task, container, host)).resolves.toBeUndefined();
+
+    expect(container.handleError).toHaveBeenCalledExactlyOnceWith(error, host, 'hook');
+    expect(taskFn).toHaveBeenCalledTimes(1);
+    expect(task.$flags$ & TaskFlags.DIRTY).toBe(0);
+    expect(task.$taskPromise$).toBeNull();
+
+    task.$flags$ |= TaskFlags.DIRTY;
+    await runTask(task, container, host);
+    expect(taskFn).toHaveBeenCalledTimes(2);
+    expect(container.handleError).toHaveBeenCalledTimes(1);
+  });
+
   it('awaits async cleanup registered with cleanup() before rerun', async () => {
     const log: string[] = [];
     const container = createMockContainer();


### PR DESCRIPTION
- prevent infinite retries when component chunk imports fail
- handle rejected task suspension promises so rendering can finish
- await asynchronous computations on streamed SSR nodes and propagate failures