### PR TITLE
fix: preserve async request and locale context on edge runtimes

### DIFF
--- a/.changeset/edge-async-request-context.md
+++ b/.changeset/edge-async-request-context.md
@@ -1,0 +1,6 @@
+---
+'@qwik.dev/core': patch
+'@qwik.dev/router': patch
+---
+
+fix: preserve async request and locale context on edge runtimes

--- a/packages/docs/src/repl/bundler/bundled.tsx
+++ b/packages/docs/src/repl/bundler/bundled.tsx
@@ -5,6 +5,7 @@ import qBuild from '../../../node_modules/@qwik.dev/core/dist/build/index.d.ts?r
 import qCoreDts from '../../../node_modules/@qwik.dev/core/dist/core-internal.d.ts?raw-source';
 import qCoreMinMjs from '../../../node_modules/@qwik.dev/core/dist/core.min.mjs?raw-source';
 import qCoreMjs from '../../../node_modules/@qwik.dev/core/dist/core.mjs?raw-source';
+import qAsyncLocalStorageMjs from '../../../node_modules/@qwik.dev/core/dist/async-local-storage.mjs?raw-source';
 import qViteMjs from '../../../node_modules/@qwik.dev/core/dist/optimizer.mjs?raw-source';
 import qPreloaderMjs from '../../../node_modules/@qwik.dev/core/dist/preloader.mjs?raw-source';
 import qHandlersMjs from '../../../node_modules/@qwik.dev/core/handlers.mjs?raw-source';
