### PR TITLE
fix(core): keep locale across async withLocale without ALS

### DIFF
--- a/.changeset/withlocale-async-fallback.md
+++ b/.changeset/withlocale-async-fallback.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/core': patch
+---
+
+FIX: withLocale() keeps the locale across await when AsyncLocalStorage is missing.

--- a/packages/qwik/src/core/shared/platform/async-local-storage.unit.ts
+++ b/packages/qwik/src/core/shared/platform/async-local-storage.unit.ts
@@ -35,6 +35,18 @@ test.each(['browser', 'edge-light', 'node'])('selects ALS for the %s bundle', as
   if (runtime === 'browser') {
     expect(_getAsyncLocalStorage()).toBeUndefined();
     expect(require).not.toHaveBeenCalled();
+    await withLocale('zh-CN', async () => {
+      expect(getLocale()).toBe('zh-CN');
+      await Promise.resolve();
+      expect(getLocale()).toBe('zh-CN');
+    });
+    await expect(
+      withLocale('zh-CN', async () => {
+        await Promise.resolve();
+        throw new Error('boom');
+      })
+    ).rejects.toThrow('boom');
+    expect(getLocale('outside')).toBe('outside');
     return;
   }
 

--- a/packages/qwik/src/core/use/use-locale.ts
+++ b/packages/qwik/src/core/use/use-locale.ts
@@ -1,7 +1,8 @@
-import { tryGetInvokeContext } from './use-core';
 import { getAsyncLocalStorage } from '@qwik.dev/core/async-local-storage';
 import { isServer } from '@qwik.dev/core/build';
 import type { AsyncLocalStorage } from 'node:async_hooks';
+import { isPromise } from '../shared/utils/promises';
+import { tryGetInvokeContext } from './use-core';
 
 let _locale: string | undefined = undefined;
 
@@ -47,6 +48,9 @@ export function getLocale(defaultLocale?: string): string {
 /**
  * Override the `getLocale` with `lang` within the `fn` execution.
  *
+ * `fn` may be async. The locale stays set until the returned promise settles, even when
+ * AsyncLocalStorage is not available.
+ *
  * @public
  */
 export function withLocale<T>(locale: string, fn: () => T): T {
@@ -55,11 +59,29 @@ export function withLocale<T>(locale: string, fn: () => T): T {
   }
 
   const previousLang = _locale;
-  try {
-    _locale = locale;
-    return fn();
-  } finally {
+  const restore = () => {
     _locale = previousLang;
+  };
+  _locale = locale;
+  try {
+    const result = fn();
+    if (isPromise(result)) {
+      return result.then(
+        (value) => {
+          restore();
+          return value;
+        },
+        (reason) => {
+          restore();
+          throw reason;
+        }
+      ) as T;
+    }
+    restore();
+    return result;
+  } catch (err) {
+    restore();
+    throw err;
   }
 }
 


### PR DESCRIPTION
# What is it?

- Bug

# Description

`withLocale('zh-CN', async () => { ... })` is supposed to keep `getLocale()` as `zh-CN` for the whole function, including after `await`.

That already works when AsyncLocalStorage is present. When it is not (browser build, some edge runtimes), the old code used `try/finally`. The `finally` runs the moment the function returns a Promise, so after `await` the locale is gone and `getLocale()` throws `Reading locale outside of context.`

This change waits until that Promise finishes (success or error), then puts the previous locale back. Sync `withLocale` is unchanged.

Related: this is the leftover hole after #8999, which taught Qwik how to *find* ALS on more runtimes. This PR is about the path that still has no ALS.

# Checklist

- [x] My code follows the [developer guidelines of this project](https://github.com/QwikDev/qwik/blob/main/CONTRIBUTING.md)
- [x] I performed a self-review of my own code
- [x] I added a changeset with `pnpm change`
- [x] I added new tests to cover the fix / functionality