@@ -67,6 +68,7 @@ const qwikUrls: PkgUrls[string] = {
   '/dist/core.d.ts': qCoreDts,
   '/dist/core.min.mjs': qCoreMinMjs,
   '/dist/core.mjs': qCoreMjs,
+  '/dist/async-local-storage.mjs': qAsyncLocalStorageMjs,
   '/dist/optimizer.mjs': qViteMjs,
   '/dist/server.mjs': qServerMjs,
   '/dist/server.d.ts': qServerDts,
@@ -103,6 +105,7 @@ export const getDeps = (qwikVersion: string) => {
     };
     for (const p of [
       `/dist/core.mjs`,
+      `/dist/async-local-storage.mjs`,
       `/dist/core.min.mjs`,
       `/dist/optimizer.mjs`,
       `/dist/server.mjs`,

--- a/packages/docs/src/repl/bundler/rolldown-plugins.ts
+++ b/packages/docs/src/repl/bundler/rolldown-plugins.ts
@@ -103,6 +103,9 @@ export const replResolver = (
         if (pkgName === '/server') {
           return resolveQwik('/dist/server.mjs');
         }
+        if (pkgName === '/async-local-storage') {
+          return resolveQwik('/dist/async-local-storage.mjs');
+        }
         if (pkgName === '/worker') {
           return resolveQwik('/dist/worker/index.mjs');
         }

--- a/packages/docs/src/repl/bundler/rolldown-plugins.unit.ts
+++ b/packages/docs/src/repl/bundler/rolldown-plugins.unit.ts
@@ -1,6 +1,33 @@
 import { describe, expect, test } from 'vitest';
 import type { QwikManifest } from '@qwik.dev/core/optimizer';
-import { replWorkerQrlChunks } from './rolldown-plugins';
+import { replResolver, replWorkerQrlChunks } from './rolldown-plugins';
+
+test.each(['client', 'ssr'] as const)(
+  'resolves async local storage to the browser module for REPL %s',
+  (target) => {
+    const plugin = replResolver(
+      {
+        '@builder.io/qwik': {
+          version: 'bundled',
+          '/dist/async-local-storage.mjs': '/assets/async-local-storage.mjs',
+        },
+      },
+      { srcInputs: [], buildMode: 'development', replId: 'test' },
+      target
+    );
+    if (typeof plugin.resolveId !== 'function') {
+      throw new Error('Expected resolveId hook');
+    }
+    expect(
+      plugin.resolveId.call(
+        {} as any,
+        '@qwik.dev/core/async-local-storage',
+        '/qwik/dist/core.mjs',
+        {} as any
+      )
+    ).toEqual({ id: '/qwik/dist/async-local-storage.mjs', sideEffects: false });
+  }
+);
 
 describe('repl worker qrl chunk rewrites', () => {
   test('rewrites worker qrl placeholders to repl client bundle paths', () => {

--- a/packages/qwik-router/src/adapters/vercel-edge/vite/index.ts
+++ b/packages/qwik-router/src/adapters/vercel-edge/vite/index.ts
@@ -15,14 +15,16 @@ export function vercelEdgeAdapter(opts: VercelEdgeAdapterOptions = {}): any {
     config(config) {
       const outDir =
         config.build?.outDir || join('.vercel', 'output', 'functions', '_qwik-router.func');
+      const conditions =
+        opts.target === 'node'
+          ? ['node', 'import', 'module', 'browser', 'default']
+          : ['edge-light', 'webworker', 'worker', 'browser', 'module', 'main'];
       return {
         resolve: {
-          conditions:
-            opts.target === 'node'
-              ? ['node', 'import', 'module', 'browser', 'default']
-              : ['edge-light', 'webworker', 'worker', 'browser', 'module', 'main'],
+          conditions,
         },
         ssr: {
+          resolve: { conditions },
           target: opts.target === 'node' ? 'node' : 'webworker',
           noExternal: true,
         },

--- a/packages/qwik-router/src/adapters/vercel-edge/vite/index.unit.ts
+++ b/packages/qwik-router/src/adapters/vercel-edge/vite/index.unit.ts
@@ -1,0 +1,51 @@
+import { fileURLToPath } from 'node:url';
+import { build, type Rolldown } from 'vite';
+import { expect, test } from 'vitest';
+import { vercelEdgeAdapter } from './index';
+
+test.each([undefined, 'node'] as const)(
+  'bundles native async local storage for the Vercel target %s',
+  async (target) => {
+    const [adapter] = vercelEdgeAdapter({ target, ssg: null });
+    const config = adapter.config({});
+    const entry = fileURLToPath(new URL('./entry.vercel-edge.js', import.meta.url));
+    const result = (await build({
+      ...config,
+      configFile: false,
+      logLevel: 'silent',
+      ssr: {
+        ...config.ssr,
+        // Qwik's Vite plugin externalizes this native module.
+        external: ['node:async_hooks'],
+      },
+      build: {
+        ...config.build,
+        write: false,
+        minify: false,
+        ssr: entry,
+      },
+      plugins: [
+        {
+          name: 'test-vercel-entry',
+          resolveId(id) {
+            if (id === entry) {
+              return id;
+            }
+          },
+          load(id) {
+            if (id === entry) {
+              return `export { getAsyncLocalStorage } from '@qwik.dev/core/async-local-storage';`;
+            }
+          },
+        },
+      ],
+    })) as Rolldown.RolldownOutput;
+
+    const chunk = result.output.find((output) => output.type === 'chunk' && output.isEntry);
+    expect(chunk?.type).toBe('chunk');
+    if (chunk?.type === 'chunk') {
+      expect(chunk.imports).toContain('node:async_hooks');
+      expect(chunk.code).not.toContain('getBuiltinModule');
+    }
+  }
+);

--- a/packages/qwik-router/src/middleware/request-handler/async-request-store.unit.ts
+++ b/packages/qwik-router/src/middleware/request-handler/async-request-store.unit.ts
@@ -1,0 +1,49 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+test('isolates concurrent request events without process.getBuiltinModule', async () => {
+  vi.resetModules();
+  vi.stubGlobal('process', { ...process, getBuiltinModule: undefined });
+  const { runQwikRouter } = await import('./user-response');
+  const { getRequestEvent } = await import('../../runtime/src/route-loaders');
+  const onRequest = vi.fn();
+
+  const requests = ['/first', '/second'].map((pathname) => {
+    const url = new URL(pathname, 'https://example.com');
+    return runQwikRouter(
+      {
+        mode: 'server',
+        url,
+        request: new Request(url),
+        locale: undefined,
+        platform: {},
+        env: { get: () => undefined },
+        getClientConn: () => ({}),
+        getWritableStream: vi.fn(),
+      },
+      { $routeName$: pathname, $params$: {}, $mods$: [] },
+      [
+        async (event) => {
+          onRequest();
+          expect(getRequestEvent()).toBe(event);
+          await Promise.resolve();
+          expect(getRequestEvent()).toBe(event);
+        },
+      ],
+      vi.fn()
+    );
+  });
+
+  expect(onRequest).toHaveBeenCalledTimes(2);
+  await expect(Promise.all(requests.map((run) => run.completion))).resolves.toEqual([
+    undefined,
+    undefined,
+  ]);
+  expect(onRequest).toHaveBeenCalledTimes(2);
+  expect(getRequestEvent()).toBeUndefined();
+});

--- a/packages/qwik/global.d.ts
+++ b/packages/qwik/global.d.ts
@@ -6,3 +6,8 @@ type ExperimentalFeatures = import('../qwik-vite/src').ExperimentalFeatures;
 declare var __EXPERIMENTAL__: {
   [K in ExperimentalFeatures]: boolean;
 };
+
+// Resolve the platform entry before generated declarations exist.
+declare module '@qwik.dev/core/async-local-storage' {
+  export const getAsyncLocalStorage: typeof import('./src/core/shared/platform/async-local-storage').getAsyncLocalStorage;
+}

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -77,6 +77,12 @@
         "default": "./dist/build/index.mjs"
       }
     },
+    "./async-local-storage": {
+      "types": "./dist/async-local-storage.d.ts",
+      "edge-light": "./dist/async-local-storage.node.mjs",
+      "node": "./dist/async-local-storage.node.mjs",
+      "default": "./dist/async-local-storage.mjs"
+    },
     "./loader": {
       "types": "./dist/loader/index.d.ts",
       "import": "./dist/loader/index.mjs"

--- a/packages/qwik/src/core/internal.ts
+++ b/packages/qwik/src/core/internal.ts
@@ -37,7 +37,7 @@ export {
   vnode_toString as _vnode_toString,
 } from './client/vnode-utils';
 export { _executeSsrChores } from './shared/cursor/ssr-chore-execution';
-export { getAsyncLocalStorage as _getAsyncLocalStorage } from './shared/platform/async-local-storage';
+export { getAsyncLocalStorage as _getAsyncLocalStorage } from '@qwik.dev/core/async-local-storage';
 export type { Container as _Container, HostElement as _HostElement } from './shared/types';
 export type { ElementVNode as _ElementVNode } from './shared/vnode/element-vnode';
 export type { TextVNode as _TextVNode } from './shared/vnode/text-vnode';

--- a/packages/qwik/src/core/qwik.core.api.md
+++ b/packages/qwik/src/core/qwik.core.api.md
@@ -4,8 +4,8 @@
 
 ```ts
 
-import type { AsyncLocalStorage } from 'node:async_hooks';
 import type * as CSS_2 from 'csstype';
+import { getAsyncLocalStorage as _getAsyncLocalStorage } from '@qwik.dev/core/async-local-storage';
 import { isBrowser } from '@qwik.dev/core/build';
 import { isDev } from '@qwik.dev/core/build';
 import { isServer } from '@qwik.dev/core/build';
@@ -503,8 +503,7 @@ export type FunctionComponent<P = unknown> = {
     renderFn(props: P, key: string | null, flags: number, dev?: DevJSX): JSXOutput;
 }['renderFn'];
 
-// @internal (undocumented)
-export const _getAsyncLocalStorage: () => (new <T>() => AsyncLocalStorage<T>) | undefined;
+export { _getAsyncLocalStorage }
 
 // @public
 export const getClientManifest: () => ServerQwikManifest | undefined;

--- a/packages/qwik/src/core/shared/platform/async-local-storage.node.ts
+++ b/packages/qwik/src/core/shared/platform/async-local-storage.node.ts
@@ -1,0 +1,3 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export const getAsyncLocalStorage = () => AsyncLocalStorage;

--- a/packages/qwik/src/core/shared/platform/async-local-storage.unit.ts
+++ b/packages/qwik/src/core/shared/platform/async-local-storage.unit.ts
@@ -1,0 +1,68 @@
+import { build } from 'esbuild';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { runInNewContext } from 'node:vm';
+import { afterEach, expect, test, vi } from 'vitest';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+test.each(['browser', 'edge-light', 'node'])('selects ALS for the %s bundle', async (runtime) => {
+  const result = await build({
+    stdin: {
+      contents:
+        "export { _getAsyncLocalStorage, getLocale, withLocale } from '@qwik.dev/core/internal';",
+      resolveDir: process.cwd(),
+    },
+    bundle: true,
+    platform: runtime === 'node' ? 'node' : 'browser',
+    conditions: [runtime],
+    external: ['node:async_hooks'],
+    format: 'cjs',
+    target: 'es2020',
+    write: false,
+    define: { __EXPERIMENTAL__: '{}', 'import.meta.hot': 'false', 'import.meta.env': '{}' },
+  });
+  const module = { exports: {} as typeof import('@qwik.dev/core/internal') };
+  const require = vi.fn((id: string) => {
+    expect(id).toBe('node:async_hooks');
+    return { AsyncLocalStorage };
+  });
+  runInNewContext(result.outputFiles[0].text, { module, require, TextEncoder, TextDecoder, URL });
+
+  const { _getAsyncLocalStorage, withLocale, getLocale } = module.exports;
+  if (runtime === 'browser') {
+    expect(_getAsyncLocalStorage()).toBeUndefined();
+    expect(require).not.toHaveBeenCalled();
+    return;
+  }
+
+  expect(_getAsyncLocalStorage()).toBe(AsyncLocalStorage);
+  expect(require).toHaveBeenCalledOnce();
+  await Promise.all(
+    ['pl', 'en'].map((locale) =>
+      withLocale(locale, async () => {
+        await Promise.resolve();
+        expect(getLocale()).toBe(locale);
+      })
+    )
+  );
+});
+
+test('preserves concurrent locales without process.getBuiltinModule', async () => {
+  vi.resetModules();
+  vi.stubGlobal('process', { ...process, getBuiltinModule: undefined });
+  const { getLocale, withLocale } = await import('../../use/use-locale');
+
+  await Promise.all(
+    ['pl', 'en'].map((locale) =>
+      withLocale(locale, async () => {
+        expect(getLocale()).toBe(locale);
+        await Promise.resolve();
+        expect(getLocale()).toBe(locale);
+      })
+    )
+  );
+  expect(getLocale('outside')).toBe('outside');
+});

--- a/packages/qwik/src/core/use/use-locale.ts
+++ b/packages/qwik/src/core/use/use-locale.ts
@@ -1,5 +1,5 @@
 import { tryGetInvokeContext } from './use-core';
-import { getAsyncLocalStorage } from '../shared/platform/async-local-storage';
+import { getAsyncLocalStorage } from '@qwik.dev/core/async-local-storage';
 import { isServer } from '@qwik.dev/core/build';
 import type { AsyncLocalStorage } from 'node:async_hooks';
 

--- a/scripts/submodule-core.ts
+++ b/scripts/submodule-core.ts
@@ -4,6 +4,7 @@ import { type InputOptions, type OutputOptions, rollup } from 'rollup';
 import { minify } from 'terser';
 import {
   type BuildConfig,
+  copyFile,
   fileSize,
   getBanner,
   readFile,
@@ -35,6 +36,24 @@ function fixPureAnnotations(code: string): string {
  * mangling and keep $...$ names in sync across both bundles.
  */
 export async function submoduleCore(config: BuildConfig): Promise<object | undefined> {
+  const platformDir = join(config.srcQwikDir, 'core', 'shared', 'platform');
+  await build({
+    entryPoints: [
+      join(platformDir, 'async-local-storage.ts'),
+      join(platformDir, 'async-local-storage.node.ts'),
+    ],
+    outdir: config.distQwikPkgDir,
+    bundle: true,
+    format: 'esm',
+    outExtension: { '.js': '.mjs' },
+    external: ['node:async_hooks'],
+    target,
+  });
+  await copyFile(
+    join(config.dtsDir, 'packages/qwik/src/core/shared/platform/async-local-storage.d.ts'),
+    join(config.distQwikPkgDir, 'async-local-storage.d.ts')
+  );
+
   if (config.dev) {
     await submoduleCoreDev(config);
     return undefined;
@@ -46,7 +65,12 @@ async function submoduleCoreProd(config: BuildConfig): Promise<object | undefine
   const input: InputOptions = {
     input: join(config.tscDir, 'packages', 'qwik', 'src', 'core', 'index.js'),
     onwarn: rollupOnWarn,
-    external: ['@qwik.dev/core/build', '@qwik.dev/core/preloader', 'node:async_hooks'],
+    external: [
+      '@qwik.dev/core/build',
+      '@qwik.dev/core/preloader',
+      'node:async_hooks',
+      '@qwik.dev/core/async-local-storage',
+    ],
     plugins: [
       {
         name: 'setVersion',
@@ -97,6 +121,9 @@ async function submoduleCoreProd(config: BuildConfig): Promise<object | undefine
       {
         name: 'build',
         resolveId(id) {
+          if (id === '@qwik.dev/core/async-local-storage') {
+            return join(config.distQwikPkgDir, 'async-local-storage.mjs');
+          }
           if (id === '@index.min') {
             return id;
           }
@@ -210,7 +237,11 @@ async function prepareProdCode(config: BuildConfig): Promise<string> {
 
   const inputProd: InputOptions = {
     input: join(config.distQwikPkgDir, 'core.mjs'),
-    external: ['@qwik.dev/core/preloader', 'node:async_hooks'],
+    external: [
+      '@qwik.dev/core/preloader',
+      'node:async_hooks',
+      '@qwik.dev/core/async-local-storage',
+    ],
     onwarn: rollupOnWarn,
     plugins: [
       {
@@ -355,7 +386,12 @@ async function submoduleCoreDev(config: BuildConfig) {
 
   await build({
     ...opts,
-    external: ['@qwik.dev/core/build', '@qwik.dev/core/preloader', 'node:async_hooks'],
+    external: [
+      '@qwik.dev/core/build',
+      '@qwik.dev/core/preloader',
+      'node:async_hooks',
+      '@qwik.dev/core/async-local-storage',
+    ],
     format: 'esm',
     outExtension: { '.js': '.mjs' },
   });


### PR DESCRIPTION
Fix async request and locale context on Vercel Edge by selecting a static node:async_hooks import through conditional exports. Keep browser builds free of Node imports and remove the Router’s async initialization workaround.